### PR TITLE
refactor: standardize Link component usage and i18n locale paths

### DIFF
--- a/app/[language]/(protected)/(default-layout)/manage/mentor-workspace/page.tsx
+++ b/app/[language]/(protected)/(default-layout)/manage/mentor-workspace/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import useSWR from 'swr';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ChevronLeft } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
@@ -9,6 +8,7 @@ import Container from '@/shared/components/Container';
 import { Image } from '@/shared/ui/image';
 import { getMentorMarathonPathname, MarathonSchema } from '@/services/mentors';
 import { differenceInDays, format } from 'date-fns';
+import { CustomLink } from '@/shared/ui/custom-link';
 
 const MentorWorkspaceCard = ({ marathon }: { marathon: MarathonSchema }) => {
   const days = Math.min(
@@ -24,7 +24,7 @@ const MentorWorkspaceCard = ({ marathon }: { marathon: MarathonSchema }) => {
     100;
 
   return (
-    <Link
+    <CustomLink
       href={`/manage/mentor-workspace/students?marathonId=${marathon.eventId}`}
       className="block rounded-lg bg-basic-white"
     >
@@ -70,7 +70,7 @@ const MentorWorkspaceCard = ({ marathon }: { marathon: MarathonSchema }) => {
           <div className="body-sm text-basic-400">{days}天</div>
         </div>
       </div>
-    </Link>
+    </CustomLink>
   );
 };
 

--- a/scripts/google-app-script/fetch-i18n.js
+++ b/scripts/google-app-script/fetch-i18n.js
@@ -25,7 +25,7 @@ const main = async () => {
     const json = await fetchGoogleSheet();
 
     const locales = Object.keys(json);
-    const outputDir = path.join(process.cwd(), 'shared/config/locales');
+    const outputDir = path.join(process.cwd(), 'shared/i18n/locales');
 
     if (!fs.existsSync(outputDir)) {
       fs.mkdirSync(outputDir, { recursive: true });

--- a/scripts/google-app-script/push-i18n.js
+++ b/scripts/google-app-script/push-i18n.js
@@ -10,7 +10,7 @@ const getLocalesPath = () => {
     return pathArg.split('=')[1];
   }
 
-  return path.join(process.cwd(), 'shared/config/locales');
+  return path.join(process.cwd(), 'shared/i18n/locales');
 };
 
 /**

--- a/widgets/circles/ui/circle-card.tsx
+++ b/widgets/circles/ui/circle-card.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { MapPin } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { Image } from '@/shared/ui/image';
@@ -17,6 +16,7 @@ import { CATEGORIES } from '@/constants/category';
 import { EDUCATION } from '@/constants/member';
 import type { CircleData } from '@/entities/circle';
 import emptyCoverPng from '@/public/assets/images/empty-cover.png';
+import { CustomLink } from '@/shared/ui/custom-link';
 
 const MarkdownEditor = dynamic(
   () =>
@@ -50,7 +50,7 @@ const formatToString = (
 
 export const CircleCard = ({ data }: CircleCardProps) => {
   return (
-    <Link
+    <CustomLink
       className={cn(
         'relative block rounded-md bg-white p-2 text-basic-500 transition-[transform,box-shadow]',
         'hover:z-10 hover:scale-105 hover:shadow-md'
@@ -119,7 +119,7 @@ export const CircleCard = ({ data }: CircleCardProps) => {
           </Badge>
         </div>
       </div>
-    </Link>
+    </CustomLink>
   );
 };
 

--- a/widgets/circles/ui/circle-detail-widget.tsx
+++ b/widgets/circles/ui/circle-detail-widget.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
 import { useCircle } from '@/entities/circle';
 import { Paper } from '@/shared/ui/wrapper';
 import { BackButton } from '@/shared/ui/back-button';
@@ -44,6 +43,7 @@ import { timeDuration } from '@/shared/lib/date';
 import { ContactModal, TargetUserType } from '@/features/email';
 import { getUserProfileBasePath, useAuth } from '@/entities/user';
 import { CircleEditForm } from './circle-edit-form';
+import { CustomLink } from '@/shared/ui/custom-link';
 
 const MarkdownEditor = dynamic(
   () =>
@@ -184,13 +184,13 @@ export const CircleDetailWidget = ({ circleId }: CircleDetailWidgetProps) => {
                     編輯
                   </button>
                 ) : (
-                  <Link
+                  <CustomLink
                     href="https://forms.gle/NkVbDWC3eXk4P4gv7"
                     target="_blank"
                     className="block p-2"
                   >
                     檢舉
-                  </Link>
+                  </CustomLink>
                 )}
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -285,7 +285,7 @@ export const CircleDetailWidget = ({ circleId }: CircleDetailWidgetProps) => {
       <Paper className="mb-4 md:p-8" asChild>
         <section>
           <header className="flex justify-between">
-            <Link href={getUserProfileBasePath({ id: data.user.userId })}>
+            <CustomLink href={getUserProfileBasePath({ id: data.user.userId })}>
               <div className="flex items-center">
                 <Avatar className="mr-3 mt-1 size-12">
                   <AvatarImage src={data.user.photoURL} />
@@ -310,7 +310,7 @@ export const CircleDetailWidget = ({ circleId }: CircleDetailWidgetProps) => {
                   </span>
                 </div>
               </div>
-            </Link>
+            </CustomLink>
 
             <div className="flex items-center gap-1">
               <LocationSvg />

--- a/widgets/manage/ui/manage-page-widget.tsx
+++ b/widgets/manage/ui/manage-page-widget.tsx
@@ -22,7 +22,6 @@ import {
   CircleChevronRight,
   CircleChevronLeft,
 } from 'lucide-react';
-import Link from 'next/link';
 
 import marathonConfig from '@/constants/marathon';
 
@@ -72,6 +71,7 @@ import {
 } from '@/features/projects/hooks/review';
 import { useProjectOutcomeMutation } from '@/features/projects/hooks/outcome';
 import { useProjectMilestoneMutation } from '@/features/projects/hooks/milestone';
+import { CustomLink } from '@/shared/ui/custom-link';
 
 const HEADER_TITLES = [
   '今天的每一小步，都在建立你的學習動能！',
@@ -401,14 +401,14 @@ const Project = ({
           className="w-full px-3 py-2 justify-between"
           withIcon
         >
-          <Link
+          <CustomLink
             href={href}
             target="_blank"
             className="flex items-center gap-2 body-md text-basic-500"
           >
             {title}
             <ArrowUpRight className="stroke-1" />
-          </Link>
+          </CustomLink>
         </CollapsibleTrigger>
         <CollapsibleContent>{children}</CollapsibleContent>
       </Collapsible>

--- a/widgets/resources/ui/resource-explore-page-widget.tsx
+++ b/widgets/resources/ui/resource-explore-page-widget.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { SWRConfig } from 'swr';
-import Link from 'next/link';
 import SEOConfig, { JsonLdType } from '@/components/SEOConfig';
 import { ChevronLeftIcon } from 'lucide-react';
 import { ResourceExplorer } from '@/features/resources';
 import { Button } from '@/shared/ui/button';
 import { ResourceListResponseSchema } from '@/services/resources';
 import { Container } from '@/shared/ui/wrapper';
+import { CustomLink } from '@/shared/ui/custom-link';
 import { ResourceExploreClient } from './resource-explore-client';
 
 interface ResourceExplorePageWidgetProps {
@@ -28,10 +28,10 @@ export const ResourceExplorePageWidget = ({
           className="-mx-2 mb-3 px-2 text-basic-300"
           asChild
         >
-          <Link href="/resource">
+          <CustomLink href="/resource">
             <ChevronLeftIcon className="h-4 w-4" />
             返回
-          </Link>
+          </CustomLink>
         </Button>
         <ResourceExploreClient />
       </Container>

--- a/widgets/resources/ui/resource-list-page-widget.tsx
+++ b/widgets/resources/ui/resource-list-page-widget.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
 import { ChevronRightIcon } from 'lucide-react';
 import SEOConfig, { JsonLdType } from '@/components/SEOConfig';
 import resourceBannerWebp from '@/public/assets/resource/banner.webp';
@@ -14,6 +13,7 @@ import { HOT_TAGS } from '@/constants/category';
 import { Button } from '@/shared/ui/button';
 import { ResourceListResponseSchema } from '@/services/resources';
 import { Container } from '@/shared/ui/wrapper';
+import { CustomLink } from '@/shared/ui/custom-link';
 import { ResourceBannerClient } from './resource-banner-client';
 import { ResourceCreateForm } from './resource-create-form';
 
@@ -62,10 +62,10 @@ export const ResourceListPageWidget = ({
               size="lg"
               asChild
             >
-              <Link href="/resource/explore">
+              <CustomLink href="/resource/explore">
                 探索 所有資源
                 <ChevronRightIcon className="w-4 h-4" />
-              </Link>
+              </CustomLink>
             </Button>
           </SectionTitle>
           <ResourceContainer data={data?.resources.slice(2, 4) ?? []} />
@@ -78,10 +78,10 @@ export const ResourceListPageWidget = ({
               className="-mx-2 px-2 body-md font-medium text-basic-300"
               asChild
             >
-              <Link href="/resource/explore">
+              <CustomLink href="/resource/explore">
                 探索 所有資源
                 <ChevronRightIcon className="w-4 h-4" />
-              </Link>
+              </CustomLink>
             </Button>
           </SectionTitle>
           <ResourceContainer data={data?.resources.slice(0, 2) ?? []} />
@@ -94,10 +94,10 @@ export const ResourceListPageWidget = ({
               className="-mx-2 px-2 body-md font-medium text-basic-300"
               asChild
             >
-              <Link href="/resource/categories">
+              <CustomLink href="/resource/categories">
                 探索 所有分類
                 <ChevronRightIcon className="w-4 h-4" />
-              </Link>
+              </CustomLink>
             </Button>
           </SectionTitle>
           <CategoriesContainer maxLength={8} disabledCollapse />


### PR DESCRIPTION
## Why is this necessary?

1. **Unified Link Component Usage**: The codebase currently mixes next/link's Link component with CustomLink. CustomLink provides:
    - Internationalization navigation support (based on next-intl)
    - Navigation blocking functionality (prompts users when there are unsaved changes)
    - Consistent link behavior across the application
2. **i18n Path Consistency**: The i18n scripts still reference the old path shared/config/locales, while the actual locale files have been moved to shared/i18n/locales. This mismatch prevents the scripts from correctly syncing translation files.

## How does it address?

1. **Replace Link with CustomLink**:
    - Replaces next/link's Link component with CustomLink across multiple widgets (mentor workspace, circles, manage, and resources pages)
    - Ensures consistent link behavior throughout the application, with proper i18n navigation support and navigation blocking capabilities
2. **Update i18n Script Paths**:
    - Updates the locale path in fetch-i18n.js and push-i18n.js to use shared/i18n/locales
    - Ensures Google Apps Script sync scripts can correctly read and write translation files

These changes improve code consistency and maintainability, and fix the i18n script path issue.