### PR TITLE
feat: add project notes pages and enable notes navigation

### DIFF
--- a/layout/PublicProjectLayout.tsx
+++ b/layout/PublicProjectLayout.tsx
@@ -81,8 +81,7 @@ function ProjectLayout({ children }: ProjectLayoutContentProps) {
               學習成果
             </Sidebar.Link>
             <Sidebar.Link
-              isDisabled
-              href={`/projects/notes/detail?projectId=${projectId}`}
+              href={`/projects/notes?projectId=${projectId}`}
               isActive={activeTabPath.startsWith('/projects/notes/detail')}
             >
               便利貼

--- a/pages/projects/notes/detail.tsx
+++ b/pages/projects/notes/detail.tsx
@@ -1,0 +1,35 @@
+import { useRouter, useSearchParams } from 'next/navigation';
+import NoteDetail from '@/components/Note/Detail';
+import getPublicProjectLayout from '@/layout/PublicProjectLayout';
+import { useProjectNote } from '@/hooks/api/project';
+
+const NoteDetailPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const projectId = searchParams.get('id') ?? undefined;
+  const noteId = parseInt(searchParams.get('noteId') ?? '0', 10);
+  const {
+    data: note,
+  } = useProjectNote({
+    projectId,
+    noteId,
+  });
+
+  console.log('NoteDetailPage', note);
+  if (!projectId || !noteId) {
+    router.replace(`/project/notes?id=${projectId}`);
+    return null;
+  }
+  return (
+    <div className="bg-basic-white rounded-2xl">
+      <NoteDetail
+        data={note}
+      />
+    </div>
+  );
+};
+
+NoteDetailPage.getLayout = (page: React.ReactElement) =>
+    getPublicProjectLayout(page);
+
+export default NoteDetailPage;

--- a/pages/projects/notes/detail.tsx
+++ b/pages/projects/notes/detail.tsx
@@ -15,9 +15,8 @@ const NoteDetailPage = () => {
     noteId,
   });
 
-  console.log('NoteDetailPage', note);
   if (!projectId || !noteId) {
-    router.replace(`/project/notes?id=${projectId}`);
+    router.replace(`/projects/notes?id=${projectId}`);
     return null;
   }
   return (

--- a/pages/projects/notes/index.tsx
+++ b/pages/projects/notes/index.tsx
@@ -4,10 +4,15 @@ import getPublicProjectLayout from '@/layout/PublicProjectLayout';
 import {
   useProjectNoteList,
 } from '@/hooks/api/project';
+import { z } from 'zod';
 
 const NotesPage = () => {
   const searchParams = useSearchParams();
-  const projectId = searchParams.get('projectId') ?? undefined;
+  const projectIdParam = searchParams.get('projectId');
+  const projectId =
+    projectIdParam && z.string().uuid().safeParse(projectIdParam).success
+      ? projectIdParam
+      : undefined;
 
   const {
     data: notes,

--- a/pages/projects/notes/index.tsx
+++ b/pages/projects/notes/index.tsx
@@ -1,0 +1,42 @@
+import { useSearchParams } from 'next/navigation';
+import NoteCard from '@/components/Note/Card';
+import getPublicProjectLayout from '@/layout/PublicProjectLayout';
+import {
+  useProjectNoteList,
+} from '@/hooks/api/project';
+
+const NotesPage = () => {
+  const searchParams = useSearchParams();
+  const projectId = searchParams.get('projectId') ?? undefined;
+
+  const {
+    data: notes,
+  } = useProjectNoteList(projectId);
+
+  if (!projectId) {
+    return <div>專案不存在</div>;
+  }
+
+  return (
+    <>
+      <ul className="px-4 bg-basic-white flex flex-col rounded-2xl">
+        {notes?.map((note) => (
+          <li
+            key={note.id}
+            className="py-6 border-b last:border-b-0 border-solid border-basic-200"
+          >
+            <NoteCard
+              data={note}
+              className="p-3 transition-shadow hover:shadow-basic-200/40 hover:shadow-lg"
+              detailLink={`/projects/notes/detail?id=${projectId}&noteId=${note.id}`}
+            />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+NotesPage.getLayout = getPublicProjectLayout;
+
+export default NotesPage;


### PR DESCRIPTION
新增公開區的便利貼

待解決
/projects/notes/detail?id=17802f76-39ca-496b-919d-677385356835&noteId=1
回到其他頁
/projects/milestones?projectId=null

拿不到projectId