### PR TITLE
feat(projects): add comments and improve UI/UX across project pages

### DIFF
--- a/app/[language]/(protected)/(default-layout)/projects/detail/page.tsx
+++ b/app/[language]/(protected)/(default-layout)/projects/detail/page.tsx
@@ -18,6 +18,8 @@ import {
   FakeCheckBox,
 } from '@/components/Projects/Project/Shared';
 import { parseToString } from '@/shared/lib/helper';
+import CommentSection from '@/shared/components/Comment/CommentSection';
+import { CommentType } from '@/services/comments';
 
 function ProjectDetailPageContent() {
   const [isFetchingProject, setIsFetchingProject] = useState(false);
@@ -92,7 +94,7 @@ function ProjectDetailPageContent() {
               )}
             </Panel>
 
-            <Panel className="bg-white">
+            <Panel className="bg-white mb-8 md:mb-6">
               <h3 className="body-md font-medium mb-5 text-basic-500">學習成果及呈現方式 *</h3>
               {Array.isArray(project?.outcome) &&
                 project?.outcome?.length > 0 && (
@@ -105,6 +107,18 @@ function ProjectDetailPageContent() {
                 text="是否公開給所有人看到"
               />
             </Panel>
+
+            {/* 評論區塊 */}
+            {projectId && (
+              <Panel className="bg-white">
+                <CommentSection
+                  targetId={projectId}
+                  targetType={CommentType.Project}
+                  hideVisibilityToggle
+                  hideCommentCount
+                />
+              </Panel>
+            )}
           </>
         )}
       </div>

--- a/app/[language]/(protected)/(default-layout)/projects/layout.tsx
+++ b/app/[language]/(protected)/(default-layout)/projects/layout.tsx
@@ -65,23 +65,29 @@ function ProjectLayoutContent({ children }: ProjectLayoutProps) {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center">
+      <div className="bg-primary-palest min-h-screen flex items-center justify-center">
         <div>Loading...</div>
       </div>
     );
   }
 
   if (!project) {
-    return <NotExist />;
+    return (
+      <div className="bg-primary-palest min-h-screen">
+        <NotExist />
+      </div>
+    );
   }
 
   return (
-    <ProjectProvider>
-      <Sidebar items={sidebarItems} backText="返回" showBackButton>
-        <ProjectHeader project={project} />
-        {children}
-      </Sidebar>
-    </ProjectProvider>
+    <div className="bg-primary-palest min-h-screen">
+      <ProjectProvider>
+        <Sidebar items={sidebarItems} backText="" showBackButton backUrl="/explore">
+          <ProjectHeader project={project} />
+          {children}
+        </Sidebar>
+      </ProjectProvider>
+    </div>
   );
 }
 

--- a/app/[language]/(protected)/(default-layout)/projects/notes/page.tsx
+++ b/app/[language]/(protected)/(default-layout)/projects/notes/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { ContentCard } from '@/features/projects';
 import { useProjectNotes } from '@/services/projects';
 import { parseToString } from '@/shared/lib/helper';
