### PR TITLE
fix: group skeleton card error

### DIFF
--- a/components/Group/GroupList/SkeletonGroupCard.jsx
+++ b/components/Group/GroupList/SkeletonGroupCard.jsx
@@ -9,7 +9,7 @@ import {
 
 function SkeletonGroupCard() {
   return (
-    <StyledGroupCard sx={{ cursor: 'default' }}>
+    <StyledGroupCard href="#" sx={{ cursor: 'default' }}>
       <Skeleton variant="rounded" width="100%" height={122} animation="wave" />
       <StyledContainer>
         <Skeleton


### PR DESCRIPTION
因為之前修正揪團列表 loading 時不應該可以點進去揪團明細，把 href 拔掉，造成測試環境列表頁壞掉，目前暫解把 href 設置為 "#"，未來重構時在調整正常寫法。