### PR TITLE
feat: show oversea user location on ConfirmForm

### DIFF
--- a/components/Marathon/SignUp/ConfirmForm.jsx
+++ b/components/Marathon/SignUp/ConfirmForm.jsx
@@ -242,7 +242,11 @@ export default function ConfirmForm({
       let userEdu = userState?.educationStage;
 
       if (userState?.location?.length > 1) {
-        userLocation = userState?.location.split('@')[1];
+        if (userState?.location.includes('@')) {
+          userLocation = userState?.location.split('@')[1];
+        } else {
+          userLocation = userState?.location;
+        }
       }
 
       if (userState?.roleList?.length) {


### PR DESCRIPTION
修正
- 學習馬拉松：修正用戶選擇海外時，確認表單上不會顯示位置的問題