### PR TITLE
Feat/marathon form/add try catch

### DIFF
--- a/components/Marathon/SignUp/ConfirmForm.jsx
+++ b/components/Marathon/SignUp/ConfirmForm.jsx
@@ -293,7 +293,6 @@ export default function ConfirmForm({
     switch (marathonState.apiStateWithType) {
       case 'updateMarathonProfileSuccess': {
         toast.success('更新成功');
-        router.push('/learning-marathon/success');
         break;
       }
       case 'createMarathonProfileByTokenSuccess': {

--- a/components/Marathon/SignUp/ConfirmForm.jsx
+++ b/components/Marathon/SignUp/ConfirmForm.jsx
@@ -211,7 +211,6 @@ export default function ConfirmForm({
   setCurrentStep,
   currentStep,
 }) {
-  const [/** hasClickSubmitButton */, setHasClickSubmitButton] = useState(false);
   const reduxDispatch = useDispatch();
   const marathonState = useSelector((state) => { return state.marathon; });
   const userState = useSelector((state) => { return state.user; });
@@ -279,6 +278,7 @@ export default function ConfirmForm({
       userId: userState._id,
       status: 'Complete'
     };
+
     if (marathonState._id) {
       reduxDispatch(updateMarathonProfile(token, marathonState._id, submitData));
       localStorage.removeItem('newMarathon');
@@ -287,7 +287,6 @@ export default function ConfirmForm({
       reduxDispatch(createMarathonProfileByToken(token, submitData));
       localStorage.removeItem('newMarathon');
     }
-    setHasClickSubmitButton(true);
   };
 
   useEffect(() => {

--- a/components/Marathon/SignUp/ConfirmForm.jsx
+++ b/components/Marathon/SignUp/ConfirmForm.jsx
@@ -293,6 +293,7 @@ export default function ConfirmForm({
     switch (marathonState.apiStateWithType) {
       case 'updateMarathonProfileSuccess': {
         toast.success('更新成功');
+        router.push('/profile?id=my-marathon');
         break;
       }
       case 'createMarathonProfileByTokenSuccess': {

--- a/components/Marathon/SignUp/ConfirmForm.jsx
+++ b/components/Marathon/SignUp/ConfirmForm.jsx
@@ -514,7 +514,7 @@ export default function ConfirmForm({
           variant="contained"
           onClick={onSubmit}
         >
-          提交申請
+          {marathonState._id ? '更新報名資料' : '提交申請'}
         </StyledButton>
       </StyledButtonGroup>
     </>

--- a/components/Marathon/SignUp/MarathonForm.jsx
+++ b/components/Marathon/SignUp/MarathonForm.jsx
@@ -88,10 +88,12 @@ export default function MarathonForm({
 
   const validators = {
     required: (value) => {
-      return value.trim().length > 0;
+      return ((typeof value === "string") && (value.trim().length > 0));
     },
     allMilestonesNameRequired: (value, milestonesLength) => {
-      const names = value.filter((milestone) => milestone?.name.trim().length > 0);
+      const names = value.filter((milestone) =>
+        typeof milestone?.name === 'string' && milestone?.name?.trim().length > 0
+      );
       return names.length === milestonesLength;
     }
   };

--- a/components/Marathon/SignUp/MarathonForm.jsx
+++ b/components/Marathon/SignUp/MarathonForm.jsx
@@ -237,10 +237,10 @@ export default function MarathonForm({
     const isValid = handleValidateAll();
     if (!isValid) {
       toast.error('請修正錯誤');
-    } else {
-      reduxDispatch(updateNewMarathon(newMarathon));
-      setCurrentStep(currentStep + 1);
+      return;
     }
+    reduxDispatch(updateNewMarathon(newMarathon));
+    setCurrentStep(currentStep + 1);
   };
 
   const onPrevStep = () => {

--- a/components/Marathon/SignUp/MarathonForm.jsx
+++ b/components/Marathon/SignUp/MarathonForm.jsx
@@ -201,7 +201,7 @@ export default function MarathonForm({
             break;
           default:
             input = newMarathon[name];
-          break;
+            break;
         }
         const validationPassed = validate(input);
 


### PR DESCRIPTION
### 新增
- 學習馬拉松：資料填寫頁面加入 try catch 與 console.error 顯示驗證欄位訊息
- 學習馬拉松：報名之後的提交按鈕文字改為「更新報名資料」
- 學習馬拉松：更新報名資料並儲存後，停止轉向 /success，避免用戶誤以為需要再度收信一次

### 移除
- 學習馬拉松：移除確認報名資料頁面中用不到的參數

