### PR TITLE
feat(projects/detail): setup publicProjectLayout for public project pages

### DIFF
--- a/layout/PublicProjectLayout.tsx
+++ b/layout/PublicProjectLayout.tsx
@@ -1,0 +1,209 @@
+import toast from 'react-hot-toast';
+import { useEffect } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import dayjs from 'dayjs';
+import { AiOutlineEye } from 'react-icons/ai';
+import { MdLockOpen, MdLock } from 'react-icons/md';
+import { GoBookmark } from 'react-icons/go';
+
+import { ProtectedComponent } from '@/contexts/Auth';
+import Button from '@/shared/components/Button';
+import Container from '@/shared/components/Container';
+import Image from '@/shared/components/Image';
+import Sidebar from '@/shared/components/Sidebar';
+import { z } from 'zod';
+import { ProjectProvider, useProject } from '@/contexts/Project';
+import { ROLE } from '@/constants/member';
+import getDefaultLayout from './DefaultLayout';
+
+const idSchema = z.string().uuid();
+
+function validateIdWithZod(id: string) {
+  try {
+    const result = idSchema.parse(id);
+    return {
+      isValid: true,
+      value: result,
+    };
+  } catch (error) {
+    return {
+      isValid: false,
+      error,
+    };
+  }
+}
+
+const tabConfigs = (projectId: string) => ({
+  outcomes: {
+    backText: '返回 學習成果',
+    backPath: `/manage/project/outcomes?id=${projectId}`,
+  },
+  notes: {
+    backText: '返回 便利貼',
+    backPath: `/manage/project/notes?id=${projectId}`,
+  },
+  review: {
+    backText: '返回 覆盤',
+    backPath: `/manage/project/review?id=${projectId}`,
+  },
+});
+
+interface ProjectLayoutContentProps {
+  children: React.ReactNode;
+  activeTabType?: keyof ReturnType<typeof tabConfigs>;
+}
+
+function ProjectLayout({ children, activeTabType }: ProjectLayoutContentProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const projectId = searchParams.get('projectId');
+  const activeTab =
+    activeTabType && projectId
+      ? tabConfigs(projectId)[activeTabType]
+      : undefined;
+  const activeTabPath = activeTab?.backPath ?? pathname;
+  const backPath = activeTab?.backPath ?? '/projects';
+  const backText = activeTab?.backText ?? '返回 學習計畫分享區';
+  const { project, fetchProject } = useProject();
+  const zhRole = ROLE.find((r) => {
+    return r.value === project.user.roleList[0];
+  })?.label;
+  const getProjectType = (eventId:string) => {
+    switch (eventId) {
+      case "2025S1":
+        return "2025春季盃學習馬拉松";
+      default:
+        return "學習計畫";
+    }
+  };
+  // TODO: move fetchProject to page /manage/projects
+  useEffect(() => {
+    if (!projectId) return;
+    if (!z.string().uuid().safeParse(projectId).success) return;
+    fetchProject(projectId);
+  }, [projectId]);
+
+  return (
+    <ProtectedComponent redirectOnCancel="/">
+      <div className="bg-primary-palest">
+        <Container className="pt-2 px-4 pb-12 max-w-6xl mx-auto" autoMinHeight>
+          <div className="flex flex-wrap gap-x-10">
+            <div className="basis-full">
+              <Button
+                size="sm"
+                className="px-0 mb-6 lg:mb-3"
+                prefixIcon="FaAngleLeft"
+                onClick={() => router.push(backPath)}
+              >
+                {backText}
+              </Button>
+            </div>
+            <Sidebar className="mb-6 lg:mb-0 basis-full -order-1 lg:order-none lg:basis-80">
+              <Sidebar.Link
+                href={
+                  projectId
+                    ? `/projects/detail?projectId=${projectId}`
+                    : '/projects'
+                }
+                isActive={activeTabPath === '/project'}
+              >
+                學習計畫
+              </Sidebar.Link>
+              <Sidebar.Link
+                isDisabled
+                href={
+                  projectId
+                    ? `/projects/milestones/detail?projectId=${projectId}`
+                    : '/projects/milestones'
+                }
+                isActive={activeTabPath === '/projects/milestones/detail'}
+              >
+                學習里程碑
+              </Sidebar.Link>
+              <Sidebar.Link
+                isDisabled
+                href={`/projects/outcomes/detail?projectId=${projectId}`}
+                isActive={activeTabPath.startsWith('/projects/outcomes/detail')}
+              >
+                學習成果
+              </Sidebar.Link>
+              <Sidebar.Link
+                isDisabled
+                href={`/projects/notes/detail?projectId=${projectId}`}
+                isActive={activeTabPath.startsWith('/projects/notes/detail')}
+              >
+                便利貼
+              </Sidebar.Link>
+              <Sidebar.Link
+                isDisabled
+                href={`/projects/review/detail?projectId=${projectId}`}
+                isActive={activeTabPath.startsWith('/projects/review/detail')}
+              >
+                覆盤
+              </Sidebar.Link>
+            </Sidebar>
+            <div className="basis-full max-w-full lg:flex-1 lg:max-w-[min(760px,100%-360px)]">
+              <header className="mb-6">
+                <div className="mb-3 flex flex-col lg:flex-row justify-between lg:items-center gap-y-3">
+                  <h1 className="heading-md text-basic-500">
+                    {project?.title || '學習計畫主題名稱'}
+                  </h1>
+                  <div className="flex items-center justify-between lg:justify-end gap-2 text-basic-300">
+                    <time>
+                      {dayjs(project?.updatedAt).format('YYYY/MM/DD')}
+                    </time>
+                    <div className="flex items-center gap-2">
+                      {/* <div className="flex items-center gap-0.5">
+                        <AiOutlineEye />
+                        <span>9999</span>
+                      </div> */}
+                      <div className="flex items-center gap-0.5">
+                        {project?.isPublic ? <MdLockOpen /> : <MdLock /> }
+                        <span>{project?.isPublic ? '公開' : '不公開'}</span>
+                      </div>
+                      {/* <div className="flex items-center gap-0.5">
+                        <GoBookmark />
+                        <span>2</span>
+                      </div> */}
+                      <Button
+                        className="-m-1 p-1"
+                        size="sm"
+                        prefixIcon="AiOutlineMore"
+                        onClick={() => toast.error('功能尚未開放')}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 body-sm">
+                  <div className="rounded-full overflow-hidden *:!block">
+                    <img src={project?.user?.photoURL} alt={project?.user?.name} width="40px" height="40px" />
+                  </div>
+                  <div className="text-basic-400">{project?.user?.name}</div>
+                  <div className="px-2.5 py-0.5 text-basic-500 bg-basic-100 rounded">
+                    {zhRole}
+                  </div>
+                  <div className="px-2.5 py-0.5 text-basic-white bg-primary-lighter rounded">
+                    {getProjectType(project.eventId)}
+                  </div>
+                </div>
+              </header>
+              {children}
+            </div>
+          </div>
+        </Container>
+      </div>
+    </ProtectedComponent>
+  );
+}
+
+export default function getPublicProjectLayout(
+  page: React.ReactElement,
+  activeTabType?: keyof ReturnType<typeof tabConfigs>
+) {
+  return getDefaultLayout(
+    <ProjectProvider>
+      <ProjectLayout activeTabType={activeTabType}>{page}</ProjectLayout>
+    </ProjectProvider>
+  );
+}

