### PR TITLE
fix: resource title

### DIFF
--- a/components/Search/SearchResultList/Item/index.jsx
+++ b/components/Search/SearchResultList/Item/index.jsx
@@ -102,13 +102,11 @@ const Item = ({ data, queryTags }) => {
     [data],
   );
 
-  const title = useMemo(
-    () =>
-      (data?.properties['資源名稱']?.title ?? []).find(
-        (item) => item?.type === 'text',
-      )?.plain_text,
-    [data?.properties],
-  );
+  const titleTextList = (data?.properties['資源名稱']?.title ?? [])
+    .filter((item) => item?.type === 'text')
+    .map((item) => item?.plain_text);
+
+  const title = useMemo(() => titleTextList.join(''), [data?.properties]);
 
   const contributors = useMemo(
     () => data?.properties['創建者']?.multi_select ?? [],


### PR DESCRIPTION
Since the text from the resource data provided by Notion is in an array format, it is necessary to iterate through all the texts.

Before:
![image](https://github.com/daodaoedu/daodao-f2e/assets/48402225/cbe3e8b0-002f-4ba4-9ae5-59200902c65e)

After:
![image](https://github.com/daodaoedu/daodao-f2e/assets/48402225/8dc63a42-752b-43b4-9e8f-4a6328d78410)
