### PR TITLE
fix(projects): correct API response types and improve cache management

### DIFF
--- a/services/practice/api.ts
+++ b/services/practice/api.ts
@@ -116,12 +116,7 @@ class PracticeAPIClass {
     const queryString = buildPracticeQueryString(params);
 
     try {
-      console.log('🔍 Practice API Request:', `${this.config.baseURL}${PRACTICE_BASE_PATH}${queryString}`);
-
       const result = await this.request<any>(`${PRACTICE_BASE_PATH}${queryString}`);
-
-      console.log('📥 Practice API Response:', result);
-
       // 適配 pagination 格式差異
       const adaptedResult = {
         data: result.data || [],
@@ -134,9 +129,6 @@ class PracticeAPIClass {
           hasPrev: result.pagination?.hasPrev,
         }
       };
-
-      console.log('🔄 Practice Adapted Result:', adaptedResult);
-
       return adaptedResult;
     } catch (error) {
       console.error('❌ Practice API Error:', error);

--- a/services/projects/core/api.ts
+++ b/services/projects/core/api.ts
@@ -6,6 +6,7 @@ import {
   ProjectSchema,
   CreateProjectSchema,
   UpdateProjectSchema,
+  ProjectMutationResponseSchema,
 } from "./schema";
 
 export type ProjectSWRKey = string;
@@ -36,62 +37,62 @@ export const getProjectPathname = ({
   return pathname;
 };
 
-// API class for fetching projects
-class ProjectAPI {
-  // Helper to transform API response to match schema
-  private transformProject(project: any): ProjectSchema {
-    return {
-      ...project,
-      createdDate: project.createdAt || project.createdDate,
-      updatedDate: project.updatedAt || project.updatedDate,
-    };
-  }
+// Helper to transform API response to match schema
+const transformProject = (project: any): ProjectSchema => ({
+  ...project,
+  createdDate: project.createdAt || project.createdDate,
+  updatedDate: project.updatedAt || project.updatedDate,
+});
 
-  /**
-   * 取得公開的學習計劃列表
-   */
+// API class for read operations
+class ProjectAPIClass {
   async readPublicList(): Promise<ProjectSchema[]> {
     const response = await fetcher<{ success: boolean; data: any[] }>(
       getProjectPathname({ isPublic: true })
     );
-    return response.data.map((project) => this.transformProject(project));
+    return response.data.map(transformProject);
   }
 
-  /**
-   * 取得我的學習計劃列表
-   */
   async readMyList(): Promise<ProjectSchema[]> {
     const response = await fetcher<{ success: boolean; data: any[] }>(
       getProjectPathname({ isMe: true })
     );
-    return response.data.map((project) => this.transformProject(project));
+    return response.data.map(transformProject);
   }
 
-  /**
-   * 取得單個學習計劃
-   */
   async read(id: string): Promise<ProjectSchema> {
     const response = await fetcher<{ success: boolean; data: any }>(
       getProjectPathname({ id })
     );
-    return this.transformProject(response.data);
+    return transformProject(response.data);
   }
 }
 
-export const projectAPIClass = new ProjectAPI();
+export const projectAPIClass = new ProjectAPIClass();
 
 interface ProjectMutationAPIType {
-  create: MutationFetcher<ProjectSchema, ProjectSWRKey, CreateProjectSchema>;
-  update: MutationFetcher<ProjectSchema, ProjectSWRKey, UpdateProjectSchema>;
+  create: MutationFetcher<
+    ProjectMutationResponseSchema,
+    ProjectSWRKey,
+    CreateProjectSchema
+  >;
+  update: MutationFetcher<
+    ProjectMutationResponseSchema,
+    ProjectSWRKey,
+    UpdateProjectSchema
+  >;
   delete: MutationFetcher<void, ProjectSWRKey, { id: string }>;
 }
 
 const projectAPI: ProjectMutationAPIType = {
   create: (_, { arg }) =>
-    mutations.post<ProjectSchema>(getProjectPathname(), arg),
+    mutations.post<ProjectMutationResponseSchema>(getProjectPathname(), arg),
 
   update: (_, { arg: { id, ...arg } }) =>
-    mutations.put<ProjectSchema>(getProjectPathname({ id }), arg),
+    mutations.put<ProjectMutationResponseSchema>(
+      getProjectPathname({ id }),
+      arg
+    ),
 
   delete: (_, { arg }) => mutations.delete<void>(getProjectPathname(arg)),
 };

--- a/services/projects/core/hooks.ts
+++ b/services/projects/core/hooks.ts
@@ -75,19 +75,62 @@ export function useProjectMutation({
   const createMutation = useSWRMutation(
     getProjectPathname({ isMe: true }),
     projectAPI.create,
-    { onSuccess: onCreated }
+    {
+      onSuccess: (response) => {
+        if (response?.data) {
+          // Update cache for the newly created project
+          mutate(
+            getProjectPathname({ id: response.data.id }),
+            response.data,
+            { revalidate: false }
+          );
+          // Invalidate the project list to refresh it
+          mutate(getProjectPathname({ isMe: true }));
+
+          if (onCreated) {
+            onCreated(response.data);
+          }
+        }
+      },
+    }
   );
 
   const updateMutation = useSWRMutation(
     getProjectPathname({ isMe: true }),
     projectAPI.update,
-    { onSuccess: onUpdated }
+    {
+      onSuccess: (response) => {
+        if (response?.data) {
+          // Update cache for the updated project
+          mutate(
+            getProjectPathname({ id: response.data.id }),
+            response.data,
+            { revalidate: false }
+          );
+          // Invalidate the project list to refresh it
+          mutate(getProjectPathname({ isMe: true }));
+
+          if (onUpdated) {
+            onUpdated(response.data);
+          }
+        }
+      },
+    }
   );
 
   const deleteMutation = useSWRMutation(
     getProjectPathname({ isMe: true }),
     projectAPI.delete,
-    { onSuccess: onDeleted }
+    {
+      onSuccess: () => {
+        // Invalidate the project list to refresh it
+        mutate(getProjectPathname({ isMe: true }));
+
+        if (onDeleted) {
+          onDeleted();
+        }
+      }
+    }
   );
 
   return {

--- a/services/projects/core/schema.ts
+++ b/services/projects/core/schema.ts
@@ -49,3 +49,13 @@ export const updateProjectSchema = projectSchema.omit({
 });
 
 export type UpdateProjectSchema = z.infer<typeof updateProjectSchema>;
+
+export const projectMutationResponseSchema = z.object({
+  success: z.boolean(),
+  data: projectSchema,
+  message: z.string().optional(),
+});
+
+export type ProjectMutationResponseSchema = z.infer<
+  typeof projectMutationResponseSchema
+>;


### PR DESCRIPTION
  ## Why is this necessary?
  - Project mutation APIs (create/update) return a wrapped response with { success, data, message } structure, but the code was expecting the project object directly. This type mismatch could cause runtime errors and incorrect cache updates.
  - SWR cache wasn't being properly updated after mutations, requiring manual page refresh to see changes.
  - Debug console.logs in practice API were left in production code.

  ## How does it address?
  - Add ProjectMutationResponseSchema to define correct API response structure
  - Update create/update API return types to use ProjectMutationResponseSchema
  - Implement proper cache updates in mutation onSuccess handlers:
    * Update individual project cache with response.data
    * Invalidate project list to trigger refresh
    * Pass unwrapped data to callback functions
  - Remove debug console.logs from practice API readList method
  - Refactor transformProject helper to standalone function for reusability
