### PR TITLE
fix(quiz): refactor background style for Safari compatibility

### DIFF
--- a/features/quiz/hooks/useResultStyles.ts
+++ b/features/quiz/hooks/useResultStyles.ts
@@ -14,8 +14,11 @@ export const useResultStyles = (theme?: Theme | null) => {
         "--bg-color": theme?.backgroundColor,
         "--color": theme?.color,
         "--secondary-color": theme?.secondaryColor,
-        "--bg-image": `url(${ResultNoisePng.src}) center / 393px 1352px repeat, linear-gradient(${theme?.backgroundColor})`,
-        background: "var(--bg-image)",
+        backgroundImage: `url(${ResultNoisePng.src})`,
+        backgroundPosition: "center",
+        backgroundRepeat: "repeat",
+        backgroundSize: "393px 1352px",
+        backgroundColor: theme?.backgroundColor,
       } as React.CSSProperties),
     [theme]
   );

--- a/pages/quiz/result/index.tsx
+++ b/pages/quiz/result/index.tsx
@@ -45,7 +45,7 @@ export default function QuizResultPage() {
   const shareAPI = getShareAPI({
     title: "【我有一個島，它叫＿島】學習風格測驗｜島島阿學",
     text: "【我有一個島，它叫＿島】學習風格測驗｜島島阿學",
-    url: '/quiz',
+    url: "/quiz",
     hashtag: "#島島阿學",
   });
 
@@ -120,6 +120,7 @@ export default function QuizResultPage() {
             <main
               ref={mainRef}
               className="p-6 pb-10 text-sm text-left text-basic-400 [background:var(--bg-image)]"
+              style={rootStyle}
             >
               <header className="mb-1">
                 <HorizontalLogoSvg className="h-[22px]" />


### PR DESCRIPTION
The shorthand 'background' property was not rendering correctly on Safari. Decomposing it into individual properties resolves the display issue.