### PR TITLE
feat(projects/milestones): setup /projects/milestone page

### DIFF
--- a/components/Milestones/MilestoneItemView.tsx
+++ b/components/Milestones/MilestoneItemView.tsx
@@ -1,0 +1,25 @@
+import { Milestone as MilestoneType } from '@/contexts/Milestones/type';
+
+import MilestoneView from './MilestoneView';
+import TaskListView from '../Tasks/TaskListView';
+
+interface MilestoneItemViewProps {
+  milestone: MilestoneType;
+}
+
+const MilestoneItemView = ({
+  milestone,
+}: MilestoneItemViewProps) => {
+  return (
+    <div className="p-2.5 bg-basic-100 flex flex-col gap-2">
+      <MilestoneView
+        milestone={milestone}
+      />
+      <TaskListView
+        tasks={milestone.tasks || []}
+      />
+    </div>
+  );
+};
+
+export default MilestoneItemView;

--- a/components/Milestones/MilestoneView.tsx
+++ b/components/Milestones/MilestoneView.tsx
@@ -1,0 +1,54 @@
+import { FaArrowRight } from 'react-icons/fa';
+import dayjs from 'dayjs';
+import { cn } from '@/utils/cn';
+import { Milestone } from '@/contexts/Milestones/type';
+import { numberToZh } from './Shared';
+
+interface MilestoneViewProps {
+  milestone: Milestone;
+}
+
+const MilestoneView = ({
+  milestone,
+}: MilestoneViewProps) => {
+  return (
+    <div className="p-[10px] md:py-3 md:px-4 rounded-lg bg-white">
+      <div className="flex flex-row items-center justify-beetween mb-[10px]">
+        <div className="bg-primary-base text-white py-[5px] px-5 rounded-[20px] font-sans text-sm leading-[140%]">
+          第{numberToZh(milestone.week)}週
+        </div>
+        <div
+          className="
+          ml-auto
+          flex flex-row items-center gap-[3px]
+          font-sans text-sm text-basic-300"
+        >
+          <p>
+            {milestone.startDate
+              ? dayjs(milestone.startDate).format('YYYY/MM/DD')
+              : dayjs().format('YYYY/MM/DD')}
+          </p>
+          <FaArrowRight className="text-basic-300" />
+          <p>
+            {milestone.endDate
+              ? dayjs(milestone.endDate).format('YYYY/MM/DD')
+              : dayjs().format('YYYY/MM/DD')}
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-row items-center justify-between">
+        <div className="w-full flex flex-col md:flex-row items-center  md:justify-between gap-1">
+          <p className={cn(
+              'font-sans text-sm text-basic-400',
+              'w-full rounded-md px-3 py-2 border border-solid border-basic-200'
+            )}
+          >
+            {milestone.name}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MilestoneView;

--- a/components/Tasks/TaskListView.tsx
+++ b/components/Tasks/TaskListView.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import { Task as TaskType } from "@/contexts/Milestones/type";
+import TaskView from "./TaskView";
+
+interface TaskListViewProps {
+  tasks: TaskType[];
+}
+
+const TaskListView = ({
+  tasks,
+}: TaskListViewProps) => {
+  const sortedTasks = useMemo(
+    () => (Array.isArray(tasks) ? [...tasks].sort((a, b) => a.id - b.id) : []),
+    [tasks]
+  );
+
+  return sortedTasks.map((task) => (
+    <TaskView
+      key={task.id}
+      task={task}
+    />
+  ));
+};
+
+export default TaskListView;

--- a/components/Tasks/TaskView.tsx
+++ b/components/Tasks/TaskView.tsx
@@ -1,0 +1,65 @@
+import { FaCheck } from "react-icons/fa6";
+import { cn } from "@/utils/cn";
+import { Task as TaskType } from "@/contexts/Milestones/type";
+
+import { MdCalendarToday } from "react-icons/md";
+
+interface TaskViewProps {
+  task: TaskType;
+}
+
+// 加入 dayMap 用於本地化轉換
+const dayMap: { [key: string]: string } = {
+  Monday: '週一',
+  Tuesday: '週二',
+  Wednesday: '週三',
+  Thursday: '週四',
+  Friday: '週五',
+  Saturday: '週六',
+  Sunday: '週日'
+};
+
+const TaskView = ({
+  task,
+}: TaskViewProps) => {
+  return (
+    <div className="ml-5 p-[10px] md:py-3 md:px-4 rounded-lg bg-white">
+      <div className="flex flex-row items-center justify-between">
+        <div className="flex flex-col w-full">
+          <div className="flex flex-row w-full justify-start gap-1">
+            <div
+              className="
+              flex flex-row justify-center items-center gap-[5px] w-full basis-0"
+            >
+              <p className={cn(
+                "w-[18px] h-[18px] p-[2px] rounded-[4px] m-[1px]",
+                "flex items-center justify-center",
+                "border-2 border-solid",
+                task.isCompleted ?
+                  "bg-primary-base text-white border-primary-base"
+                  :
+                  "bg-white text-basic-400 border-basic-400"
+              )}
+              >
+                {task.isCompleted && <FaCheck />}
+              </p>
+            </div>
+            <p className="w-full">{task.name || ""}</p>
+          </div>
+          {task.daysOfWeek?.length > 0 && (
+            <div className="flex items-center gap-1 mt-1 ml-7 text-sm text-text-secondary">
+              <MdCalendarToday className="w-4 h-4 text-[#92989A] shrink-0" />
+              <span>
+                {task.daysOfWeek
+                  ?.map((enDay) => dayMap[enDay])
+                  ?.join('、') ?? ''}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TaskView;

--- a/layout/PublicProjectLayout.tsx
+++ b/layout/PublicProjectLayout.tsx
@@ -15,38 +15,18 @@ import { ProjectProvider, useProject } from '@/contexts/Project';
 import { ROLE } from '@/constants/member';
 import getDefaultLayout from './DefaultLayout';
 
-const tabConfigs = (projectId: string) => ({
-  outcomes: {
-    backText: '返回 學習成果',
-    backPath: `/manage/project/outcomes?id=${projectId}`,
-  },
-  notes: {
-    backText: '返回 便利貼',
-    backPath: `/manage/project/notes?id=${projectId}`,
-  },
-  review: {
-    backText: '返回 覆盤',
-    backPath: `/manage/project/review?id=${projectId}`,
-  },
-});
-
 interface ProjectLayoutContentProps {
   children: React.ReactNode;
-  activeTabType?: keyof ReturnType<typeof tabConfigs>;
 }
 
-function ProjectLayout({ children, activeTabType }: ProjectLayoutContentProps) {
+function ProjectLayout({ children }: ProjectLayoutContentProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const projectId = searchParams.get('projectId');
-  const activeTab =
-    activeTabType && projectId
-      ? tabConfigs(projectId)[activeTabType]
-      : undefined;
-  const activeTabPath = activeTab?.backPath ?? pathname;
-  const backPath = activeTab?.backPath ?? '/projects';
-  const backText = activeTab?.backText ?? '返回 學習計畫分享區';
+  const activeTabPath = pathname;
+  const backPath = '/projects';
+  const backText = '返回 學習計畫分享區';
   const { project, fetchProject } = useProject();
   const zhRole = ROLE.find((r) => {
     return r.value === project.user.roleList[0];
@@ -82,29 +62,20 @@ function ProjectLayout({ children, activeTabType }: ProjectLayoutContentProps) {
           </div>
           <Sidebar className="mb-6 lg:mb-0 basis-full -order-1 lg:order-none lg:basis-80">
             <Sidebar.Link
-              href={
-                projectId
-                  ? `/projects/detail?projectId=${projectId}`
-                  : '/projects'
-              }
-              isActive={activeTabPath === '/project'}
+              href={`/projects/detail?projectId=${projectId}`}
+              isActive={activeTabPath.startsWith('/projects/detail')}
             >
               學習計畫
             </Sidebar.Link>
             <Sidebar.Link
-              isDisabled
-              href={
-                projectId
-                  ? `/projects/milestones/detail?projectId=${projectId}`
-                  : '/projects/milestones'
-              }
-              isActive={activeTabPath === '/projects/milestones/detail'}
+              href={`/projects/milestones?projectId=${projectId}`}
+              isActive={activeTabPath.startsWith('/projects/milestones')}
             >
               學習里程碑
             </Sidebar.Link>
             <Sidebar.Link
               isDisabled
-              href={`/projects/outcomes/detail?projectId=${projectId}`}
+              href={`/projects/outcomes?projectId=${projectId}`}
               isActive={activeTabPath.startsWith('/projects/outcomes/detail')}
             >
               學習成果
@@ -179,11 +150,10 @@ function ProjectLayout({ children, activeTabType }: ProjectLayoutContentProps) {
 
 export default function getPublicProjectLayout(
   page: React.ReactElement,
-  activeTabType?: keyof ReturnType<typeof tabConfigs>
 ) {
   return getDefaultLayout(
     <ProjectProvider>
-      <ProjectLayout activeTabType={activeTabType}>{page}</ProjectLayout>
+      <ProjectLayout>{page}</ProjectLayout>
     </ProjectProvider>
   );
 }

--- a/pages/projects/milestones/index.tsx
+++ b/pages/projects/milestones/index.tsx
@@ -1,0 +1,63 @@
+import getPublicProjectLayout from '@/layout/PublicProjectLayout';
+import { useSearchParams } from 'next/navigation';
+import { Skeleton } from '@mui/material';
+import useProjectMilestoneList from '@/hooks/api/project/useProjectMilestoneList';
+import EmptyList from '@/components/Projects/ProjectList/EmptyList';
+import MilestoneItemView from '@/components/Milestones/MilestoneItemView';
+import { MilestonesProvider } from '@/contexts/Milestones';
+
+const ProjectMilestonesPage = () => {
+  const searchParams = useSearchParams();
+  const projectId = searchParams.get('projectId') ?? undefined;
+  const {
+    data: milestones,
+    isLoading,
+  } = useProjectMilestoneList(projectId);
+
+  return (
+    <div className="w-[750px] max-w-full mx-auto">
+      {isLoading ? (
+        <>
+          <Skeleton
+            variant="rectangular"
+            width="100%"
+            height={120}
+            animation="wave"
+            className="mb-3"
+          />
+          <Skeleton
+            variant="rectangular"
+            width="100%"
+            height={300}
+            animation="wave"
+          />
+        </>
+      ) : (
+        <div>
+          {projectId && Array.isArray(milestones) && milestones.length > 0 ? (
+            milestones
+              .sort((a, b) => {
+                return a.week - b.week;
+              })
+              .map((milestone) => {
+                return (
+                  <MilestoneItemView
+                    milestone={milestone}
+                    key={milestone.id}
+                  />
+                );
+              })
+          ) : (
+            <EmptyList />
+          )}
+        </div>
+      )
+    }
+    </div>
+  );
+};
+ProjectMilestonesPage.getLayout = (page: React.ReactElement) =>
+  getPublicProjectLayout(
+    <MilestonesProvider>{page}</MilestonesProvider>
+  );
+export default ProjectMilestonesPage;


### PR DESCRIPTION
### 新增
- 建立 /projects/milestones （學習分享區 -> 學習計畫的里程碑頁面）
- 調整 PublicProjectLayout: 減少不必要的側欄參數
- fork 原有的 milestones, task... 等 component 並移除交互參數製作唯獨版本，分離資料顯示和編輯功能
