### PR TITLE
fix: build error ReferenceError: Blob is not defined

### DIFF
--- a/pages/group/create/index.jsx
+++ b/pages/group/create/index.jsx
@@ -1,11 +1,15 @@
 import React, { useMemo } from 'react';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useSnackbar } from '@/contexts/Snackbar';
-import GroupForm from '@/components/Group/Form';
 import useMutation from '@/hooks/useMutation';
 import SEOConfig from '@/shared/components/SEO';
 import Navigation from '@/shared/components/Navigation_v2';
 import Footer from '@/shared/components/Footer_v2';
+
+const GroupForm = dynamic(() => import('@/components/Group/Form'), {
+  ssr: false,
+});
 
 function CreateGroupPage() {
   const { pushSnackbar } = useSnackbar();

--- a/pages/group/edit/index.jsx
+++ b/pages/group/edit/index.jsx
@@ -1,14 +1,18 @@
 import React, { useEffect, useMemo } from 'react';
+import dynamic from 'next/dynamic';
 import { useSelector } from 'react-redux';
 import { useRouter } from 'next/router';
 import { Box, CircularProgress } from '@mui/material';
-import GroupForm from '@/components/Group/Form';
 import { useSnackbar } from '@/contexts/Snackbar';
 import useFetch from '@/hooks/useFetch';
 import useMutation from '@/hooks/useMutation';
 import SEOConfig from '@/shared/components/SEO';
 import Navigation from '@/shared/components/Navigation_v2';
 import Footer from '@/shared/components/Footer_v2';
+
+const GroupForm = dynamic(() => import('@/components/Group/Form'), {
+  ssr: false,
+});
 
 function EditGroupPage() {
   const { pushSnackbar } = useSnackbar();


### PR DESCRIPTION
## 描述
在自動部署時，發生錯誤 `ReferenceError: Blob is not defined`
針對客戶端的元件，告訴 Next.js 不要嘗試在伺服器上渲染它們

```js
import dynamic from 'next/dynamic';

const ClientComponent = dynamic(() => import('@/components/ClientComponent'), {
  ssr: false
});

<ClientComponent />
```