### PR TITLE
feat: adjust savebar padding-top and padding-bottom on mobile devices

### DIFF
--- a/components/Marathon/SignUp/SaveBar.jsx
+++ b/components/Marathon/SignUp/SaveBar.jsx
@@ -43,14 +43,13 @@ export const StyledSaveBar = styled(Box)`
   }
 
   .MuiStepLabel-iconContainer {
-    
-    
     .MuiStepIcon-text {
       fill: #FFF;
     }
   }
 
   @media (max-width: 767px) {
+    padding: 8px 6.9vw;
     .top h2 {
       font-size: 18px;
     }

--- a/components/Marathon/SignUp/SaveBar.jsx
+++ b/components/Marathon/SignUp/SaveBar.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
 import Stepper from '@mui/material/Stepper';


### PR DESCRIPTION
調整
- 學習馬拉松報名頁面：手機版的 Stepper 上下 padding 改為 8px

其他
- 移除不必要的 useState