### PR TITLE
feat(practice): add ownership validation and improve check-in UX

### DIFF
--- a/app/[language]/(protected)/(default-layout)/practice/[practiceId]/edit/page.tsx
+++ b/app/[language]/(protected)/(default-layout)/practice/[practiceId]/edit/page.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { usePractice } from '@/services/practice/hooks';
+import { useSession } from '@/entities/session/model/context';
 import { practiceAPI } from '@/services/practice/api';
 import { Practice, UpdatePracticeInput } from '@/services/practice/schema';
 import EditForm from '@/features/practice/components/Edit/EditForm';
@@ -14,6 +15,7 @@ const PracticeEditPage = () => {
   const router = useRouter();
   const params = useParams();
   const practiceId = params?.practiceId as string;
+  const { user } = useSession();
 
   const { practice, isLoading, error, mutate } = usePractice(practiceId || null);
   const [formData, setFormData] = useState<Partial<Practice>>({});
@@ -101,6 +103,24 @@ const PracticeEditPage = () => {
           <Button onClick={() => router.push('/explore')} variant="outline">
             <ArrowLeft className="h-4 w-4 mr-2" />
             返回探索頁面
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Check if current user is the owner
+  const isOwner = user?.id && practice.user?.id === user.id;
+
+  if (!isOwner) {
+    return (
+      <div className="min-h-screen bg-basic-white pt-20 flex items-center justify-center">
+        <div className="bg-white rounded-lg border border-basic-200 shadow-sm p-6 w-full max-w-2xl text-center">
+          <h1 className="text-xl font-bold mb-4 text-basic-600">無權限編輯</h1>
+          <p className="text-base text-basic-400 mb-4">只有主題實踐的創建者才能進行編輯</p>
+          <Button onClick={() => router.push(`/practice/${practiceId}`)} variant="outline">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            返回主題實踐
           </Button>
         </div>
       </div>

--- a/app/[language]/(protected)/(default-layout)/practice/[practiceId]/page.tsx
+++ b/app/[language]/(protected)/(default-layout)/practice/[practiceId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { usePractice } from '@/services/practice/hooks';
+import { useSession } from '@/entities/session/model/context';
 import DashboardFlow from '@/features/practice/components/Dashboard/DashboardFlow';
 import { Button } from '@/shared/ui/button';
 import { ArrowLeft } from 'lucide-react';
@@ -10,8 +11,9 @@ const PracticeDetailPage = () => {
   const router = useRouter();
   const params = useParams();
   const practiceId = params?.practiceId as string;
+  const { user } = useSession();
 
-  const { practice, isLoading, error } = usePractice(practiceId || null);
+  const { practice, isLoading, error, mutate } = usePractice(practiceId || null);
 
   if (!practiceId) {
     return null;
@@ -43,7 +45,9 @@ const PracticeDetailPage = () => {
   return (
     <DashboardFlow
       practice={practice}
-      onBack={() => router.push('/explore')}
+      currentUserId={user?.id}
+      onBack={() => router.back()}
+      onDataUpdate={() => mutate()}
     />
   );
 };

--- a/app/[language]/Providers.tsx
+++ b/app/[language]/Providers.tsx
@@ -41,7 +41,15 @@ function Providers({ children, locale }: ProvidersProps) {
               <PromotionProvider>
                 <ThemeProvider attribute="class">
                   {children}
-                  <Toaster />
+                  <Toaster
+                    position="top-center"
+                    expand
+                    toastOptions={{
+                      style: {
+                        marginTop: '80px', // 避免被 header 遮擋
+                      },
+                    }}
+                  />
                   <LoginModal />
                 </ThemeProvider>
               </PromotionProvider>

--- a/features/practice/components/Dashboard/CheckInView.tsx
+++ b/features/practice/components/Dashboard/CheckInView.tsx
@@ -1,29 +1,36 @@
 import React, { useState } from 'react';
 import {
-  ArrowLeft, CheckCircle, Heart, Frown, Minus as Meh, Smile, Star, Plus, X,
+  CheckCircle, Heart, Frown, Minus as Meh, Smile, Star, Plus, X,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Practice, MoodType, CheckInInput } from '@/services/practice/schema';
 import { CheckInService } from '@/features/practice';
 import { usePracticeManager } from '@/features/practice/hooks';
 import { useScrollToTop } from '@/features/practice/hooks/useScrollToTop';
 import { Button } from '@/shared/ui/button';
+import { BackButton } from '@/shared/ui/back-button';
 import { Input } from '@/shared/ui/input';
 import { Textarea } from '@/shared/ui/textarea';
 import { Label } from '@/shared/ui/label';
 
 interface CheckInViewProps {
   practice: Practice;
+  currentUserId?: string;
   onBack: () => void;
   onSuccess?: () => void;
 }
 
 const CheckInView: React.FC<CheckInViewProps> = ({
   practice,
+  currentUserId,
   onBack,
   onSuccess,
 }) => {
   const { checkIn } = usePracticeManager();
   const { scrollToTop } = useScrollToTop();
+
+  // Check if current user is the owner of this practice
+  const isOwner = currentUserId && practice.user?.id === currentUserId;
 
   const [progress, setProgress] = useState<number>(1);
   const [note, setNote] = useState<string>('');
@@ -31,27 +38,51 @@ const CheckInView: React.FC<CheckInViewProps> = ({
   const [tags, setTags] = useState<string[]>([]);
   const [newTag, setNewTag] = useState<string>('');
   const [submitting, setSubmitting] = useState<boolean>(false);
-  const [errors, setErrors] = useState<string[]>([]);
 
   // 檢查是否可以打卡
   const canCheckIn = !CheckInService.hasCheckedInToday(practice);
 
+  // If not the owner, show an error message
+  if (!isOwner) {
+    return (
+      <div className="min-h-screen bg-primary-palest pt-24">
+        <div className="mx-auto max-w-md px-4 py-8">
+          {/* 返回按鈕 */}
+          <BackButton
+            onClick={() => onBack()}
+            className="mb-6 text-basic-500 hover:text-basic-black"
+          />
+
+          <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-md">
+            <div className="p-6 text-center">
+              <CheckCircle className="mx-auto mb-4 size-16 text-alert" />
+              <h3 className="heading-md mb-2 text-basic-black">無權限打卡</h3>
+              <p className="text-basic-600 body-md mb-4">
+                只有主題實踐的創建者才能進行打卡。
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // 心情選項
   const moodOptions = [
     {
-      value: 'excellent' as MoodType, label: '優秀', icon: Star, color: '#10b981',
+      value: 'awesome' as MoodType, label: '超棒', icon: Star, color: '#10b981',
     },
     {
-      value: 'good' as MoodType, label: '良好', icon: Smile, color: '#06b6d4',
+      value: 'happy' as MoodType, label: '開心', icon: Smile, color: '#06b6d4',
     },
     {
-      value: 'average' as MoodType, label: '普通', icon: Meh, color: '#6b7280',
+      value: 'neutral' as MoodType, label: '普通', icon: Meh, color: '#6b7280',
     },
     {
-      value: 'challenging' as MoodType, label: '有挑戰', icon: Heart, color: '#f59e0b',
+      value: 'tired' as MoodType, label: '疲累', icon: Heart, color: '#f59e0b',
     },
     {
-      value: 'difficult' as MoodType, label: '困難', icon: Frown, color: '#ef4444',
+      value: 'frustrated' as MoodType, label: '受挫', icon: Frown, color: '#ef4444',
     },
   ];
 
@@ -84,32 +115,40 @@ const CheckInView: React.FC<CheckInViewProps> = ({
   // 處理打卡提交
   const handleSubmit = async () => {
     if (!canCheckIn) {
-      setErrors(['今天已經打卡過了']);
+      toast.error('今天已經打卡過了', {
+        duration: 5000,
+        position: 'top-center',
+      });
       return;
     }
 
     const checkInInput: CheckInInput = {
-      practiceId: practice.id,
       progress,
       note: note.trim(),
       mood,
-      tags: tags.filter((tag) => tag.trim()),
     };
 
     // 驗證輸入
     const validation = CheckInService.validateCheckInInput(practice, checkInInput);
     if (!validation.isValid) {
-      setErrors(validation.errors);
+      validation.errors.forEach((error) => toast.error(error, {
+        duration: 5000,
+        position: 'top-center',
+      }));
       return;
     }
 
     setSubmitting(true);
-    setErrors([]);
 
     try {
-      await checkIn(checkInInput);
+      await checkIn(practice.id, checkInInput);
 
       // 打卡成功，顯示成功訊息
+      toast.success('打卡成功！', {
+        duration: 3000,
+        position: 'top-center',
+      });
+
       if (onSuccess) {
         // 滾動到頂部
         scrollToTop('smooth');
@@ -120,7 +159,12 @@ const CheckInView: React.FC<CheckInViewProps> = ({
         onBack();
       }
     } catch (error) {
-      setErrors([error instanceof Error ? error.message : '打卡失敗']);
+      // Display the backend error message using toast
+      const errorMessage = error instanceof Error ? error.message : '打卡失敗，請稍後再試';
+      toast.error(errorMessage, {
+        duration: 5000, // 顯示 5 秒
+        position: 'top-center', // 顯示在頂部中間
+      });
     } finally {
       setSubmitting(false);
     }
@@ -131,17 +175,14 @@ const CheckInView: React.FC<CheckInViewProps> = ({
     const todayCheckIn = CheckInService.getTodayCheckIn(practice);
 
     return (
-      <div className="mx-auto max-w-md p-4">
-        <Button
-          variant="ghost"
-          onClick={onBack}
-          className="text-basic-600 hover:text-basic-800 mb-4 flex items-center transition-colors"
-        >
-          <ArrowLeft className="mr-2 size-4" />
-          <span>返回儀表板</span>
-        </Button>
-
-        <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-md">
+      <div className="min-h-screen bg-primary-palest pt-24">
+        <div className="mx-auto max-w-md px-4 py-8">
+          {/* 返回按鈕 */}
+          <BackButton
+            onClick={() => onBack()}
+            className="mb-6 text-basic-500 hover:text-basic-black"
+          />
+          <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-md">
           <div className="p-6 text-center">
             <CheckCircle className="mx-auto mb-4 size-16 text-success" />
             <h3 className="heading-md mb-2 text-basic-black">今日已打卡</h3>
@@ -154,18 +195,10 @@ const CheckInView: React.FC<CheckInViewProps> = ({
                 <h4 className="text-basic-700 body-sm mb-2 font-medium">今日打卡記錄</h4>
                 <div className="text-basic-600 body-sm space-y-2">
                   <div>
-                    進度：+
-                    {todayCheckIn.progress}
-                    {' '}
-                    {practice.unit}
+                    進度：+{todayCheckIn.progress} {practice.unit || '分鐘'}
                   </div>
                   <div>
-                    總進度：
-                    {todayCheckIn.totalProgress}
-                    /
-                    {practice.totalAmount}
-                    {' '}
-                    {practice.unit}
+                    總進度：{todayCheckIn.totalProgress}/{practice.totalAmount} {practice.unit || '分鐘'}
                   </div>
                   {todayCheckIn.note && (
                   <div>
@@ -191,23 +224,21 @@ const CheckInView: React.FC<CheckInViewProps> = ({
               </div>
             )}
           </div>
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="mx-auto max-w-md p-4">
-      <Button
-        variant="ghost"
-        onClick={onBack}
-        className="text-basic-600 hover:text-basic-800 mb-4 flex items-center transition-colors"
-      >
-        <ArrowLeft className="mr-2 size-4" />
-        <span>返回儀表板</span>
-      </Button>
-
-      <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-md">
+    <div className="min-h-screen bg-primary-palest pt-24">
+      <div className="mx-auto max-w-md px-4 py-8">
+        {/* 返回按鈕 */}
+        <BackButton
+          onClick={() => onBack()}
+          className="mb-6 text-basic-500 hover:text-basic-black"
+        />
+        <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-md">
         {/* 標題 */}
         <div className="border-b border-basic-200 p-6">
           <h3 className="heading-lg text-basic-black">
@@ -215,20 +246,6 @@ const CheckInView: React.FC<CheckInViewProps> = ({
             打卡
           </h3>
         </div>
-
-        {/* 錯誤訊息 */}
-        {errors.length > 0 && (
-          <div className="bg-alert-lighter border-l-4 border-alert p-4">
-            <ul className="text-alert-darker body-sm">
-              {errors.map((error) => (
-                <li key={error}>
-                  •
-                  {error}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
 
         <div className="space-y-6 p-6">
 
@@ -248,10 +265,10 @@ const CheckInView: React.FC<CheckInViewProps> = ({
                   onChange={(e) => setProgress(Math.max(1, parseInt(e.target.value, 10) || 1))}
                   min="1"
                   max={practice.totalAmount - practice.currentProgress}
-                  className="w-full"
+                  className="w-full pr-16"
                 />
-                <span className="body-sm absolute right-3 top-2 text-basic-500">
-                  {practice.unit}
+                <span className="body-sm absolute right-3 top-1/2 -translate-y-1/2 text-basic-500 pointer-events-none">
+                  {practice.unit || '分鐘'}
                 </span>
               </div>
             </div>
@@ -303,11 +320,11 @@ const CheckInView: React.FC<CheckInViewProps> = ({
                     <div className="flex items-center justify-center gap-1">
                       {React.createElement(option.icon, {
                         className: `h-4 w-4 ${
-                          option.value === 'excellent' ? 'text-green-500'
-                            : option.value === 'good' ? 'text-cyan-500'
-                              : option.value === 'average' ? 'text-gray-500'
-                                : option.value === 'challenging' ? 'text-amber-500'
-                                  : option.value === 'difficult' ? 'text-red-500' : 'text-gray-400'
+                          option.value === 'awesome' ? 'text-green-500'
+                            : option.value === 'happy' ? 'text-cyan-500'
+                              : option.value === 'neutral' ? 'text-gray-500'
+                                : option.value === 'tired' ? 'text-amber-500'
+                                  : option.value === 'frustrated' ? 'text-red-500' : 'text-gray-400'
                         }`,
                       })}
                       <span className="text-basic-700 text-xs">{option.label}</span>
@@ -431,6 +448,7 @@ const CheckInView: React.FC<CheckInViewProps> = ({
               </>
             )}
           </Button>
+        </div>
         </div>
       </div>
     </div>

--- a/features/practice/components/Dashboard/DashboardFlow.tsx
+++ b/features/practice/components/Dashboard/DashboardFlow.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
+import { useSearchParams } from 'next/navigation';
 import { Practice } from '@/services/practice/schema';
 import { DashboardView } from '@/features/practice';
 import MainDashboard from '@/features/practice/components/Dashboard/MainDashboard';
@@ -11,20 +12,41 @@ import { useScrollToTop } from '@/features/practice/hooks/useScrollToTop';
 
 interface DashboardFlowProps {
   practice: Practice;
+  currentUserId?: string;
   onBack: () => void;
+  onDataUpdate?: () => void;
 }
 
 const DashboardFlow: React.FC<DashboardFlowProps> = ({
   practice,
+  currentUserId,
   onBack,
+  onDataUpdate,
 }) => {
+  const searchParams = useSearchParams();
   const [currentView, setCurrentView] = useState<DashboardView>('main');
   const [showConfetti, setShowConfetti] = useState(false);
   const [celebrationMessage, setCelebrationMessage] = useState('');
   const { scrollToTop } = useScrollToTop();
 
+  // 檢查 URL 參數，自動切換到指定視圖
+  useEffect(() => {
+    if (!searchParams) return;
+    const view = searchParams.get('view');
+    if (view === 'checkin') {
+      setCurrentView('checkin');
+    } else if (view === 'history') {
+      setCurrentView('history');
+    }
+  }, [searchParams]);
+
   // 處理打卡成功
   const handleCheckInSuccess = () => {
+    // 重新獲取最新的實踐數據
+    if (onDataUpdate) {
+      onDataUpdate();
+    }
+
     // 顯示慶祝動畫
     setShowConfetti(true);
     setCelebrationMessage('打卡成功！繼續保持學習的好習慣！');
@@ -94,6 +116,7 @@ const DashboardFlow: React.FC<DashboardFlowProps> = ({
         {currentView === 'main' && (
           <MainDashboard
             practice={practice}
+            currentUserId={currentUserId}
             onCheckIn={() => handleViewChange('checkin')}
             onBack={onBack}
           />
@@ -102,6 +125,7 @@ const DashboardFlow: React.FC<DashboardFlowProps> = ({
         {currentView === 'checkin' && (
           <CheckInView
             practice={practice}
+            currentUserId={currentUserId}
             onBack={() => handleViewChange('main')}
             onSuccess={handleCheckInSuccess}
           />

--- a/features/practice/components/Dashboard/HistoryView.tsx
+++ b/features/practice/components/Dashboard/HistoryView.tsx
@@ -20,18 +20,17 @@ const HistoryView: React.FC<HistoryViewProps> = ({
   const stats = CheckInService.getCheckInStats(practice);
 
   return (
-    <div className="min-h-screen bg-primary-palest">
-      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-        {/* 返回按鈕 */}
-        <Button
-          variant="ghost"
-          onClick={onBack}
-          className="text-basic-600 hover:text-basic-800 mb-6 flex items-center transition-colors"
-        >
-          <ArrowLeft className="mr-2 size-4" />
-          <span>返回儀表板</span>
-        </Button>
+    <div className="min-h-screen bg-primary-palest pt-16">
+      {/* 返回按鈕 - 固定在左上角 */}
+      <Button
+        variant="ghost"
+        onClick={onBack}
+        className="fixed left-4 top-20 z-10 flex size-10 items-center justify-center rounded-full bg-white p-0 shadow-sm hover:bg-basic-50 sm:left-6"
+      >
+        <ArrowLeft className="size-5 text-basic-600" />
+      </Button>
 
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         {/* 標題區域 */}
         <div className="mb-8">
           <h1 className="heading-xl mb-2 text-basic-black">簽到歷史</h1>
@@ -136,21 +135,11 @@ const HistoryView: React.FC<HistoryViewProps> = ({
                         <div className="text-basic-700 body-md mb-1">
                           學習進度：
                           <span className="font-medium">
-                            +
-                            {entry.progress}
-                            {' '}
-                            {practice.unit}
+                            +{entry.progress} {practice.unit || '分鐘'}
                           </span>
                         </div>
                         <div className="body-sm text-basic-500">
-                          累計進度：
-                          {entry.totalProgress}
-                          {' '}
-                          /
-                          {' '}
-                          {practice.totalAmount}
-                          {' '}
-                          {practice.unit}
+                          累計進度：{entry.totalProgress} / {practice.totalAmount} {practice.unit || '分鐘'}
                         </div>
                       </div>
 

--- a/features/practice/components/Dashboard/MainDashboard.tsx
+++ b/features/practice/components/Dashboard/MainDashboard.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/navigation';
 import {
   CheckCircle,
   Edit,
-  ArrowLeft,
   Plus,
   Flame,
   Book,
@@ -20,23 +19,31 @@ import { CheckInService } from '@/services/practice/checkIn';
 import { useScrollToTop } from '@/features/practice/hooks/useScrollToTop';
 import { formatSmartDate, formatDate } from '@/services/practice/utils';
 import { Button } from '@/shared/ui/button';
+import { BackButton } from '@/shared/ui/back-button';
 import { CustomLink } from '@/shared/ui/custom-link';
 import { Progress } from '@/shared/ui/progress';
+import CommentSection from '@/shared/components/Comment/CommentSection';
+import { CommentType } from '@/services/comments';
 import TagList from '../Shared/TagList';
 
 interface MainDashboardProps {
   practice: Practice;
+  currentUserId?: string;
   onCheckIn: () => void;
   onBack: () => void;
 }
 
 const MainDashboard: React.FC<MainDashboardProps> = ({
   practice,
+  currentUserId,
   onCheckIn,
   onBack,
 }) => {
   const router = useRouter();
   const { scrollToTop } = useScrollToTop();
+
+  // Check if current user is the owner of this practice
+  const isOwner = currentUserId && practice.user?.id === currentUserId;
 
   // 顯示 Toast 通知
   const showToastNotification = (message: string) => {
@@ -112,7 +119,7 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
       case 'paused':
         return 'bg-warning text-warning-darker';
       case 'active':
-        return 'bg-primary-base text-white';
+        return 'bg-yellow-100 text-yellow-700';
       default:
         return 'bg-basic-200 text-basic-600';
     }
@@ -129,17 +136,12 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
     <div className="min-h-screen bg-primary-palest pt-24">
       <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
         {/* 返回按鈕 */}
-        <Button
-          variant="ghost"
+        <BackButton
           onClick={onBack}
-          className="mb-6 flex items-center text-basic-500 hover:text-basic-black"
-        >
-          <ArrowLeft className="mr-2 size-4" />
-          <span>返回</span>
-        </Button>
-
+          className="mb-6 text-basic-500 hover:text-basic-black"
+        />
         {/* 主要內容 */}
-        <div className="overflow-hidden rounded-lg bg-basic-white shadow-sm">
+        <div className="overflow-hidden rounded-2xl bg-basic-white">
           {/* 標題區域 */}
           <div className="p-6">
             <div className="flex items-start justify-between">
@@ -148,7 +150,7 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
                   <h1 className="text-2xl font-bold text-basic-black">
                     {practice.title}
                   </h1>
-                  <span className={`rounded-full px-3 py-1 text-xs font-medium ${getStatusColor()}`}>
+                  <span className={`rounded-full px-3 py-1 text-xs font-medium whitespace-nowrap ${getStatusColor()}`}>
                     {practice.status === 'active' ? '進行中'
                       : practice.status === 'completed' ? '已完成'
                         : practice.status === 'paused' ? '暫停' : '草稿'}
@@ -187,15 +189,17 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
                 )}
               </div>
 
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleEdit}
-                className="rounded-lg p-2 text-basic-500 hover:text-basic-black"
-                title="編輯實踐"
-              >
-                <Edit className="size-5" />
-              </Button>
+              {isOwner && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleEdit}
+                  className="rounded-lg p-2 text-basic-500 hover:text-basic-black"
+                  title="編輯實踐"
+                >
+                  <Edit className="size-5" />
+                </Button>
+              )}
             </div>
           </div>
 
@@ -263,54 +267,56 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
             </div>
           )}
 
-          {/* 打卡區域 */}
-          <div className="p-6">
-            <div className="space-y-6">
-              {/* 打卡 */}
-              <div className="rounded-lg bg-gradient-to-r from-primary/10 to-blue-50 p-4">
-                <h3 className="mb-3 text-lg font-semibold text-basic-black">打卡</h3>
-                {canCheckIn ? (
-                  <div className="space-y-3">
-                    <p className="text-sm text-basic-500">
-                      準備好記錄今天的學習進度了嗎？
-                    </p>
-                    <Button
-                      onClick={onCheckIn}
-                      className="flex items-center justify-center space-x-2"
-                    >
-                      <Plus className="size-4" />
-                      <span>開始打卡</span>
-                    </Button>
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="flex items-center space-x-2">
-                      <div className="flex size-8 items-center justify-center rounded-full bg-success">
-                        <CheckCircle className="size-5 text-white" />
-                      </div>
-                      <div>
-                        <p className="text-sm font-medium text-green-600">今日已打卡</p>
-                        {todayCheckIn && (
-                          <p className="text-xs text-basic-500">
-                            進度：+
-                            {todayCheckIn.progress}
-                            {' '}
-                            {practice.unit}
-                          </p>
-                        )}
-                      </div>
+          {/* 打卡區域 - 只有主題擁有者可以看到 */}
+          {isOwner && (
+            <div className="p-6">
+              <div className="space-y-6">
+                {/* 打卡 */}
+                <div className="rounded-lg bg-gradient-to-r from-primary/10 to-blue-50 p-4">
+                  <h3 className="mb-3 text-lg font-semibold text-basic-black">打卡</h3>
+                  {canCheckIn ? (
+                    <div className="space-y-3">
+                      <p className="text-sm text-basic-500">
+                        準備好記錄今天的學習進度了嗎？
+                      </p>
+                      <Button
+                        onClick={() => {
+                          console.log('打卡按鈕被點擊');
+                          onCheckIn();
+                        }}
+                        className="flex items-center justify-center space-x-2"
+                        type="button"
+                      >
+                        <Plus className="size-4" />
+                        <span>開始打卡</span>
+                      </Button>
                     </div>
-                    <Button
-                      disabled
-                      variant="secondary"
-                      className="flex cursor-not-allowed items-center justify-center space-x-2"
-                    >
-                      <CheckCircle className="size-4" />
-                      <span>已完成打卡</span>
-                    </Button>
-                  </div>
-                )}
-              </div>
+                  ) : (
+                    <div className="space-y-3">
+                      <div className="flex items-center space-x-2">
+                        <div className="flex size-8 items-center justify-center rounded-full bg-success">
+                          <CheckCircle className="size-5 text-white" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-green-600">今日已打卡</p>
+                          {todayCheckIn && (
+                            <p className="text-xs text-basic-500">
+                              進度：+{todayCheckIn.progress}{practice.unit ? ` ${practice.unit}` : ' 天'}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        disabled
+                        variant="secondary"
+                        className="flex cursor-not-allowed items-center justify-center space-x-2"
+                      >
+                        <CheckCircle className="size-4" />
+                        <span>已完成打卡</span>
+                      </Button>
+                    </div>
+                  )}
+                </div>
 
               {/* 打卡記錄 */}
               <div className="rounded-lg border border-basic-200 bg-basic-white p-4">
@@ -327,34 +333,29 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
                     {practice.checkIns.map((checkIn, index) => (
                       <div
                         key={checkIn.id || index}
-                        className="flex items-center space-x-3 border-b border-basic-200 py-3 last:border-b-0"
+                        className="border-b border-basic-200 py-3 last:border-b-0"
                       >
-                        <div className="size-2 shrink-0 rounded-full bg-primary" />
-                        <div className="flex-1">
-                          <p className="text-sm text-basic-black">
-                            我在
-                            {' '}
-                            <span className="font-medium text-green-600">
-                              {formatSmartDate(checkIn.date)}
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center space-x-3">
+                            <div className="size-2 shrink-0 rounded-full bg-primary" />
+                            <span className="text-sm font-medium text-basic-black">
+                              {formatDate(checkIn.date)}
                             </span>
-                            {' '}
-                            實踐
-                            {' '}
-                            <span className="font-medium text-primary">
-                              {practice.title}
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <span className="text-sm font-medium text-primary">
+                              +{checkIn.progress}{practice.unit ? ` ${practice.unit}` : ' 天'}
                             </span>
-                            {' '}
-                            <span className="text-basic-500">
-                              {checkIn.progress}
+                            <span className="text-xs text-basic-400">
+                              (累積 {checkIn.totalProgress}{practice.unit ? ` ${practice.unit}` : ' 天'})
                             </span>
-                            {' '}
-                            <span className="text-basic-500">
-                              (
-                              {practice.unit}
-                              )
-                            </span>
-                          </p>
+                          </div>
                         </div>
+                        {checkIn.note && (
+                          <div className="ml-5 mt-2">
+                            <p className="text-xs text-basic-500">{checkIn.note}</p>
+                          </div>
+                        )}
                       </div>
                     ))}
                   </div>
@@ -366,9 +367,10 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
                     </p>
                   </div>
                 )}
+                </div>
               </div>
             </div>
-          </div>
+          )}
 
           {/* 學習資源區域 */}
           {practice.resources && practice.resources.length > 0 && (
@@ -409,8 +411,16 @@ const MainDashboard: React.FC<MainDashboardProps> = ({
           )}
         </div>
 
+        {/* 留言區域 - 獨立卡片 */}
+        <div className="mt-6 rounded-2xl bg-basic-white p-4 md:p-8 lg:p-10">
+          <CommentSection
+            targetId={practice.id}
+            targetType={CommentType.Practice}
+            hideVisibilityToggle
+            hideCommentCount
+          />
+        </div>
       </div>
-
     </div>
   );
 };

--- a/features/practice/components/List/PracticeCard.tsx
+++ b/features/practice/components/List/PracticeCard.tsx
@@ -32,6 +32,7 @@ import {
 
 interface PracticeCardProps {
   practice: Practice | PracticeWithUser;
+  currentUserId?: string;
   onEdit?: (practice: Practice | PracticeWithUser) => void;
   onDelete?: (practice: Practice | PracticeWithUser) => void;
   onCheckIn?: (practice: Practice | PracticeWithUser) => void;
@@ -40,11 +41,14 @@ interface PracticeCardProps {
 
 const PracticeCard: React.FC<PracticeCardProps> = ({
   practice,
+  currentUserId,
   onEdit,
   onDelete,
   onCheckIn,
   showActions = true,
 }) => {
+  // Check if current user is the owner of this practice
+  const isOwner = currentUserId && practice.user?.id === currentUserId;
 
   const getStatusDisplay = () => {
     const statusMap = {
@@ -60,7 +64,7 @@ const PracticeCard: React.FC<PracticeCardProps> = ({
   const getStatusColor = () => {
     const colorMap = {
       draft: 'bg-basic-100 text-basic-300',
-      active: 'bg-tips/20 text-tips',
+      active: 'bg-yellow-100 text-yellow-700',
       paused: 'bg-orange-100 text-orange-600',
       completed: 'bg-success/20 text-success',
       archived: 'bg-basic-100 text-basic-300',
@@ -94,7 +98,7 @@ const PracticeCard: React.FC<PracticeCardProps> = ({
                 </span>
               </div>
               <div className="text-xs text-basic-300 mt-0.5">
-                {getContentTypeLabel(practice.contentType, practice.customContentType)}
+                {'user' in practice && practice.user?.roleList?.[0] ? practice.user.roleList[0] : '實踐者'}
               </div>
             </div>
           </div>
@@ -120,7 +124,7 @@ const PracticeCard: React.FC<PracticeCardProps> = ({
               </div>
             )}
 
-            {showActions && (
+            {showActions && isOwner && (
               <div className="relative">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -183,6 +187,11 @@ const PracticeCard: React.FC<PracticeCardProps> = ({
           {practice.title}
         </h3>
 
+        {/* 內容類型 - 移到標題底下 */}
+        <div className="mb-3 text-xs text-basic-400">
+          {getContentTypeLabel(practice.contentType, practice.customContentType)}
+        </div>
+
         {/* Tags */}
         {practice.tags && practice.tags.length > 0 && (
           <div className="mb-3 flex flex-wrap gap-1 sm:mb-4 sm:gap-2">
@@ -228,7 +237,7 @@ const PracticeCard: React.FC<PracticeCardProps> = ({
               天
             </span>
           </div>
-          <Badge className={getStatusColor()}>
+          <Badge className={`${getStatusColor()} whitespace-nowrap`}>
             {getStatusDisplay()}
           </Badge>
         </div>

--- a/features/practice/components/List/PracticeExploreSection.tsx
+++ b/features/practice/components/List/PracticeExploreSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useSession } from '@/entities/session/model/context';
 import { CustomLink } from '@/shared/ui/custom-link';
 import {
   Search, Plus, Target, SortAsc, RefreshCw,
@@ -37,6 +38,7 @@ const PracticeExploreSection: React.FC<PracticeExploreSectionProps> = ({
   onCreateClick,
 }) => {
   const router = useRouter();
+  const { user } = useSession();
   // Filter and search state
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'createdAt' | 'updatedAt' | 'progress' | 'streak'>('createdAt');
@@ -88,8 +90,8 @@ const PracticeExploreSection: React.FC<PracticeExploreSectionProps> = ({
   };
 
   const handleCheckIn = (practice: Practice) => {
-    console.log('Check in practice:', practice.id);
-    // Handle check-in operation
+    // Navigate directly to check-in view
+    router.push(`/practice/${practice.id}?view=checkin`);
   };
 
   // const handleJoin = (practice: Practice) => {
@@ -160,7 +162,7 @@ const PracticeExploreSection: React.FC<PracticeExploreSectionProps> = ({
                   className="flex items-center gap-2"
                 >
                   <Plus className="size-4" />
-                  <span className="hidden sm:inline">開始實踐</span>
+                  <span>開始實踐</span>
                 </Button>
               ) : (
                 <CustomLink href="/practice/create">
@@ -169,7 +171,7 @@ const PracticeExploreSection: React.FC<PracticeExploreSectionProps> = ({
                     className="flex items-center gap-2"
                   >
                     <Plus className="size-4" />
-                    <span className="hidden sm:inline">開始實踐</span>
+                    <span>開始實踐</span>
                   </Button>
                 </CustomLink>
               )
@@ -277,6 +279,7 @@ const PracticeExploreSection: React.FC<PracticeExploreSectionProps> = ({
               <PracticeCard
                 key={practice.id}
                 practice={practice}
+                currentUserId={user?.id}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 onCheckIn={handleCheckIn}

--- a/features/practice/components/List/PracticeRecommendationSection.tsx
+++ b/features/practice/components/List/PracticeRecommendationSection.tsx
@@ -57,8 +57,8 @@ const PracticeRecommendationSection: React.FC<PracticeRecommendationSectionProps
   };
 
   const handleCheckIn = (practice: Practice) => {
-    console.log('Check in practice:', practice.id);
-    // Handle check-in operation
+    // Navigate directly to check-in view
+    router.push(`/practice/${practice.id}?view=checkin`);
   };
 
   if (error) {
@@ -205,6 +205,7 @@ const PracticeRecommendationSection: React.FC<PracticeRecommendationSectionProps
           <div key={item.id} className="relative">
             <PracticeCard
               practice={convertToPracticeSchema(item)}
+              currentUserId={user?.id}
               onEdit={handleEdit}
               onDelete={handleDelete}
               onCheckIn={handleCheckIn}

--- a/features/practice/components/Setup/SetupFlow.tsx
+++ b/features/practice/components/Setup/SetupFlow.tsx
@@ -5,6 +5,8 @@ import Confetti from '@/features/practice/components/Shared/Confetti';
 import CelebrationMessage from '@/features/practice/components/Shared/CelebrationMessage';
 import { PathInfo } from '@/services/practice/schema';
 import { useScrollToTop } from '@/features/practice/hooks/useScrollToTop';
+import { Button } from '@/shared/ui/button';
+import { X } from 'lucide-react';
 import Step1 from './Step1';
 import Step2 from './Step2';
 import Step3 from './Step3';
@@ -23,6 +25,7 @@ interface Resource {
 
 const SetupFlow: React.FC<SetupFlowProps> = ({
   onComplete,
+  onCancel,
 }) => {
   const router = useRouter();
   const { createPracticeFromPathInfo } = usePracticeManager();
@@ -103,6 +106,10 @@ const SetupFlow: React.FC<SetupFlowProps> = ({
         errors.totalAmount = '總量必須大於0';
       } else if (totalAmount > 10000) {
         errors.totalAmount = '總量不能超過10000';
+      }
+    } else if (setupStep === 3) {
+      if (resources.length === 0) {
+        errors.resources = '請至少添加一個資源';
       }
     }
 
@@ -278,6 +285,29 @@ const SetupFlow: React.FC<SetupFlowProps> = ({
         />
 
         <div className="overflow-visible rounded-lg border border-basic-200 bg-white shadow-sm">
+          {/* Header */}
+          <div className="flex items-center justify-between bg-primary-base bg-gradient-to-r px-6 py-4">
+            <div className="flex items-center">
+              <div className="flex size-10 items-center justify-center rounded-full border border-white/30 bg-white/20 font-medium text-white">
+                島
+              </div>
+              <div className="ml-3">
+                <div className="text-sm font-medium text-white">建立主題實踐</div>
+                <div className="text-xs text-white/80">步驟 {setupStep}/4</div>
+              </div>
+            </div>
+            {onCancel && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onCancel}
+                className="p-2 text-white hover:bg-white/20"
+              >
+                <X className="size-5" />
+              </Button>
+            )}
+          </div>
+
           {renderStepContent()}
         </div>
       </div>

--- a/features/practice/components/Setup/Step1.tsx
+++ b/features/practice/components/Setup/Step1.tsx
@@ -45,7 +45,7 @@ const Step1: React.FC<Step1Props> = ({
   selectedTags,
   setSelectedTags,
 }) => (
-  <div className="overflow-visible rounded-lg border border-basic-200 bg-white shadow-sm">
+  <div>
     <div className="p-6">
       <div className="mb-2 flex items-center">
         <div className="mr-2 size-2 rounded-full bg-primary-base" />

--- a/features/practice/components/Setup/Step2.tsx
+++ b/features/practice/components/Setup/Step2.tsx
@@ -70,7 +70,7 @@ const StepTwo: React.FC<StepTwoProps> = ({
   };
 
   return (
-    <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-sm">
+    <div>
       {/* Header */}
       <div className="p-6">
         <div className="mb-4 flex items-center">

--- a/features/practice/components/Setup/Step3.tsx
+++ b/features/practice/components/Setup/Step3.tsx
@@ -95,7 +95,7 @@ const Step3: React.FC<Step3Props> = ({
     }
   };
   return (
-    <div className="overflow-hidden rounded-lg border border-basic-200 bg-white shadow-sm">
+    <div>
       <div className="p-6">
         <div className="mb-2 flex items-center">
           <div className="mr-2 size-2 rounded-full bg-primary-base" />
@@ -261,6 +261,15 @@ const Step3: React.FC<Step3Props> = ({
               你的資源分享將能幫助有相同興趣的島友們
             </p>
           </div>
+
+          {validationErrors.resources && (
+            <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4">
+              <div className="flex items-center justify-center text-sm text-destructive">
+                <AlertCircle className="mr-2 size-4" />
+                <span>{validationErrors.resources}</span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/features/practice/components/Setup/Step4.tsx
+++ b/features/practice/components/Setup/Step4.tsx
@@ -61,7 +61,7 @@ const StepFivePreview: React.FC<StepFivePreviewProps> = ({
   };
 
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-md">
+    <div>
       <div className="p-4">
         <div className="mb-2 flex items-center">
           <div className="mr-2 size-2 rounded-full bg-primary-base" />

--- a/features/practice/hooks/usePracticeUpdater.ts
+++ b/features/practice/hooks/usePracticeUpdater.ts
@@ -20,7 +20,7 @@ export function usePracticeUpdater(practiceId: string | undefined) {
 
   const checkIn = async (input: CheckInInput) => {
     if (!practiceId) return undefined;
-    const result = await practiceAPI.checkIn(input);
+    const result = await practiceAPI.checkIn(practiceId, input);
     invalidateAllCaches(practiceId);
     return result;
   };

--- a/features/practice/hooks/usePractices.ts
+++ b/features/practice/hooks/usePractices.ts
@@ -37,9 +37,9 @@ export function usePractices() {
   };
 
   // 簽到
-  const checkIn = async (input: CheckInInput) => {
-    const result = await practiceAPI.checkIn(input);
-    invalidateAllCaches(input.practiceId);
+  const checkIn = async (practiceId: string, input: CheckInInput) => {
+    const result = await practiceAPI.checkIn(practiceId, input);
+    invalidateAllCaches(practiceId);
     return result;
   };
 

--- a/services/comments/schema.ts
+++ b/services/comments/schema.ts
@@ -8,6 +8,7 @@ export enum CommentType {
   Idea = 'idea',
   Resource = 'resource',
   ResourceReview = 'resource-review',
+  Practice = 'practice',
 }
 
 export enum CommentVisibility {

--- a/services/practice/api.ts
+++ b/services/practice/api.ts
@@ -98,7 +98,40 @@ class PracticeAPIClass {
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        // Try to extract error message from response body
+        let errorMessage = `HTTP error! status: ${response.status}`;
+
+        try {
+          const contentType = response.headers.get('content-type');
+          if (contentType && contentType.includes('application/json')) {
+            const errorData = await response.json();
+            // Check for common error message formats from backend
+            if (errorData.message) {
+              errorMessage = errorData.message;
+            } else if (errorData.error?.message) {
+              errorMessage = errorData.error.message;
+            } else if (errorData.error && typeof errorData.error === 'string') {
+              errorMessage = errorData.error;
+            } else if (errorData.msg) {
+              errorMessage = errorData.msg;
+            } else if (errorData.detail) {
+              errorMessage = errorData.detail;
+            }
+
+            // Handle 409 Conflict specifically for duplicate check-in
+            if (response.status === 409 && errorMessage.includes('HTTP error')) {
+              errorMessage = '今日已完成簽到';
+            }
+          }
+        } catch (e) {
+          // If response body is not JSON or parsing fails
+          // Use default error message or status-specific message
+          if (response.status === 409) {
+            errorMessage = '今日已完成簽到';
+          }
+        }
+
+        throw new Error(errorMessage);
       }
 
       const data = await response.json();
@@ -141,7 +174,8 @@ class PracticeAPIClass {
    */
   read = async (id: string): Promise<Practice> => {
     const result = await this.request<unknown>(`${PRACTICE_BASE_PATH}/${id}`);
-    return (result as { data?: Practice }).data || (result as Practice);
+    const practice = (result as { data?: Practice }).data || (result as Practice);
+    return practice;
   };
 
   /**
@@ -178,11 +212,59 @@ class PracticeAPIClass {
   };
 
   /**
+   * 獲取打卡記錄列表（支持分頁獲取所有記錄）
+   */
+  getCheckIns = async (practiceId: string): Promise<CheckInRecord[]> => {
+    const allCheckIns: CheckInRecord[] = [];
+    let page = 1;
+    const limit = 100; // 後端最大限制為 100
+    let hasMore = true;
+
+    while (hasMore) {
+      const result = await this.request<any>(`${PRACTICE_BASE_PATH}/${practiceId}/checkins?page=${page}&limit=${limit}`);
+
+      // 處理不同的響應格式
+      let data = (result as { data?: any[] }).data || (result as { items?: any[] }).items || [];
+
+      // 如果 data 仍然是包裝對象，嘗試提取內部的數組
+      if (data && typeof data === 'object' && 'items' in data) {
+        data = (data as any).items || [];
+      }
+
+      // 映射後端字段到前端 schema
+      const mappedData: CheckInRecord[] = data.map((item: any) => ({
+        id: String(item.id),
+        practiceId: String(item.practiceId),
+        date: item.checkInDate, // 後端: checkInDate -> 前端: date
+        progress: item.progressAmount || 0, // 後端: progressAmount -> 前端: progress
+        totalProgress: item.cumulativeProgress || 0, // 後端: cumulativeProgress -> 前端: totalProgress
+        note: item.note || '',
+        mood: item.mood,
+        tags: item.tags || [],
+        createdAt: item.createdAt,
+      }));
+
+      if (mappedData.length > 0) {
+        allCheckIns.push(...mappedData);
+      }
+
+      // 檢查是否還有更多數據
+      if (data.length < limit) {
+        hasMore = false;
+      } else {
+        page += 1;
+      }
+    }
+
+    return allCheckIns;
+  };
+
+  /**
    * 簽到
    */
-  checkIn = async (input: CheckInInput): Promise<CheckInRecord> => {
+  checkIn = async (practiceId: string, input: CheckInInput): Promise<CheckInRecord> => {
     const validatedInput = checkInInputSchema.parse(input);
-    const result = await this.request<any>(`${PRACTICE_BASE_PATH}/checkin`, {
+    const result = await this.request<any>(`${PRACTICE_BASE_PATH}/${practiceId}/checkins`, {
       method: 'POST',
       body: JSON.stringify(validatedInput),
     });

--- a/services/practice/checkIn.ts
+++ b/services/practice/checkIn.ts
@@ -6,11 +6,11 @@ import { getRecentActivity, generateCheckInId, getCurrentDateISO, getCurrentTime
 
 // 簽到輸入驗證 schema
 const checkInInputValidationSchema = z.object({
-  practiceId: z.string().min(1, '請提供實踐 ID'),
   progress: z.number().min(0, '進度必須大於等於 0'),
   note: z.string().max(1000, '簽到筆記不能超過 1000 字元').optional(),
-  mood: z.enum(['excellent', 'good', 'average', 'challenging', 'difficult']).optional(),
-  tags: z.array(z.string().max(20, '單個標籤不能超過 20 字元')).max(5, '標籤不能超過 5 個').default([])
+  mood: z.enum(['awesome', 'happy', 'neutral', 'tired', 'frustrated']).optional(),
+  reflectionText: z.string().optional(),
+  relatedResourceId: z.string().optional()
 });
 
 // 簽到服務類
@@ -25,7 +25,7 @@ export class CheckInService {
       totalProgress: practice.currentProgress + input.progress,
       note: input.note || '',
       mood: input.mood,
-      tags: input.tags || [],
+      tags: [],
       createdAt: getCurrentTimeISO()
     };
 
@@ -138,11 +138,11 @@ export class CheckInService {
         averageProgress: 0,
         lastWeekCheckIns: 0,
         moodDistribution: {
-          excellent: 0,
-          good: 0,
-          average: 0,
-          challenging: 0,
-          difficult: 0
+          awesome: 0,
+          happy: 0,
+          neutral: 0,
+          tired: 0,
+          frustrated: 0
         },
         weeklyProgress: []
       };
@@ -160,11 +160,11 @@ export class CheckInService {
 
     // 心情分佈
     const moodDistribution: Record<MoodType, number> = {
-      excellent: 0,
-      good: 0,
-      average: 0,
-      challenging: 0,
-      difficult: 0
+      awesome: 0,
+      happy: 0,
+      neutral: 0,
+      tired: 0,
+      frustrated: 0
     };
 
     checkIns.forEach((checkIn) => {
@@ -181,6 +181,7 @@ export class CheckInService {
       const weekEnd = subDays(new Date(), i * 7);
 
       const weekCheckIns = checkIns.filter((checkIn) => {
+        if (!checkIn.date) return false;
         const checkInDate = parseISO(checkIn.date);
         return isAfter(checkInDate, weekStart) && isBefore(checkInDate, weekEnd);
       });
@@ -219,7 +220,7 @@ export class CheckInService {
       }
 
       // 心情建議
-      const negativeRatio = (stats.moodDistribution.challenging + stats.moodDistribution.difficult) / stats.totalCheckIns;
+      const negativeRatio = (stats.moodDistribution.tired + stats.moodDistribution.frustrated) / stats.totalCheckIns;
       if (negativeRatio > 0.5) {
         suggestions.push('最近學習感覺有挑戰性，可以考慮降低目標或尋求幫助');
       }
@@ -302,11 +303,11 @@ export class CheckInService {
     const threeDaysAgo = subDays(new Date(), 3);
 
     const moodLabels: Record<MoodType, string> = {
-      excellent: '極佳',
-      good: '良好',
-      average: '普通',
-      challenging: '有挑戰',
-      difficult: '困難'
+      awesome: '超棒',
+      happy: '開心',
+      neutral: '普通',
+      tired: '疲累',
+      frustrated: '受挫'
     };
 
     return checkIns
@@ -361,11 +362,11 @@ export class CheckInService {
         .reduce((a, b) => a[1] > b[1] ? a : b)[0] as MoodType;
 
       const moodLabels: Record<MoodType, string> = {
-        excellent: '優秀',
-        good: '良好',
-        average: '普通',
-        challenging: '有挑戰',
-        difficult: '困難'
+        awesome: '超棒',
+        happy: '開心',
+        neutral: '普通',
+        tired: '疲累',
+        frustrated: '受挫'
       };
 
       summary += `• 主要心情: ${moodLabels[dominantMood]}\n`;

--- a/services/practice/hooks.ts
+++ b/services/practice/hooks.ts
@@ -45,7 +45,22 @@ export function usePractice(id: string | null) {
     id ? getPracticePathname({ id }) : null,
     async () => {
       const { practiceAPI } = await import('./api');
-      return await practiceAPI.read(id!);
+      const practice = await practiceAPI.read(id!);
+
+      // 同時獲取打卡記錄並合併到 practice 對象中
+      try {
+        const checkIns = await practiceAPI.getCheckIns(id!);
+        return {
+          ...practice,
+          checkIns: checkIns || [],
+        };
+      } catch (err) {
+        // 如果獲取失敗，返回原始 practice（checkIns 可能為空或 undefined）
+        return {
+          ...practice,
+          checkIns: practice.checkIns || [],
+        };
+      }
     }
   );
 

--- a/services/practice/schema.ts
+++ b/services/practice/schema.ts
@@ -43,11 +43,11 @@ export const resourceTypeSchema = z.enum([
 ]);
 
 export const moodTypeSchema = z.enum([
-  'excellent',
-  'good',
-  'average',
-  'challenging',
-  'difficult'
+  'awesome',
+  'happy',
+  'neutral',
+  'tired',
+  'frustrated'
 ]);
 
 // ==================== 實際的列舉值（可以作為值使用） ====================
@@ -92,11 +92,11 @@ export const ResourceType = {
 } as const;
 
 export const MoodType = {
-  EXCELLENT: 'excellent' as const,
-  GOOD: 'good' as const,
-  AVERAGE: 'average' as const,
-  CHALLENGING: 'challenging' as const,
-  DIFFICULT: 'difficult' as const
+  AWESOME: 'awesome' as const,
+  HAPPY: 'happy' as const,
+  NEUTRAL: 'neutral' as const,
+  TIRED: 'tired' as const,
+  FRUSTRATED: 'frustrated' as const
 } as const;
 
 // ==================== 基礎 schema ====================
@@ -162,17 +162,18 @@ export const practiceSchema = z.object({
   viewCount: z.number().min(0).default(0),
   shareCount: z.number().min(0).default(0),
   createdAt: z.string(),
-  updatedAt: z.string()
-});
-
-// 擴展的實踐 schema - 包含使用者資訊 (用於公開列表等場景)
-export const practiceWithUserSchema = practiceSchema.extend({
+  updatedAt: z.string(),
+  // 使用者資訊 (可選)
   user: baseUserSchema.extend({
     _id: z.string().optional(),
     photoURL: z.string().optional(),
     roleList: z.array(z.string()).optional(),
   }).optional(),
 });
+
+// 擴展的實踐 schema - 包含使用者資訊 (用於公開列表等場景)
+// Note: practiceSchema already includes user field, so this is just an alias for backward compatibility
+export const practiceWithUserSchema = practiceSchema;
 
 // ==================== 操作相關 schema ====================
 export const createPracticeSchema = z.object({
@@ -181,6 +182,7 @@ export const createPracticeSchema = z.object({
   contentType: contentTypeSchema,
   customContentType: z.string().max(20, '自定義類型名稱不可超過 20 字').optional(),
   totalAmount: z.number().min(1, '總量必須大於 0').max(999999, '總量不可超過 999999'),
+  unit: z.string().min(1, '請輸入單位').max(20, '單位不可超過 20 字').optional(),
   targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '請輸入有效的目標日期格式 YYYY-MM-DD').optional(),
   motivationType: motivationTypeSchema.optional(),
   customMotivation: z.string().max(200, '自定義動機不可超過 200 字').optional(),
@@ -232,11 +234,11 @@ export const updatePracticeSchema = z.object({
 });
 
 export const checkInInputSchema = z.object({
-  practiceId: z.string().min(1, '請提供實踐 ID'),
   progress: z.number().min(0, '進度必須大於等於 0'),
   note: z.string().max(1000, '筆記不可超過 1000 字').optional(),
   mood: moodTypeSchema.optional(),
-  tags: z.array(z.string()).default([])
+  reflectionText: z.string().optional(),
+  relatedResourceId: z.string().optional()
 });
 
 // ==================== 篩選相關 schema ====================

--- a/services/practice/utils.ts
+++ b/services/practice/utils.ts
@@ -629,12 +629,36 @@ export function pathInfoToCreatePracticeInput(
     other: 'other'
   };
 
+  const contentType = contentTypeMap[String(pathInfo.contentType)] || 'custom';
+
+  // 根據 dailyGoalType 決定 totalAmount 和 unit
+  const dailyGoalType = dailyGoalConfig?.type;
+  const practiceDays = parseInt(String(pathInfo.totalAmount), 10) || 1;
+
+  let totalAmount: number;
+  let unit: string | null;
+
+  if (dailyGoalType === 'time' && dailyGoalConfig) {
+    // 時間目標：totalAmount = 實踐天數，unit = null
+    totalAmount = practiceDays;
+    unit = null;
+  } else if (dailyGoalType === 'completion' && dailyGoalConfig) {
+    // 完成目標：totalAmount = 天數，unit = 自定義單位
+    totalAmount = practiceDays;
+    unit = String(dailyGoalConfig.unit || '');
+  } else {
+    // 預設：使用內容類型的單位
+    totalAmount = practiceDays;
+    unit = getContentTypeUnit(contentType);
+  }
+
   return {
     title: String(pathInfo.title || ''),
     description: pathInfo.notes ? String(pathInfo.notes) : undefined,
-    contentType: contentTypeMap[String(pathInfo.contentType)] || 'custom',
+    contentType,
     customContentType: pathInfo.customContentType ? String(pathInfo.customContentType) : undefined,
-    totalAmount: parseInt(String(pathInfo.totalAmount), 10) || 1,
+    totalAmount,
+    unit: unit || undefined,
     targetDate: pathInfo.targetDate ? String(pathInfo.targetDate) : undefined,
     motivationType: pathInfo.motivationType ? motivationTypeMap[String(pathInfo.motivationType)] : undefined,
     customMotivation: pathInfo.customMotivation ? String(pathInfo.customMotivation) : undefined,

--- a/shared/ui/sonner.tsx
+++ b/shared/ui/sonner.tsx
@@ -1,24 +1,34 @@
-import { useTheme } from 'next-themes';
 import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme="light"
       className="toaster group"
+      richColors={false}
       toastOptions={{
+        unstyled: false,
         classNames: {
           toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-          description: 'group-[.toast]:text-muted-foreground',
+            'group toast group-[.toaster]:bg-white group-[.toaster]:text-gray-900 group-[.toaster]:border group-[.toaster]:border-gray-200 group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-gray-600',
           actionButton:
-            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+            'group-[.toast]:bg-primary group-[.toast]:text-white',
           cancelButton:
-            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+            'group-[.toast]:bg-gray-100 group-[.toast]:text-gray-700',
+          error: 'group-[.toaster]:!bg-white group-[.toaster]:!text-gray-900 group-[.toaster]:!border-red-300',
+          success: 'group-[.toaster]:!bg-white group-[.toaster]:!text-gray-900 group-[.toaster]:!border-green-300',
+          warning: 'group-[.toaster]:!bg-white group-[.toaster]:!text-gray-900 group-[.toaster]:!border-yellow-300',
+          info: 'group-[.toaster]:!bg-white group-[.toaster]:!text-gray-900 group-[.toaster]:!border-blue-300',
+        },
+        style: {
+          zIndex: 9999,
+          backgroundColor: 'white',
+          color: '#1f2937',
+          border: '1px solid #e5e7eb',
+          ...props.toastOptions?.style,
         },
       }}
       {...props}

--- a/shared/ui/status-badge.tsx
+++ b/shared/ui/status-badge.tsx
@@ -47,7 +47,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({
       active: {
         icon: Play,
         label: '進行中',
-        className: 'bg-primary-base/20 text-primary-base border-primary-base/30',
+        className: 'bg-yellow-100 text-yellow-700 border-yellow-200',
       },
       paused: {
         icon: Pause,
@@ -113,7 +113,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1 font-medium rounded-full border',
+        'inline-flex items-center gap-1 font-medium rounded-full border whitespace-nowrap',
         sizeClasses,
         config?.className,
         className


### PR DESCRIPTION
  ## Why is this necessary?
  - Practice check-ins and editing should only be available to the practice owner
  - Users could previously access and modify practices they didn't create
  - Check-in UI lacked proper error handling and user feedback
  - Toast notifications were being covered by the header
  - Need better visual feedback for successful check-ins and errors

  ## How does it address?
  - Add ownership validation in practice edit and detail pages using useSession
  - Display permission denied message for non-owners attempting to edit/check-in
  - Replace error state arrays with toast notifications for better UX
  - Configure Toaster with top margin to avoid header overlap
  - Update check-in flow to refresh practice data after successful check-in
  - Add support for URL query parameters (view=checkin, view=history)
  - Improve visual layout with BackButton component and consistent spacing
  - Update mood types from generic (excellent/good) to specific (awesome/happy/neutral/tired/frustrated)
  - Add Comment section integration to practice dashboard
  - Refactor status badge colors for better visual distinction
  - Update all unit displays to fallback to '分鐘' when unit is undefined
