### PR TITLE
feat: add error handle for eduZh or roleZh not found in marathon/prof…

### DIFF
--- a/pages/learning-marathon/profile/index.jsx
+++ b/pages/learning-marathon/profile/index.jsx
@@ -265,7 +265,11 @@ const LearningMarathonProfile = () => {
             const roleZh = ROLE.find((option) => {
               return option.value === result.roleList[0];
             });
-            setRole(roleZh.label);
+            if (roleZh) {
+              setRole(roleZh.label);
+            } else {
+              setRole('暫無資料');
+            }
           } else {
             setRole('暫無資料');
           }
@@ -275,7 +279,11 @@ const LearningMarathonProfile = () => {
             const eduZh = EDUCATION_STEP.find((option) => {
               return option.value === result.educationStage;
             });
-            setEduStep(eduZh.label);
+            if (eduZh) {
+              setEduStep(eduZh.label);
+            } else {
+              setEduStep('暫無資料');
+            }
           } else {
             setEduStep('暫無資料');
           }


### PR DESCRIPTION
## 修正

- 學習馬拉松檢視頁：User 資料找不到對應的中文名稱時顯示「暫無資料」以避免 Error