### PR TITLE
feat: Enhance Project Pages with SEO Metadata and Task Operation Confirmations

### DIFF
--- a/components/Tasks/Task.tsx
+++ b/components/Tasks/Task.tsx
@@ -13,6 +13,7 @@ import { useMilestones } from '@/contexts/Milestones/index';
 import { Task as TaskType } from "@/contexts/Milestones/type";
 import Button from '@/shared/components/Button';
 import Dropdown from '@/shared/components/Dropdown';
+import { useDialog } from '@/contexts/Dialog';
 
 interface TaskProps {
   index?: number;
@@ -56,6 +57,7 @@ const Task = ({
   const { createTask, dispatchTask, deleteTask, fetchMilestones } = useMilestones();
   const [isEditing, setIsEditing] = useState(false);
   const [newTask, setNewTask] = useState<Omit<TaskType, 'id'>>(task ?? DEFAULT_TASK);
+  const { openDialog } = useDialog();
 
   const handleClickUpdate = async () => {
     const success = isCreating
@@ -84,11 +86,23 @@ const Task = ({
     });
   };
 
-  const handleClickCancel = () => {
-    // TODO: add popup to let user confirm discard editing message
-    setNewTask(task ?? DEFAULT_TASK);
-    onCancel?.();
-    setIsEditing(false);
+  const handleClickCancel = async () => {
+    if (task === newTask) {
+      onCancel?.();
+      setIsEditing(false);
+      return;
+    }
+
+    const result = await openDialog({
+      title: '取消編輯',
+      content: '取消編輯後，會恢復原本的任務，確定要取消嗎？',
+    });
+
+    if (result) {
+      setNewTask(task ?? DEFAULT_TASK);
+      onCancel?.();
+      setIsEditing(false);
+    }
   };
 
   const handleCheckCompleted = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -114,13 +128,22 @@ const Task = ({
   const handleClickDelete = async () => {
     if (isCreating) return;
 
-    const success = await deleteTask(projectId, milestoneId, task);
-    if (success) {
-      toast.success('任務刪除成功');
-      fetchMilestones(projectId);
-      onRefreshData?.();
-    } else {
-      toast.error('任務刪除失敗，請稍後再試');
+    const result = await openDialog({
+      title: '刪除任務',
+      content: '刪除後無法恢復，確定要刪除嗎？',
+      confirmText: '確定',
+      cancelText: '取消',
+    });
+
+    if (result) {
+      const success = await deleteTask(projectId, milestoneId, task);
+      if (success) {
+        toast.success('任務刪除成功');
+        fetchMilestones(projectId);
+        onRefreshData?.();
+      } else {
+        toast.error('任務刪除失敗，請稍後再試');
+      }
     }
   };
 

--- a/pages/manage/project/notes/detail.tsx
+++ b/pages/manage/project/notes/detail.tsx
@@ -1,7 +1,8 @@
 import toast from 'react-hot-toast';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import NoteDetail from '@/components/Note/Detail';
+import SEOConfig from '@/shared/components/SEO';
 import getProjectLayout from '@/layout/ProjectLayout';
 import {
   useProject,
@@ -42,12 +43,28 @@ const NoteDetailPage = () => {
     },
   });
 
+  const SEOData = useMemo(
+    () => ({
+      title: `${note?.title} 便利貼｜島島阿學`,
+      description:
+        note?.content?.substring(0, 150) ||
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/project/notes?id=${projectId}&noteId=${noteId}`,
+    }),
+    [note?.title, note?.content, projectId, noteId]
+  );
+
   if (!projectId || noteId == null) {
     return null;
   }
 
   return (
     <div className="bg-basic-white rounded-2xl">
+      <SEOConfig data={SEOData} />
       <NoteDetail
         data={note}
         authorUser={project?.user}

--- a/pages/manage/project/notes/index.tsx
+++ b/pages/manage/project/notes/index.tsx
@@ -1,9 +1,10 @@
 import toast from 'react-hot-toast';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import NoteCard from '@/components/Note/Card';
 import getProjectLayout from '@/layout/ProjectLayout';
 import Button from '@/shared/components/Button';
+import SEOConfig from '@/shared/components/SEO';
 import CreateModal from '@/components/Note/Modals/CreateModal';
 import UpdateModal from '@/components/Note/Modals/UpdateModal';
 import ConfirmModal from '@/shared/components/Confirm';
@@ -57,12 +58,28 @@ const NotesPage = () => {
       },
     });
 
+  const SEOData = useMemo(
+    () => ({
+      title: `${project?.title} 便利貼｜島島阿學`,
+      description:
+        project?.description?.substring(0, 150) ||
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/project/notes?id=${projectId}`,
+    }),
+    [project?.title, project?.description, projectId]
+  );
+
   if (!projectId) {
     return <div>專案不存在</div>;
   }
 
   return (
     <>
+      <SEOConfig data={SEOData} />
       <div className="mb-6 flex items-center justify-between body-md">
         <div className="text-basic-500">便利貼 ({notes?.length || 0})</div>
         <Button

--- a/pages/manage/project/outcomes/detail.tsx
+++ b/pages/manage/project/outcomes/detail.tsx
@@ -1,8 +1,9 @@
 import toast from 'react-hot-toast';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import OutcomeDetail from '@/components/Outcome/Detail';
 import getProjectLayout from '@/layout/ProjectLayout';
+import SEOConfig from '@/shared/components/SEO';
 import {
   useProject,
   useProjectOutcome,
@@ -42,12 +43,28 @@ const OutcomeDetailPage = () => {
     },
   });
 
+  const SEOData = useMemo(
+    () => ({
+      title: `${outcome?.title} 學習成果｜島島阿學`,
+      description:
+        outcome?.content?.substring(0, 150) ||
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/project/outcomes?id=${projectId}&outcomeId=${outcomeId}`,
+    }),
+    [outcome?.title, outcome?.content, projectId, outcomeId]
+  );
+
   if (!projectId || outcomeId == null) {
     return null;
   }
 
   return (
     <div className="bg-basic-white rounded-2xl">
+      <SEOConfig data={SEOData} />
       <OutcomeDetail
         data={outcome}
         authorUser={project?.user}

--- a/pages/manage/project/outcomes/index.tsx
+++ b/pages/manage/project/outcomes/index.tsx
@@ -1,6 +1,7 @@
 import toast from 'react-hot-toast';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import SEOConfig from '@/shared/components/SEO';
 import OutcomeCard from '@/components/Outcome/Card';
 import getProjectLayout from '@/layout/ProjectLayout';
 import Button from '@/shared/components/Button';
@@ -57,12 +58,28 @@ const OutcomesPage = () => {
       },
     });
 
+  const SEOData = useMemo(
+    () => ({
+      title: `${project?.title} 學習成果｜島島阿學`,
+      description:
+        project?.description?.substring(0, 150) ||
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/project/outcomes?id=${projectId}`,
+    }),
+    [project?.title, project?.description, projectId]
+  );
+
   if (!projectId) {
     return <div>專案不存在</div>;
   }
 
   return (
     <>
+      <SEOConfig data={SEOData} />
       <div className="mb-6 flex items-center justify-between body-md">
         <div className="text-basic-500">學習成果 ({outcomes?.length ?? 0})</div>
         <Button

--- a/pages/manage/project/review/detail.tsx
+++ b/pages/manage/project/review/detail.tsx
@@ -1,7 +1,8 @@
 import { toast } from 'react-hot-toast';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import getProjectLayout from '@/layout/ProjectLayout';
+import SEOConfig from '@/shared/components/SEO';
 import ReviewDetail from '@/components/Review/Detail';
 import UpdateModal from '@/components/Review/Modals/UpdateModal';
 import {
@@ -43,12 +44,29 @@ const ReviewPage = () => {
     },
   });
 
+  const SEOData = useMemo(
+    () => ({
+      title: `${review?.title} 覆盤｜島島阿學`,
+      description:
+        review?.adjustmentPlan?.substring(0, 150) ||
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/project/review?id=${projectId}&reviewId=${reviewId}`,
+    }),
+    [review?.title, review?.adjustmentPlan, projectId, reviewId]
+  );
+
   if (!projectId || reviewId == null) {
     return null;
   }
 
   return (
     <>
+      <SEOConfig data={SEOData} />
+
       <ReviewDetail
         data={review}
         authorUser={project?.user}

--- a/pages/manage/project/review/index.tsx
+++ b/pages/manage/project/review/index.tsx
@@ -1,10 +1,11 @@
 import toast from 'react-hot-toast';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import getProjectLayout from '@/layout/ProjectLayout';
 import Button from '@/shared/components/Button';
 import ReviewCard from '@/components/Review/Card';
 import CreateModal from '@/components/Review/Modals/CreateModal';
+import SEOConfig from '@/shared/components/SEO';
 import UpdateModal from '@/components/Review/Modals/UpdateModal';
 import {
   useProject,
@@ -56,12 +57,28 @@ const ReviewPage = () => {
       },
     });
 
+  const SEOData = useMemo(
+    () => ({
+      title: `${project?.title} 覆盤｜島島阿學`,
+      description:
+        project?.description?.substring(0, 150) ||
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/project/review?id=${projectId}`,
+    }),
+    [project?.title, project?.description, projectId]
+  );
+
   if (!projectId) {
     return <div>專案不存在</div>;
   }
 
   return (
     <>
+      <SEOConfig data={SEOData} />
       <div className="mb-6 flex items-end sm:items-center justify-between body-md">
         <div className="flex flex-col items-start sm:flex-row sm:items-center gap-1">
           <div className="text-basic-500">

--- a/pages/manage/projects/index.jsx
+++ b/pages/manage/projects/index.jsx
@@ -3,9 +3,9 @@ import { useRouter } from 'next/router';
 import { RoleEnum, useAuth, ProtectedComponent } from '@/contexts/Auth';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import Select from '@/components/Projects/Form/Select';
+import SEOConfig from '@/shared/components/SEO';
 import AccessDenied from '@/shared/components/AccessDenied';
-import GoBackButton
-  from '@/components/Projects/GoBackButton';
+import GoBackButton from '@/components/Projects/GoBackButton';
 import emptyCoverImg from '@/public/assets/empty-cover.png';
 import CircleIcon from '@mui/icons-material/Circle';
 import { useMyProjects } from '@/services/modules/projects';
@@ -53,8 +53,23 @@ const Projects = () => {
     // }
   };
 
+  const SEOData = useMemo(
+    () => ({
+      title: '學習計畫｜島島阿學',
+      description:
+        '「島島阿學」盼能透過建立多元的學習資源網絡，讓自主學習者能找到合適的成長方法，進一步成為自己想成為的人，從中培養共好精神。目前正積極打造「可共編的學習資源平台」。',
+      keywords: '島島阿學',
+      author: '島島阿學',
+      copyright: '島島阿學',
+      imgLink: 'https://www.daoedu.tw/preview.webp',
+      link: `${process.env.HOSTNAME}/manage/projects`,
+    }),
+    []
+  );
+
   return (
     <ProtectedComponent>
+      <SEOConfig data={SEOData} />
       <div className="bg-[#F3FCFC] md:py-8 min-h-screen-without-padding-top">
         <div className="w-full p-4
           md:max-w-[860px] mx-auto box-border flex flex-col gap-6"


### PR DESCRIPTION
1. 新增 SEO 元數據到專案頁面
- 為學習計畫、便利貼、學習成果及覆盤等頁面實作 SEO 配置
- 加入標題、描述、作者和社交媒體元數據
- 確保所有專案管理頁面具有一致的 SEO 數據結構
- 優化各頁面的 URL 連結，提高搜尋引擎索引效率
2. 任務操作增加確認對話框
- 取消任務編輯時增加確認對話框，防止意外丟失編輯內容
- 刪除任務前增加確認對話框，避免誤刪
- 透過清晰的警告訊息改善用戶體驗
- 只有當任務內容有變更時才顯示取消編輯確認對話框

此次更新提升了網站的 SEO 表現並改善了任務管理模組的用戶體驗，使操作更加安全且友善。