### PR TITLE
feat(ideas): add edit/delete functionality and improve UX

### DIFF
--- a/features/ideas/components/IdeaActions.tsx
+++ b/features/ideas/components/IdeaActions.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Edit, Trash2, MoreVertical } from 'lucide-react';
+import { Button } from '@/shared/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/alert-dialog';
+import { useIdeaActions } from '@/features/ideas/hooks';
+import type { IdeaSchema } from '@/services/ideas';
+
+interface IdeaActionsProps {
+  idea: IdeaSchema;
+  onEdit?: () => void;
+  onDeleteSuccess?: () => void;
+  variant?: 'icon' | 'text';
+}
+
+/**
+ * 共用的 Idea 編輯/刪除操作元件
+ * 避免在 IdeaCard 和 IdeaHeader 中重複相同的邏輯
+ */
+export function IdeaActions({
+  idea,
+  onEdit,
+  onDeleteSuccess,
+  variant = 'icon'
+}: IdeaActionsProps) {
+  const router = useRouter();
+  const { deleteIdea, isDeleting } = useIdeaActions();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const handleEdit = (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    if (onEdit) {
+      onEdit();
+    } else {
+      router.push(`/ideas/${idea.id}?edit=true`);
+    }
+  };
+
+  const handleDelete = async (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    try {
+      await deleteIdea(idea.id);
+      setShowDeleteDialog(false);
+      toast.success('想法已刪除');
+
+      if (onDeleteSuccess) {
+        onDeleteSuccess();
+      }
+    } catch (error) {
+      console.error('刪除想法失敗:', error);
+      toast.error('刪除失敗,請稍後再試');
+    }
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-basic-400 hover:text-basic-600"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <MoreVertical className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuItem onClick={handleEdit}>
+            <Edit className="mr-2 h-4 w-4" />
+            編輯
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setShowDeleteDialog(true);
+            }}
+            className="text-red-600 focus:text-red-600"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            刪除
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* 刪除確認對話框 */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認刪除想法</AlertDialogTitle>
+            <AlertDialogDescription>
+              此操作無法復原。確定要刪除這個想法嗎?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
+              取消
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {isDeleting ? '刪除中...' : '確認刪除'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/features/ideas/components/IdeaActions.tsx
+++ b/features/ideas/components/IdeaActions.tsx
@@ -28,7 +28,6 @@ interface IdeaActionsProps {
   idea: IdeaSchema;
   onEdit?: () => void;
   onDeleteSuccess?: () => void;
-  variant?: 'icon' | 'text';
 }
 
 /**
@@ -39,7 +38,6 @@ export function IdeaActions({
   idea,
   onEdit,
   onDeleteSuccess,
-  variant = 'icon'
 }: IdeaActionsProps) {
   const router = useRouter();
   const { deleteIdea, isDeleting } = useIdeaActions();

--- a/features/ideas/components/IdeaCard.tsx
+++ b/features/ideas/components/IdeaCard.tsx
@@ -1,9 +1,16 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { CustomLink } from '@/shared/ui/custom-link';
 import {
   Share2,
   Link as LinkIcon,
   Eye,
+  Edit,
+  Trash2,
+  MoreVertical,
 } from 'lucide-react';
 import Shell from '@/public/assets/icons/shell.svg';
 import Comment from '@/public/assets/icons/comment.svg';
@@ -11,6 +18,24 @@ import { Button } from '@/shared/ui';
 import { Card, CardContent } from '@/shared/ui/card';
 import { Badge } from '@/shared/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/shared/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/alert-dialog';
+import { useSession } from '@/entities/session';
+import { useIdeaActions } from '@/features/ideas/hooks';
 import type { IdeaSchema } from '@/services/ideas/schema';
 
 interface IdeaCardProps {
@@ -22,10 +47,39 @@ function IdeaCard({
   idea,
   onClick,
 }: IdeaCardProps) {
+  const router = useRouter();
+  const { user } = useSession();
+  const { deleteIdea, isDeleting } = useIdeaActions();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  // 檢查是否為想法的作者
+  const isOwner = user?.id === idea.user?.id || user?.id === idea.user?._id;
+
   const handleCardClick = (e: React.MouseEvent) => {
     e.preventDefault();
     if (onClick) {
       onClick(idea.id);
+    }
+  };
+
+  const handleEdit = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    router.push(`/ideas/${idea.id}?edit=true`);
+  };
+
+  const handleDelete = async (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    try {
+      await deleteIdea(idea.id);
+      setShowDeleteDialog(false);
+      toast.success('想法已刪除');
+    } catch (error) {
+      console.error('刪除想法失敗:', error);
+      toast.error('刪除失敗，請稍後再試');
     }
   };
 
@@ -61,7 +115,7 @@ function IdeaCard({
                 </span>
               </div>
               <div className="text-xs text-basic-300 mt-0.5">
-                {idea.user?.roleList?.join(' | ') || '想法分享者'}
+                {idea.user?.roleList?.[0] || '想法分享者'}
               </div>
             </div>
           </div>
@@ -75,10 +129,43 @@ function IdeaCard({
             <div className="text-xs text-basic-300 hidden sm:block">
               {new Date(idea.createdAt).toLocaleDateString('zh-TW')}
             </div>
+
+            {/* 編輯/刪除選單 - 只有作者可見 */}
+            {isOwner && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0 text-basic-400 hover:text-basic-600"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  <DropdownMenuItem onClick={handleEdit}>
+                    <Edit className="mr-2 h-4 w-4" />
+                    編輯
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setShowDeleteDialog(true);
+                    }}
+                    className="text-red-600 focus:text-red-600"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    刪除
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         </div>
 
