### PR TITLE
fix: match subMilestone by id when user edit subMilestone data

### DIFF
--- a/components/Marathon/SignUp/MilestonePanel.jsx
+++ b/components/Marathon/SignUp/MilestonePanel.jsx
@@ -122,6 +122,17 @@ export default function MilestonePanel({
 
   const handleDeleteSubMilestone = (deletedItem) => {
     const newSubMilestones = (milestone.subMilestones).filter((item) => {
+      /*
+        if is submitted subMilestone,
+        match deleted subMilestone with item._id
+      */
+      if (item._id) {
+        return (item._id !== deletedItem._id);
+      }
+      /*
+        if not submitted subMilestone,
+        match deleted subMilestone with item._tempId
+      */
       return (item._tempId !== deletedItem._tempId);
     });
     onChange({
@@ -132,6 +143,17 @@ export default function MilestonePanel({
 
   const handleEditSubMilestone = (newItem) => {
     const newSubMilestones = (milestone.subMilestones).map((item) => {
+      /*
+        if is submitted subMilestone,
+        match edited subMilestone with item._id
+      */
+      if (item._id) {
+        return (newItem._id === item._id) ? newItem : item;
+      }
+      /*
+        if not submitted subMilestone,
+        match edited subMilestone with item._tempId
+      */
       return (newItem._tempId === item._tempId) ? newItem : item;
     });
     onChange({


### PR DESCRIPTION
## 修正
修正問題：當使用者從個人頁面回來編輯學習馬拉松資料時，部分 subMilestone 沒有 _tempId 而造成修改 / 刪除錯誤。 