+import EmptyList from '@/components/Projects/ProjectList/EmptyList';
 
 export default function NotesPage() {
   const searchParams = useSearchParams();
@@ -15,10 +16,18 @@ export default function NotesPage() {
     return <div>專案不存在</div>;
   }
 
+  if (!notes || notes.length === 0) {
+    return (
+      <div className="rounded-2xl overflow-hidden">
+        <EmptyList />
+      </div>
+    );
+  }
+
   return (
     <>
       <ul className="px-4 bg-basic-white flex flex-col rounded-2xl">
-        {notes?.map((note) => (
+        {notes.map((note) => (
           <li
             key={note.id}
             className="py-6 border-b last:border-b-0 border-solid border-basic-200"
@@ -26,8 +35,7 @@ export default function NotesPage() {
             <ContentCard
               type="note"
               data={note}
-              className="p-3 transition-shadow hover:shadow-basic-200/40 hover:shadow-lg"
-              detailLink={`/projects/notes/detail?id=${projectId}&noteId=${note.id}`}
+              className="p-3"
             />
           </li>
         ))}

--- a/app/[language]/(protected)/(default-layout)/projects/outcomes/page.tsx
+++ b/app/[language]/(protected)/(default-layout)/projects/outcomes/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { ContentCard } from '@/features/projects';
 import { useProjectOutcomes } from '@/features/projects/hooks/outcome';
 import { parseToString } from '@/shared/lib/helper';
+import EmptyList from '@/components/Projects/ProjectList/EmptyList';
 
 export default function OutcomesPage() {
   const searchParams = useSearchParams();
@@ -15,10 +16,18 @@ export default function OutcomesPage() {
     return <div>專案不存在</div>;
   }
 
+  if (!outcomes || outcomes.length === 0) {
+    return (
+      <div className="rounded-2xl overflow-hidden">
+        <EmptyList />
+      </div>
+    );
+  }
+
   return (
     <>
       <ul className="px-4 bg-basic-white flex flex-col rounded-2xl">
-        {outcomes?.map((outcome) => (
+        {outcomes.map((outcome) => (
           <li
             key={outcome.id}
             className="py-6 border-b last:border-b-0 border-solid border-basic-200"
@@ -26,8 +35,7 @@ export default function OutcomesPage() {
             <ContentCard
               type="outcome"
               data={outcome}
-              className="p-3 transition-shadow hover:shadow-basic-200/40 hover:shadow-lg"
-              detailLink={`/projects/outcomes/detail?id=${projectId}&outcomeId=${outcome.id}`}
+              className="p-3"
             />
           </li>
         ))}

--- a/components/Projects/Project/type.ts
+++ b/components/Projects/Project/type.ts
@@ -34,7 +34,7 @@ export const DEFAULT_PROJECT: Project = {
   id: '',
   title: '',
   description: '',
-  isPublic: false,
+  isPublic: true,
   motivation: [],
   motivationDescription: '',
   goal: '',

--- a/features/projects/components/ProjectsExploreSection.tsx
+++ b/features/projects/components/ProjectsExploreSection.tsx
@@ -243,8 +243,8 @@ const ProjectsExploreSection: React.FC<ProjectsExploreSectionProps> = ({
             <Badge
               className={
                 isCompleted
-                  ? 'bg-success/20 text-success'
-                  : 'bg-tips/20 text-tips'
+                  ? 'bg-success/20 text-success whitespace-nowrap'
+                  : 'bg-tips/20 text-tips whitespace-nowrap'
               }
             >
               {isCompleted ? '已完成' : '進行中'}
@@ -332,7 +332,7 @@ const ProjectsExploreSection: React.FC<ProjectsExploreSectionProps> = ({
                   className="flex items-center gap-2"
                 >
                   <Plus className="size-4" />
-                  <span className="hidden sm:inline">建立計劃</span>
+                  <span>建立計劃</span>
                 </Button>
               ) : (
                 <CustomLink href="/manage/projects/create">
@@ -341,7 +341,7 @@ const ProjectsExploreSection: React.FC<ProjectsExploreSectionProps> = ({
                     className="flex items-center gap-2"
                   >
                     <Plus className="size-4" />
-                    <span className="hidden sm:inline">建立計劃</span>
+                    <span>建立計劃</span>
                   </Button>
                 </CustomLink>
               )

--- a/features/projects/components/ProjectsRecommendationSection.tsx
+++ b/features/projects/components/ProjectsRecommendationSection.tsx
@@ -187,7 +187,7 @@ const ProjectsRecommendationSection: React.FC<ProjectsRecommendationSectionProps
               <div className="flex items-center justify-between">
                 <Badge
                   variant={item.status === '進行中' ? 'default' : 'secondary'}
-                  className="text-xs"
+                  className="text-xs whitespace-nowrap"
                 >
                   {item.status}
                 </Badge>

--- a/services/comments/schema.ts
+++ b/services/comments/schema.ts
@@ -9,6 +9,7 @@ export enum CommentType {
   Resource = 'resource',
   ResourceReview = 'resource-review',
   Practice = 'practice',
+  Project = 'project',
 }
 
 export enum CommentVisibility {


### PR DESCRIPTION
  ## Why is this necessary?
  - Projects need comment functionality to enable user discussions and feedback
  - Empty states were missing for notes and outcomes, showing nothing when lists are empty
  - Badge text wrapping and button visibility issues affected mobile UX
  - Inconsistent background colors and spacing across project layout
  - Default project visibility should encourage public sharing

  ## How does it address?
  - Add CommentSection component to project detail page with Project comment type in schema
  - Implement EmptyList component for empty notes/outcomes pages
  - Add whitespace-nowrap to status badges preventing text wrapping on small screens
  - Show 建立計劃 button text on all screen sizes (remove hidden sm:inline)
  - Apply consistent bg-primary-palest background throughout project layout
  - Improve loading and error states with proper background styling
  - Change default isPublic from false to true for new projects
  - Remove hover effects and detail links from notes/outcomes ContentCards for cleaner UI
  - Update back button to use custom URL (/explore) with empty text label