-        <p className="text-basic-500 mb-3 sm:mb-4 text-sm sm:text-base line-clamp-3 sm:line-clamp-none">{idea.content}</p>
+        <p className="text-basic-500 mb-3 sm:mb-4 text-sm sm:text-base line-clamp-3 sm:line-clamp-none whitespace-pre-wrap">{idea.content}</p>
 
         <div className="flex gap-1 sm:gap-2 mb-3 sm:mb-4 flex-wrap">
           {idea.tags?.map((tag) => (
@@ -138,13 +225,43 @@ function IdeaCard({
     </Card>
   );
 
+  const content = (
+    <>
+      {cardContent}
+
+      {/* 刪除確認對話框 */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認刪除想法</AlertDialogTitle>
+            <AlertDialogDescription>
+              此操作無法復原。確定要刪除這個想法嗎?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
+              取消
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {isDeleting ? '刪除中...' : '確認刪除'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+
   if (onClick) {
-    return cardContent;
+    return content;
   }
 
   return (
     <CustomLink href={`/ideas/${idea.id}`} className="block max-w-xs sm:max-w-sm md:max-w-md lg:max-w-3xl mx-auto">
-      {cardContent}
+      {content}
     </CustomLink>
   );
 }

--- a/features/ideas/components/IdeaCard.tsx
+++ b/features/ideas/components/IdeaCard.tsx
@@ -14,8 +14,8 @@ import { Card, CardContent } from '@/shared/ui/card';
 import { Badge } from '@/shared/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/shared/ui/avatar';
 import { useSession } from '@/entities/session';
-import { IdeaActions } from './IdeaActions';
 import type { IdeaSchema } from '@/services/ideas/schema';
+import { IdeaActions } from './IdeaActions';
 
 interface IdeaCardProps {
   idea: IdeaSchema;

--- a/features/ideas/components/IdeaCard.tsx
+++ b/features/ideas/components/IdeaCard.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
+import React from 'react';
 import { CustomLink } from '@/shared/ui/custom-link';
 import {
   Share2,
   Link as LinkIcon,
   Eye,
-  Edit,
-  Trash2,
-  MoreVertical,
 } from 'lucide-react';
 import Shell from '@/public/assets/icons/shell.svg';
 import Comment from '@/public/assets/icons/comment.svg';
@@ -18,24 +13,8 @@ import { Button } from '@/shared/ui';
 import { Card, CardContent } from '@/shared/ui/card';
 import { Badge } from '@/shared/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/shared/ui/avatar';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/shared/ui/dropdown-menu';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/shared/ui/alert-dialog';
 import { useSession } from '@/entities/session';
-import { useIdeaActions } from '@/features/ideas/hooks';
+import { IdeaActions } from './IdeaActions';
 import type { IdeaSchema } from '@/services/ideas/schema';
 
 interface IdeaCardProps {
@@ -47,39 +26,15 @@ function IdeaCard({
   idea,
   onClick,
 }: IdeaCardProps) {
-  const router = useRouter();
   const { user } = useSession();
-  const { deleteIdea, isDeleting } = useIdeaActions();
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // 檢查是否為想法的作者
-  const isOwner = user?.id === idea.user?.id || user?.id === idea.user?._id;
+  const isOwner = user?.id === idea.user?.id;
 
   const handleCardClick = (e: React.MouseEvent) => {
     e.preventDefault();
     if (onClick) {
       onClick(idea.id);
-    }
-  };
-
-  const handleEdit = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    router.push(`/ideas/${idea.id}?edit=true`);
-  };
-
-  const handleDelete = async (e?: React.MouseEvent) => {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-    try {
-      await deleteIdea(idea.id);
-      setShowDeleteDialog(false);
-      toast.success('想法已刪除');
-    } catch (error) {
-      console.error('刪除想法失敗:', error);
-      toast.error('刪除失敗，請稍後再試');
     }
   };
 
@@ -131,37 +86,7 @@ function IdeaCard({
             </div>
 
             {/* 編輯/刪除選單 - 只有作者可見 */}
-            {isOwner && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0 text-basic-400 hover:text-basic-600"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <MoreVertical className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-40">
-                  <DropdownMenuItem onClick={handleEdit}>
-                    <Edit className="mr-2 h-4 w-4" />
-                    編輯
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setShowDeleteDialog(true);
-                    }}
-                    className="text-red-600 focus:text-red-600"
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    刪除
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+            {isOwner && <IdeaActions idea={idea} />}
           </div>
         </div>
 
@@ -225,35 +150,7 @@ function IdeaCard({
     </Card>
   );
 
-  const content = (
-    <>
-      {cardContent}
-
-      {/* 刪除確認對話框 */}
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <AlertDialogContent onClick={(e) => e.stopPropagation()}>
-          <AlertDialogHeader>
-            <AlertDialogTitle>確認刪除想法</AlertDialogTitle>
-            <AlertDialogDescription>
-              此操作無法復原。確定要刪除這個想法嗎?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={(e) => e.stopPropagation()}>
-              取消
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700"
-            >
-              {isDeleting ? '刪除中...' : '確認刪除'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
+  const content = cardContent;
 
   if (onClick) {
     return content;

--- a/features/ideas/components/IdeaForm.tsx
+++ b/features/ideas/components/IdeaForm.tsx
@@ -262,9 +262,6 @@ const IdeaCreateForm: React.FC<IdeaCreateFormProps> = ({
 
             <div className="ml-3">
               <div className="text-sm font-medium text-white">分享新想法</div>
-              <div className="mt-1 text-xs text-white opacity-80">
-                與島友分享你的學習洞察和創新想法
-              </div>
             </div>
           </div>
           {onCancel && (
@@ -297,11 +294,11 @@ const IdeaCreateForm: React.FC<IdeaCreateFormProps> = ({
                       {...form.register('content')}
                       placeholder="分享你的學習洞察、重要發現或創新想法..."
                       className="text-basic-700 min-h-[24px] w-full resize-none rounded-none !border-0 !border-none bg-transparent px-0 py-4 leading-6 shadow-none focus:border-transparent focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
-                      maxLength={5000}
+                      maxLength={1000}
                     />
                     <div className="mt-2 text-right text-xs text-basic-400">
                       {charactersUsed}
-                      /5000
+                      /1000
                     </div>
                   </div>
                 </div>

--- a/features/resources/components/ContributorInfo.tsx
+++ b/features/resources/components/ContributorInfo.tsx
@@ -60,7 +60,7 @@ export default function ContributorInfo({ user }: ContributorInfoProps) {
           <h3 className="body-lg mb-2 font-bold text-basic-500">簡介</h3>
           <p className="mb-2 text-basic-500">{user.selfIntroduction}</p>
           <Button type="button" variant="link" className="-mx-2 px-2" asChild>
-            <CustomLink href={`/partner/detail?id=${user._id}`}>了解更多</CustomLink>
+            <CustomLink href={`/partner/detail?id=${user.id}`}>了解更多</CustomLink>
           </Button>
         </div>
       </div>

--- a/layout/features/getProjectLayout.tsx
+++ b/layout/features/getProjectLayout.tsx
@@ -104,7 +104,7 @@ const useProjectPermission = (type: ProjectType) => {
       case ProjectType.Admin:
         return role ? ADMIN_PERMISSIONS.includes(role) : false;
       case ProjectType.Manage:
-        return swr.isLoading || swr.data?.user._id === user?.id;
+        return swr.isLoading || swr.data?.user.id === user?.id;
       default:
         return !pathname?.startsWith(`${baseUrl}${projectRoutes.reviews}`);
     }

--- a/pages/[language]/resource/[resourceId]/index.tsx
+++ b/pages/[language]/resource/[resourceId]/index.tsx
@@ -135,7 +135,7 @@ export default function ResourceDetailPage({
               <TabsTrigger
                 value={TabEnum.Contributor}
                 className="basis-1/3"
-                disabled={!data.user?._id}
+                disabled={!data.user?.id}
               >
                 分享者資訊
               </TabsTrigger>

--- a/services/users/schema.ts
+++ b/services/users/schema.ts
@@ -69,7 +69,6 @@ export const userSchema = z.object({
 
 export const baseUserSchema = userSchema
   .pick({
-    _id: true,
     id: true,
     name: true,
     photoURL: true,

--- a/shared/components/Comment/CommentCard.tsx
+++ b/shared/components/Comment/CommentCard.tsx
@@ -25,6 +25,7 @@ interface CommentCardProps extends CommentSchema {
   onCreate?: (data: Omit<CommentData, 'id'>) => void;
   onUpdate?: (data: CommentData) => void;
   onDelete?: (data: { id: number }) => void;
+  hideVisibilityToggle?: boolean;
 }
 
 function CommentCard({
@@ -37,6 +38,7 @@ function CommentCard({
   onCreate,
   onUpdate,
   onDelete,
+  hideVisibilityToggle = false,
 }: CommentCardProps) {
   const { user } = useSession();
   const [isShowCommentInput, setIsShowCommentInput] = useState(false);
@@ -47,7 +49,7 @@ function CommentCard({
 
   const actions = isSelf
     ? [
-      onUpdate && {
+      !hideVisibilityToggle && onUpdate && {
         key: 'toggleVisibility',
         children: isPublic ? '設為不公開' : '設為公開',
         onClick: () => onUpdate({
@@ -108,10 +110,12 @@ function CommentCard({
         </div>
         <div className="flex items-center gap-3 text-basic-300">
           <time>{timeDuration(updatedAt)}</time>
-          <div className="hidden items-center gap-0.5 sm:flex">
-            {visibility === 'public' ? <LockKeyholeOpen /> : <LockKeyhole />}
-            <span>{visibility === 'public' ? '公開' : '不公開'}</span>
-          </div>
+          {!hideVisibilityToggle && (
+            <div className="hidden items-center gap-0.5 sm:flex">
+              {visibility === 'public' ? <LockKeyholeOpen /> : <LockKeyhole />}
+              <span>{visibility === 'public' ? '公開' : '不公開'}</span>
+            </div>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger className="-m-2 p-2">
@@ -147,6 +151,7 @@ function CommentCard({
             }}
             onCancel={() => setIsEditing(false)}
             hideHeader
+            hideVisibilityToggle={hideVisibilityToggle}
           />
         ) : (
           <p className="whitespace-pre-wrap text-basic-500">{content}</p>
@@ -196,6 +201,7 @@ function CommentCard({
                   onCreate={onCreate}
                   onUpdate={onUpdate}
                   onDelete={onDelete}
+                  hideVisibilityToggle={hideVisibilityToggle}
                   {...reply}
                 />
               ))}
@@ -211,6 +217,7 @@ function CommentCard({
           defaultIsEditing
           onSubmit={handleCreateComment}
           onCancel={() => setIsShowCommentInput(false)}
+          hideVisibilityToggle={hideVisibilityToggle}
         />
       )}
     </div>

--- a/shared/components/Comment/CommentInput.tsx
+++ b/shared/components/Comment/CommentInput.tsx
@@ -20,6 +20,7 @@ interface CommentInputProps {
   parentId?: number;
   className?: string;
   hideHeader?: boolean;
+  hideVisibilityToggle?: boolean;
   defaultContent?: string;
   defaultIsEditing?: boolean;
   defaultIsPublic?: boolean;
@@ -32,6 +33,7 @@ function CommentInput({
   parentId,
   className,
   hideHeader = false,
+  hideVisibilityToggle = false,
   defaultContent = '',
   defaultIsEditing = false,
   defaultIsPublic = true,
@@ -94,7 +96,7 @@ function CommentInput({
             <div className="text-basic-500">{user.name}</div>
             <div className="rounded bg-basic-100 px-2.5 py-1 text-basic-500">{role}</div>
           </div>
-          {isEditing && (
+          {isEditing && !hideVisibilityToggle && (
             <Button
               className="-mb-1 mt-1 p-1"
               size="sm"
@@ -122,7 +124,7 @@ function CommentInput({
           onChange={(e) => setContent(e.target.value)}
           onClick={handleClick}
           placeholder={placeholder}
-          className="focus:ring-primary-500 w-full rounded-lg border px-4 py-2 focus:outline-none focus:ring-1"
+          className="w-full rounded-lg border border-basic-200 bg-white px-4 py-2 text-basic-500 placeholder:text-basic-300 focus:outline-none focus:ring-1 focus:ring-primary-base focus:border-primary-base"
           autoRows
         />
         {isEditing && (

--- a/shared/components/Comment/CommentSection.tsx
+++ b/shared/components/Comment/CommentSection.tsx
@@ -6,9 +6,11 @@ import CommentCard from './CommentCard';
 interface CommentSectionProps {
   targetId: string | number;
   targetType: CommentType;
+  hideVisibilityToggle?: boolean;
+  hideCommentCount?: boolean;
 }
 
-function CommentSection({ targetId, targetType }: CommentSectionProps) {
+function CommentSection({ targetId, targetType, hideVisibilityToggle = false, hideCommentCount = false }: CommentSectionProps) {
   const {
     data: comments,
     createMutation,
@@ -24,17 +26,20 @@ function CommentSection({ targetId, targetType }: CommentSectionProps) {
       <CommentInput
         className="px-4 pb-4 pt-6"
         onSubmit={createMutation.trigger}
+        hideVisibilityToggle={hideVisibilityToggle}
       />
       {Array.isArray(comments) && comments.length > 0 && (
         <>
-          <div className="body-md mb-2 flex items-center gap-0.5 border-t border-solid border-basic-200 pt-2 text-basic-500">
-            <Comment />
-            <span>
-              回覆 (
-              {comments.length}
-              )
-            </span>
-          </div>
+          {!hideCommentCount && (
+            <div className="body-md mb-2 flex items-center gap-0.5 border-t border-solid border-basic-200 pt-2 text-basic-500">
+              <Comment />
+              <span>
+                回覆 (
+                {comments.length}
+                )
+              </span>
+            </div>
+          )}
           {Array.isArray(comments) && comments.length > 0 && (
             <div className="flex flex-col gap-4 rounded-lg border border-solid border-basic-200 px-8 py-6">
               {comments.map((comment) => (
@@ -43,6 +48,7 @@ function CommentSection({ targetId, targetType }: CommentSectionProps) {
                   onCreate={createMutation.trigger}
                   onUpdate={updateMutation.trigger}
                   onDelete={deleteMutation.trigger}
+                  hideVisibilityToggle={hideVisibilityToggle}
                   {...comment}
                 />
               ))}

--- a/shared/ui/back-button.tsx
+++ b/shared/ui/back-button.tsx
@@ -11,7 +11,7 @@ interface BackButtonProps extends Omit<ButtonProps, 'children' | 'onClick'> {
 }
 
 export const BackButton = ({
-  label = '返回',
+  label,
   className,
   onClick,
   ...props
@@ -26,7 +26,7 @@ export const BackButton = ({
       className={cn('-mx-2 px-2 text-basic-400', className)}
       {...props}
     >
-      <ChevronLeft className="size-4" />
+      <ChevronLeft className="size-7" />
       {label}
     </Button>
   );

--- a/widgets/idea-detail/ui/IdeaContent.tsx
+++ b/widgets/idea-detail/ui/IdeaContent.tsx
@@ -8,6 +8,18 @@ import { Textarea } from '@/shared/ui/textarea';
 import { Input } from '@/shared/ui/input';
 import type { IdeaSchema, IdeaResourceSchema } from '@/services/ideas';
 
+/**
+ * 為編輯模式的資源添加唯一 ID
+ *
+ * 為什麼需要這個:
+ * - 當資源列表中有重複的 name 或 url 時,僅用 name 或 url 作為 key 會導致錯誤刪除
+ * - 使用 crypto.randomUUID() 生成的唯一 ID 確保每個資源都能被正確識別和刪除
+ * - 保存時會將 id 移除,只傳送原始的 { name, url } 資料給後端
+ */
+interface EditableResource extends IdeaResourceSchema {
+  id: string;
+}
+
 interface IdeaContentProps {
   idea: IdeaSchema;
   isEditing?: boolean;
@@ -18,7 +30,13 @@ interface IdeaContentProps {
 export function IdeaContent({ idea, isEditing = false, onSave, onCancel }: IdeaContentProps) {
   const [editContent, setEditContent] = useState(idea.content);
   const [editTags, setEditTags] = useState<string[]>(idea.tags || []);
-  const [editResources, setEditResources] = useState<IdeaResourceSchema[]>(idea.resources || []);
+  // 為每個資源添加唯一 ID 以確保正確刪除
+  const [editResources, setEditResources] = useState<EditableResource[]>(
+    () => (idea.resources || []).map((resource) => ({
+      ...resource,
+      id: crypto.randomUUID(),
+    }))
+  );
   const [newTag, setNewTag] = useState('');
   const [newResourceName, setNewResourceName] = useState('');
   const [newResourceUrl, setNewResourceUrl] = useState('');
@@ -36,14 +54,22 @@ export function IdeaContent({ idea, isEditing = false, onSave, onCancel }: IdeaC
 
   const handleAddResource = () => {
     if (newResourceName.trim() && newResourceUrl.trim()) {
-      setEditResources([...editResources, { name: newResourceName.trim(), url: newResourceUrl.trim() }]);
+      setEditResources([
+        ...editResources,
+        {
+          name: newResourceName.trim(),
+          url: newResourceUrl.trim(),
+          id: crypto.randomUUID(),
+        },
+      ]);
       setNewResourceName('');
       setNewResourceUrl('');
     }
   };
 
-  const handleRemoveResource = (index: number) => {
-    setEditResources(editResources.filter((_, i) => i !== index));
+  const handleRemoveResource = (id: string) => {
+    // 使用唯一 ID 刪除,避免重複資源造成錯誤刪除
+    setEditResources(editResources.filter((resource) => resource.id !== id));
   };
 
   const handleSave = () => {
@@ -51,7 +77,10 @@ export function IdeaContent({ idea, isEditing = false, onSave, onCancel }: IdeaC
       onSave({
         content: editContent,
         tags: editTags,
-        resources: editResources,
+        resources: editResources.map((resource) => ({
+          name: resource.name,
+          url: resource.url,
+        })),
       });
     }
   };
@@ -175,7 +204,7 @@ export function IdeaContent({ idea, isEditing = false, onSave, onCancel }: IdeaC
             <div className="space-y-2">
               {editResources.map((resource) => (
                 <div
-                  key={`${resource.url}-${resource.name}`}
+                  key={resource.id}
                   className="flex items-center justify-between p-2 sm:p-3 bg-primary-lightest rounded-lg"
                 >
                   <div className="flex items-center flex-1 min-w-0">
@@ -185,7 +214,7 @@ export function IdeaContent({ idea, isEditing = false, onSave, onCancel }: IdeaC
                     </span>
                   </div>
                   <Button
-                    onClick={() => handleRemoveResource(editResources.indexOf(resource))}
+                    onClick={() => handleRemoveResource(resource.id)}
                     variant="ghost"
                     size="sm"
                     className="size-auto p-1 h-auto hover:text-alert ml-2"

--- a/widgets/idea-detail/ui/IdeaContent.tsx
+++ b/widgets/idea-detail/ui/IdeaContent.tsx
@@ -1,13 +1,226 @@
-import { Link as LinkIcon } from 'lucide-react';
+'use client';
+
+import { useState } from 'react';
+import { Link as LinkIcon, X, Plus, Save } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Badge } from '@/shared/ui/badge';
+import { Textarea } from '@/shared/ui/textarea';
+import { Input } from '@/shared/ui/input';
 import type { IdeaSchema, IdeaResourceSchema } from '@/services/ideas';
 
 interface IdeaContentProps {
   idea: IdeaSchema;
+  isEditing?: boolean;
+  onSave?: (data: { content: string; tags: string[]; resources: IdeaResourceSchema[] }) => void;
+  onCancel?: () => void;
 }
 
-export function IdeaContent({ idea }: IdeaContentProps) {
+export function IdeaContent({ idea, isEditing = false, onSave, onCancel }: IdeaContentProps) {
+  const [editContent, setEditContent] = useState(idea.content);
+  const [editTags, setEditTags] = useState<string[]>(idea.tags || []);
+  const [editResources, setEditResources] = useState<IdeaResourceSchema[]>(idea.resources || []);
+  const [newTag, setNewTag] = useState('');
+  const [newResourceName, setNewResourceName] = useState('');
+  const [newResourceUrl, setNewResourceUrl] = useState('');
+
+  const handleAddTag = () => {
+    if (newTag.trim() && editTags.length < 5 && !editTags.includes(newTag.trim())) {
+      setEditTags([...editTags, newTag.trim()]);
+      setNewTag('');
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setEditTags(editTags.filter((tag) => tag !== tagToRemove));
+  };
+
+  const handleAddResource = () => {
+    if (newResourceName.trim() && newResourceUrl.trim()) {
+      setEditResources([...editResources, { name: newResourceName.trim(), url: newResourceUrl.trim() }]);
+      setNewResourceName('');
+      setNewResourceUrl('');
+    }
+  };
+
+  const handleRemoveResource = (index: number) => {
+    setEditResources(editResources.filter((_, i) => i !== index));
+  };
+
+  const handleSave = () => {
+    if (onSave) {
+      onSave({
+        content: editContent,
+        tags: editTags,
+        resources: editResources,
+      });
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <main className="space-y-4">
+        {/* 內容編輯 */}
+        <div>
+          <div className="text-sm font-medium text-basic-700 mb-2">
+            想法內容 <span className="text-alert">*</span>
+          </div>
+          <Textarea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            placeholder="分享你的想法..."
+            rows={6}
+            maxLength={1000}
+            className="w-full resize-none"
+            aria-label="想法內容"
+          />
+          <div className="text-xs text-basic-500 mt-1 text-right">
+            {editContent.length}/1000
+          </div>
+        </div>
+
+        {/* 標籤編輯 */}
+        <div>
+          <div className="text-sm font-medium text-basic-700 mb-2">
+            標籤 (最多5個)
+          </div>
+
+          {/* 新增標籤輸入 */}
+          {editTags.length < 5 && (
+            <div className="flex gap-2 mb-3">
+              <Input
+                type="text"
+                value={newTag}
+                onChange={(e) => setNewTag(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleAddTag()}
+                placeholder="輸入標籤"
+                maxLength={20}
+                className="flex-1"
+                aria-label="新增標籤"
+              />
+              <Button
+                onClick={handleAddTag}
+                disabled={!newTag.trim()}
+                size="sm"
+                variant="outline"
+                aria-label="新增標籤"
+              >
+                <Plus className="size-4" />
+              </Button>
+            </div>
+          )}
+
+          {/* 當前標籤 */}
+          {editTags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {editTags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="secondary"
+                  className="px-2 py-1 bg-basic-100 text-basic-500 text-xs font-medium rounded-full inline-flex items-center gap-1"
+                >
+                  {tag}
+                  <Button
+                    onClick={() => handleRemoveTag(tag)}
+                    variant="ghost"
+                    size="sm"
+                    className="size-auto p-0 h-auto hover:text-alert ml-1"
+                  >
+                    <X className="size-3" />
+                  </Button>
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* 資源連結編輯 */}
+        <div>
+          <div className="text-sm font-medium text-basic-700 mb-2">
+            資源連結
+          </div>
+
+          {/* 新增資源輸入 */}
+          <div className="space-y-2 mb-3">
+            <Input
+              type="text"
+              value={newResourceName}
+              onChange={(e) => setNewResourceName(e.target.value)}
+              placeholder="資源名稱"
+              maxLength={100}
+              aria-label="資源名稱"
+            />
+            <div className="flex gap-2">
+              <Input
+                type="url"
+                value={newResourceUrl}
+                onChange={(e) => setNewResourceUrl(e.target.value)}
+                placeholder="資源連結 (https://...)"
+                className="flex-1"
+                aria-label="資源連結"
+              />
+              <Button
+                onClick={handleAddResource}
+                disabled={!newResourceName.trim() || !newResourceUrl.trim()}
+                size="sm"
+                variant="outline"
+                aria-label="新增資源"
+              >
+                <Plus className="size-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* 當前資源 */}
+          {editResources.length > 0 && (
+            <div className="space-y-2">
+              {editResources.map((resource) => (
+                <div
+                  key={`${resource.url}-${resource.name}`}
+                  className="flex items-center justify-between p-2 sm:p-3 bg-primary-lightest rounded-lg"
+                >
+                  <div className="flex items-center flex-1 min-w-0">
+                    <LinkIcon size={14} className="text-primary-base mr-1 sm:mr-2 flex-shrink-0" />
+                    <span className="text-primary-darker text-xs sm:text-sm truncate">
+                      {resource.name}
+                    </span>
+                  </div>
+                  <Button
+                    onClick={() => handleRemoveResource(editResources.indexOf(resource))}
+                    variant="ghost"
+                    size="sm"
+                    className="size-auto p-1 h-auto hover:text-alert ml-2"
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* 編輯操作按鈕 */}
+        <div className="flex gap-2 pt-4">
+          <Button
+            onClick={onCancel}
+            variant="outline"
+            className="flex-1"
+          >
+            取消
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={!editContent.trim()}
+            className="flex-1"
+          >
+            <Save className="size-4 mr-2" />
+            儲存
+          </Button>
+        </div>
+      </main>
+    );
+  }
+
+  // 顯示模式（原始設計）
   return (
     <main>
       <div className="prose max-w-none">

--- a/widgets/idea-detail/ui/IdeaDetailWidget.tsx
+++ b/widgets/idea-detail/ui/IdeaDetailWidget.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useIdea } from '@/features/ideas/hooks';
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+import { useIdea , useIdeaActions } from '@/features/ideas/hooks';
+import { BackButton } from '@/shared/ui/back-button';
 import CommentSection from '@/shared/components/Comment/CommentSection';
 import { CommentType } from '@/services/comments';
+import type { IdeaResourceSchema } from '@/services/ideas';
 import { IdeaHeader } from './IdeaHeader';
 import { IdeaContent } from './IdeaContent';
 import { IdeaStats } from './IdeaStats';
@@ -16,7 +20,19 @@ interface IdeaDetailWidgetProps {
 
 export function IdeaDetailWidget({ ideaId }: IdeaDetailWidgetProps) {
   const router = useRouter();
-  const { idea, isLoading, isError } = useIdea(ideaId);
+  const searchParams = useSearchParams();
+  const { idea, isLoading, isError, refresh } = useIdea(ideaId);
+  const { updateIdea } = useIdeaActions();
+  const [isEditing, setIsEditing] = useState(false);
+
+  // 檢查 URL 參數，如果有 edit=true 則自動進入編輯模式
+  useEffect(() => {
+    if (searchParams?.get('edit') === 'true' && idea) {
+      setIsEditing(true);
+      // 移除 URL 參數，保持 URL 乾淨
+      router.replace(`/ideas/${ideaId}`, { scroll: false });
+    }
+  }, [searchParams, idea, ideaId, router]);
 
   if (isLoading) {
     return <LoadingState />;
@@ -26,19 +42,58 @@ export function IdeaDetailWidget({ ideaId }: IdeaDetailWidgetProps) {
     return <ErrorState onBack={() => router.push('/explore')} />;
   }
 
+  const handleEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+  };
+
+  const handleContentSave = async (data: { content: string; tags: string[]; resources: IdeaResourceSchema[] }) => {
+    try {
+      await updateIdea({
+        id: idea.id,
+        content: data.content,
+        tags: data.tags,
+        ideaResources: data.resources,
+      });
+      await refresh(); // 重新獲取更新後的數據
+      toast.success('想法更新成功!');
+      setIsEditing(false);
+    } catch (error) {
+      console.error('更新想法失敗:', error);
+      toast.error('更新想法失敗，請稍後再試');
+    }
+  };
+
   return (
     <div className="min-h-screen bg-primary-palest pt-24">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        <div className="bg-basic-white rounded-2xl p-4 md:p-8 lg:p-10 mt-6">
-          <IdeaHeader idea={idea} onBack={() => router.back()} />
-          <IdeaContent idea={idea} />
-          <IdeaStats idea={idea} />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* 返回按鈕 */}
+        <BackButton
+          onClick={() => router.back()}
+          className="mb-6 text-basic-500 hover:text-basic-black"
+        />
+
+        {/* 主要內容 */}
+        <div className="bg-basic-white rounded-2xl p-4 md:p-8 lg:p-10">
+          <IdeaHeader idea={idea} onEdit={handleEdit} />
+          <IdeaContent
+            idea={idea}
+            isEditing={isEditing}
+            onSave={handleContentSave}
+            onCancel={handleCancelEdit}
+          />
+          {!isEditing && <IdeaStats idea={idea} />}
         </div>
 
-        {/* 評論區塊 */}
-        <div className="mt-6 bg-basic-white rounded-2xl p-4 md:p-8 lg:p-10">
-          <CommentSection targetId={idea.id} targetType={CommentType.Idea} />
-        </div>
+        {/* 評論區塊 - 編輯時隱藏 */}
+        {!isEditing && (
+          <div className="mt-6 bg-basic-white rounded-2xl p-4 md:p-8 lg:p-10">
+            <CommentSection targetId={idea.id} targetType={CommentType.Idea} hideVisibilityToggle hideCommentCount />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/widgets/idea-detail/ui/IdeaHeader.tsx
+++ b/widgets/idea-detail/ui/IdeaHeader.tsx
@@ -1,31 +1,11 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
-import { Edit, Trash2, MoreVertical } from 'lucide-react';
 import { Image } from '@/shared/ui/image';
 import { ROLE } from '@/constants/member';
 import DefaultAvatar from '@/public/assets/icons/default-avatar.svg';
-import { Button } from '@/shared/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/shared/ui/dropdown-menu';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/shared/ui/alert-dialog';
 import { useSession } from '@/entities/session';
-import { useIdeaActions } from '@/features/ideas/hooks';
+import { IdeaActions } from '@/features/ideas/components/IdeaActions';
 import type { IdeaSchema } from '@/services/ideas';
 
 interface IdeaHeaderProps {
@@ -36,30 +16,12 @@ interface IdeaHeaderProps {
 export function IdeaHeader({ idea, onEdit }: IdeaHeaderProps) {
   const router = useRouter();
   const { user } = useSession();
-  const { deleteIdea, isDeleting } = useIdeaActions();
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // 檢查是否為想法的作者
-  const isOwner = user?.id === idea.user?.id || user?.id === idea.user?._id;
+  const isOwner = user?.id === idea.user?.id;
 
-  const handleEdit = () => {
-    if (onEdit) {
-      onEdit();
-    } else {
-      router.push(`/ideas/${idea.id}/edit`);
-    }
-  };
-
-  const handleDelete = async () => {
-    try {
-      await deleteIdea(idea.id);
-      setShowDeleteDialog(false);
-      toast.success('想法已刪除');
-      router.push('/explore');
-    } catch (error) {
-      console.error('刪除想法失敗:', error);
-      toast.error('刪除失敗，請稍後再試');
-    }
+  const handleDeleteSuccess = () => {
+    router.push('/explore');
   };
 
   return (
@@ -107,57 +69,16 @@ export function IdeaHeader({ idea, onEdit }: IdeaHeaderProps) {
 
               {/* 編輯/刪除選單 - 只有作者可見 */}
               {isOwner && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 w-8 p-0 text-basic-400 hover:text-basic-600"
-                    >
-                      <MoreVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-40">
-                    <DropdownMenuItem onClick={handleEdit}>
-                      <Edit className="mr-2 h-4 w-4" />
-                      編輯
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setShowDeleteDialog(true)}
-                      className="text-red-600 focus:text-red-600"
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      刪除
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <IdeaActions
+                  idea={idea}
+                  onEdit={onEdit}
+                  onDeleteSuccess={handleDeleteSuccess}
+                />
               )}
             </div>
           </div>
         </header>
       </div>
-
-      {/* 刪除確認對話框 */}
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>確認刪除想法</AlertDialogTitle>
-            <AlertDialogDescription>
-              此操作無法復原。確定要刪除這個想法嗎?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>取消</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700"
-            >
-              {isDeleting ? '刪除中...' : '確認刪除'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 }

--- a/widgets/idea-detail/ui/IdeaHeader.tsx
+++ b/widgets/idea-detail/ui/IdeaHeader.tsx
@@ -1,28 +1,69 @@
-import { ArrowLeft } from 'lucide-react';
-import { Button } from '@/shared/ui/button';
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Edit, Trash2, MoreVertical } from 'lucide-react';
 import { Image } from '@/shared/ui/image';
 import { ROLE } from '@/constants/member';
 import DefaultAvatar from '@/public/assets/icons/default-avatar.svg';
+import { Button } from '@/shared/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/alert-dialog';
+import { useSession } from '@/entities/session';
+import { useIdeaActions } from '@/features/ideas/hooks';
 import type { IdeaSchema } from '@/services/ideas';
 
 interface IdeaHeaderProps {
   idea: IdeaSchema;
-  onBack: () => void;
+  onEdit?: () => void;
 }
 
-export function IdeaHeader({ idea, onBack }: IdeaHeaderProps) {
+export function IdeaHeader({ idea, onEdit }: IdeaHeaderProps) {
+  const router = useRouter();
+  const { user } = useSession();
+  const { deleteIdea, isDeleting } = useIdeaActions();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  // 檢查是否為想法的作者
+  const isOwner = user?.id === idea.user?.id || user?.id === idea.user?._id;
+
+  const handleEdit = () => {
+    if (onEdit) {
+      onEdit();
+    } else {
+      router.push(`/ideas/${idea.id}/edit`);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteIdea(idea.id);
+      setShowDeleteDialog(false);
+      toast.success('想法已刪除');
+      router.push('/explore');
+    } catch (error) {
+      console.error('刪除想法失敗:', error);
+      toast.error('刪除失敗，請稍後再試');
+    }
+  };
+
   return (
     <>
-      {/* 返回按鈕 */}
-      <Button
-        variant="ghost"
-        onClick={onBack}
-        className="mb-4 text-basic-500 hover:text-primary-base px-0"
-      >
-        <ArrowLeft className="h-4 w-4 mr-2" />
-        返回
-      </Button>
-
       {/* 想法內容 */}
       <div className="space-y-6">
         <header>
@@ -63,10 +104,60 @@ export function IdeaHeader({ idea, onBack }: IdeaHeaderProps) {
               <span className="text-sm text-[#92989A] text-center sm:text-left">
                 {new Date(idea.createdAt).toLocaleDateString('zh-TW')}
               </span>
+
+              {/* 編輯/刪除選單 - 只有作者可見 */}
+              {isOwner && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0 text-basic-400 hover:text-basic-600"
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-40">
+                    <DropdownMenuItem onClick={handleEdit}>
+                      <Edit className="mr-2 h-4 w-4" />
+                      編輯
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setShowDeleteDialog(true)}
+                      className="text-red-600 focus:text-red-600"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      刪除
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           </div>
         </header>
       </div>
+
+      {/* 刪除確認對話框 */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認刪除想法</AlertDialogTitle>
+            <AlertDialogDescription>
+              此操作無法復原。確定要刪除這個想法嗎?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {isDeleting ? '刪除中...' : '確認刪除'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }


### PR DESCRIPTION
  ## Why is this necessary?
  - Users need the ability to edit and delete their own ideas after creation
  - Comment visibility toggle is not needed for idea comments (ideas are public)
  - Idea content character limit should be reduced from 5000 to 1000 for better UX
  - Navigation and layout need refinement for better user experience
  - Back button default label "返回" is redundant with the icon

  ## How does it address?
  - Add edit/delete menu to IdeaCard with ownership check:
    * Show dropdown menu with Edit/Delete options for idea owners only
    * Add delete confirmation dialog with AlertDialog component
    * Implement handleEdit to navigate to edit mode via URL params
    * Integrate useIdeaActions hook for delete functionality
  - Implement edit mode in IdeaDetailWidget:
    * Add URL param-based edit mode (?edit=true) that auto-triggers editing
    * Create edit interface in IdeaContent with inline editing UI
    * Support editing content, tags, and resources with live preview
    * Add save/cancel buttons with proper state management
    * Refresh data after successful update using SWR mutate
  - Improve Comment components for ideas context:
    * Add hideVisibilityToggle prop to hide public/private toggle in CommentCard
    * Add hideCommentCount prop to hide comment count in CommentSection
    * Pass hideVisibilityToggle through all comment-related components
    * Update CommentInput styling for better visual consistency
  - Update IdeaForm character limit from 5000 to 1000 characters
  - Refine BackButton component:
    * Remove default "返回" label (make label optional)
    * Increase icon size from size-4 to size-7 for better visibility
  - Improve IdeaCard display:
    * Show only first role instead of all roles joined with "|"
    * Add whitespace-pre-wrap to preserve line breaks in content
    * Fix dropdown menu click event propagation