--- a/pages/projects/detail/index.tsx
+++ b/pages/projects/detail/index.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
+import getPublicProjectLayout from '@/layout/PublicProjectLayout';
 import { Project as ProjectType } from '@/components/Projects/Project/type';
 import { BASE_URL } from '@/constants/common';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { Skeleton } from '@mui/material';
 import {
@@ -13,53 +14,11 @@ import {
   FakeInput,
   FakeCheckBox,
 } from '@/components/Projects/Project/Shared';
-import Button from '@/shared/components/Button';
-import Dropdown from '@/shared/components/Dropdown';
-import { MdMoreVert } from 'react-icons/md';
-import dayjs from 'dayjs';
-import { ROLE } from '@/constants/member';
 import z from 'zod';
 
-interface UserInfoBarProps {
-  user: {
-    name: string,
-    photoURL: string,
-    roleList: string[]
-  }
-}
-
-const ProjectUserInfoBar = ({ user }: UserInfoBarProps) => {
-  const zhRole = ROLE.find((r) => {
-    return r.value === user.roleList[0];
-  })?.label;
-
-  return (
-    <div className="flex flex-row gap-2 items-center">
-      <img
-        src={user.photoURL}
-        alt={user.name}
-        className="rounded-full w-[30px] h-[30px]"
-      />
-      <span className="font-sans text-sm font-medium text-basic-400">
-        {user.name}
-      </span>
-      {zhRole && (
-        <div className="
-          py-[3px] px-[10px] bg-basic-100 rounded-[4px]
-          font-sans text-sm text-basic-500 leading-[1.4]
-          "
-        >
-          {zhRole}
-        </div>
-      )}
-    </div>
-  );
-};
-
-const PageProjectDetail = () => {
+const ProjectDetailPage = () => {
   const [isFetchingProject, setIsFetchingProject] = useState(false);
   const [project, setProject] = useState<ProjectType>();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const projectId = searchParams.get('projectId') ?? undefined;
 
@@ -95,123 +54,72 @@ const PageProjectDetail = () => {
 
   return (
     <>
-      <div className="bg-[#EEF9F9] min-h-dvh">
-        <div className="w-[750px] max-w-full mx-auto py-8 px-4 md:pt-[72px] md:pb-[100px]">
-          {isFetchingProject ?
-            <Skeleton />
-            :
-            (
-              <>
-                <div className="mb-8 md:mb-6">
-                  <Button
-                    size="sm"
-                    className="px-0 mb-6"
-                    prefixIcon="FaAngleLeft"
-                    onClick={() => router.push('/projects')}
-                  >
-                    返回
-                  </Button>
-                </div>
-                <div className="px-2 mb-4 md:mb-4">
-                  <div className="flex flex-col md:flex-row items-start md:items-center justify-center md:justify-between gap-3 mb-3">
-                    <h2 className="font-sans heading-md">{project?.title}</h2>
-                    <div className="ml-auto flex flex-row justify-start items-center gap-2">
-                      <span className="font-sans text-basic-300 text-sm leading-normal">
-                        {dayjs(project?.updatedAt).format('YYYY/MM/DD')}
-                      </span>
+      <div className="w-[750px] max-w-full mx-auto">
+        {isFetchingProject ?
+          <Skeleton />
+          :
+          (
+            <>
+              <Panel className=" bg-white mb-8 md:mb-6">
+                <Title title="計畫簡述" />
+                <Description description={project?.description || ""} />
+                <Divider />
+                <Title title="學習動機" />
+                {
+                  Array.isArray(project?.motivation) && project?.motivation?.length > 0 && (
+                    <Tags category="motivation_tags" tags={project?.motivation} />
+                  )
+                }
+                <Description description={project?.motivationDescription || ""} />
+                <Divider />
+                <Title title="學習目標" />
+                <Description description={project?.goal || ""} />
+                <Divider />
+                <Title title="學習內容" />
+                <Description description={project?.content || ""} />
+                <Divider />
+                <Title title="學習方法與策略" />
+                {
+                  Array.isArray(project?.strategy) && project?.strategy?.length > 0 && (
+                    <Tags category="strategy_tags" tags={project?.strategy} />
+                  )
+                }
+                <Description description={project?.strategyDescription || ""} />
+                {
+                  project?.resourceName && (
+                    <>
+                      <Divider />
+                      <Title title="學習資源" />
+                      <div className="flex flex-col gap-2">
+                        <FakeInput
+                          value={project?.resourceName}
+                        />
+                      </div>
+                    </>
+                  )
+                }
+              </Panel>
 
-                      {/*
-                        <span className="flex flex-row items-center justify-start gap-1
-                          font-sans text-basic-300 text-base leading-normal"
-                        >
-                          <ViewIcon />
-                          9999
-                        </span>
-                      */}
-                      <Dropdown>
-                        <Dropdown.Toggle variant="solid" className="flex flex-row items-center justify-center bg-transparent text-basic-300 hover:bg-basic-100 hover:text-basic-300 hover:shadow-none p-0 w-6 h-6 text-base">
-                          <MdMoreVert />
-                        </Dropdown.Toggle>
-                        <Dropdown.List className="top-full left-0 z-20 p-0">
-                          <Dropdown.Item className="rounded-lg text-nowrap">
-                            <Button
-                              onClick={() => window.open('https://forms.gle/NkVbDWC3eXk4P4gv7', '_blank', 'noopener')}
-                              className="w-full text-left p-2 text-basic-500 hover:bg-transparent transition"
-                            >
-                              檢舉
-                            </Button>
-                          </Dropdown.Item>
-                        </Dropdown.List>
-                      </Dropdown>
-                    </div>
-                  </div>
-                  {
-                    project?.user && (
-                      <ProjectUserInfoBar user={project?.user} />
-                    )
-                  }
-                </div>
-                <Panel className=" bg-white mb-8 md:mb-6">
-                  <Title title="計畫簡述" />
-                  <Description description={project?.description || ""} />
-                  <Divider />
-                  <Title title="學習動機" />
-                  {
-                    Array.isArray(project?.motivation) && project?.motivation?.length > 0 && (
-                      <Tags category="motivation_tags" tags={project?.motivation} />
-                    )
-                  }
-                  <Description description={project?.motivationDescription || ""} />
-                  <Divider />
-                  <Title title="學習目標" />
-                  <Description description={project?.goal || ""} />
-                  <Divider />
-                  <Title title="學習內容" />
-                  <Description description={project?.content || ""} />
-                  <Divider />
-                  <Title title="學習方法與策略" />
-                  {
-                    Array.isArray(project?.strategy) && project?.strategy?.length > 0 && (
-                      <Tags category="strategy_tags" tags={project?.strategy} />
-                    )
-                  }
-                  <Description description={project?.strategyDescription || ""} />
-                  {
-                    project?.resourceName && (
-                      <>
-                        <Divider />
-                        <Title title="學習資源" />
-                        <div className="flex flex-col gap-2">
-                          <FakeInput
-                            value={project?.resourceName}
-                          />
-                        </div>
-                      </>
-                    )
-                  }
-                </Panel>
-
-                <Panel className="bg-white">
-                  <h3 className="body-md font-medium mb-5">學習成果及呈現方式 *</h3>
-                  {
-                    (Array.isArray(project?.outcome) && project?.outcome?.length > 0) && (
-                      <Tags category="outcome_tags" tags={project?.outcome} />
-                    )
-                  }
-                  <Description description={project?.outcomeDescription || ""} />
-                  <Divider />
-                  <FakeCheckBox
-                    isChecked={project?.isPublic}
-                    text="是否公開給所有人看到"
-                  />
-                </Panel>
-              </>
-            )
-          }
-        </div>
+              <Panel className="bg-white">
+                <h3 className="body-md font-medium mb-5">學習成果及呈現方式 *</h3>
+                {
+                  (Array.isArray(project?.outcome) && project?.outcome?.length > 0) && (
+                    <Tags category="outcome_tags" tags={project?.outcome} />
+                  )
+                }
+                <Description description={project?.outcomeDescription || ""} />
+                <Divider />
+                <FakeCheckBox
+                  isChecked={project?.isPublic}
+                  text="是否公開給所有人看到"
+                />
+              </Panel>
+            </>
+          )
+        }
       </div>
     </>
   );
 };
-
-export default PageProjectDetail;
+ProjectDetailPage.getLayout = getPublicProjectLayout;
+export default ProjectDetailPage;


### PR DESCRIPTION
### 新增
學習計畫公開分享區加入左側欄
- 新建 publicProjectLayout 和個人學習計畫後台做區隔
- 左側欄上的里程碑、成果、覆盤目前先 disabled
- 公開的學習計畫頁面路由沒有 /manage，例如: /projects/detail?projectId=[projectId]；個人編輯學習計畫頁面後台有 manage，例如：/manage/projects, /manage/project/outcomes?id=[projectId]