### PR TITLE
feat(settings): enhance public info form with custom ID validation

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -3,6 +3,7 @@
 import { useMyPracticeStats, useMyPractices } from "@daodao/api";
 import { MessagesSvg } from "@daodao/assets";
 import { useRouter } from "@daodao/i18n/navigation";
+import { format, parseISO } from "date-fns";
 import { CheckCircle2 } from "lucide-react";
 import { useMemo } from "react";
 import {
@@ -42,6 +43,12 @@ export default function HomePage() {
         practice.status === PracticeStatus.draft ||
         practice.status === PracticeStatus.notStarted;
 
+      // 將 ISO timestamp 轉換為 yyyy-MM-dd 格式
+      // API 回傳 lastCheckinAt 為 ISO 8601 格式 (e.g., "2024-01-20T09:00:00.000Z")
+      const lastCheckInDate = practice.lastCheckinAt
+        ? format(parseISO(practice.lastCheckinAt), "yyyy-MM-dd")
+        : null;
+
       if (isInProgress) {
         inProgressTasksData.push({
           id: practice.id,
@@ -54,8 +61,7 @@ export default function HomePage() {
           isUnreadMessages: false, // TODO: 需要從其他 API 取得
           theme: practice.themeColor || "#FCDD84",
           status: mapPracticeStatusToTaskStatus(practice.status),
-          // TODO: 需要從 practice.stats 或打卡記錄 API 獲取最新的打卡日期
-          lastCheckInDate: null,
+          lastCheckInDate,
         });
       } else if (practice.status === PracticeStatus.completed) {
         completedTasksData.push({

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -214,11 +214,15 @@ export default function PracticeDetailPage() {
     }
   };
 
+  const handleBack = () => {
+    router.push("/");
+  };
+
   // Loading 狀態
   if (isLoading) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-        <PageHeader leftAction="back" title="主題實踐" rightActionTo="/" />
+        <PageHeader leftAction="back" title="主題實踐" onLeftAction={handleBack} rightActionTo="/" />
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">載入中...</div>
@@ -231,7 +235,7 @@ export default function PracticeDetailPage() {
   if (error || !practice) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-        <PageHeader leftAction="back" title="主題實踐" rightActionTo="/" />
+        <PageHeader leftAction="back" title="主題實踐" onLeftAction={handleBack} rightActionTo="/" />
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">
@@ -244,7 +248,7 @@ export default function PracticeDetailPage() {
 
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-      <PageHeader leftAction="back" title="主題實踐" rightActionTo="/" />
+      <PageHeader leftAction="back" title="主題實踐" onLeftAction={handleBack} rightActionTo="/" />
 
       <BackgroundAnimation />
 

--- a/apps/product/src/app/[locale]/practices/create/success/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/success/page.tsx
@@ -97,8 +97,8 @@ export default function PracticeSuccessPage() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.6, delay: 0.7 }}
         >
-          <p className="text-sm text-logo-cyan">鼓勵文字鼓勵文字鼓勵文字鼓勵文字</p>
-          <p className="text-sm text-logo-cyan">鼓勵文字鼓勵文字鼓勵文字</p>
+          <p className="text-sm text-logo-cyan">完成規劃已是踏出第一步，已為你推進 20% 進度！</p>
+          <p className="text-sm text-logo-cyan">期待你的第一次打卡分享！</p>
         </motion.div>
 
         {/* 按鈕區域 */}

--- a/apps/product/src/components/check-in/display/check-in-detail.tsx
+++ b/apps/product/src/components/check-in/display/check-in-detail.tsx
@@ -2,9 +2,8 @@
 
 import { Button } from "@daodao/ui/components/button";
 import { ImageLightbox } from "@daodao/ui/components/image-lightbox";
-import { Share2, Trash2 } from "lucide-react";
+import { Share2 } from "lucide-react";
 import * as React from "react";
-import { DeleteCheckInResult, useDeleteCheckInDialog } from "@/hooks/use-delete-check-in-dialog";
 import { useShareCheckInSheet } from "@/hooks/use-share-check-in-sheet";
 import type { ICheckInDisplayData, ICheckInFormData } from "../types";
 import { CheckInCard } from "./check-in-card";
@@ -20,16 +19,6 @@ export const CheckInDetail = ({ checkInData }: ICheckInDetailProps) => {
 
   const [lightboxOpen, setLightboxOpen] = React.useState(false);
   const [lightboxIndex, setLightboxIndex] = React.useState(0);
-
-  // 處理刪除打卡
-  const { openDeleteDialog } = useDeleteCheckInDialog();
-
-  const handleDeleteCheckIn = async () => {
-    const result = await openDeleteDialog(checkInData.id);
-    if (result === DeleteCheckInResult.Deleted) {
-      // TODO: 實作刪除打卡功能
-    }
-  };
 
   // 處理分享打卡
   const { openShareSheet } = useShareCheckInSheet({
@@ -68,14 +57,6 @@ export const CheckInDetail = ({ checkInData }: ICheckInDetailProps) => {
         <Button variant="white" className="px-8" onClick={openShareSheet}>
           <Share2 className="size-4 mr-2" />
           分享這篇打卡
-        </Button>
-        <Button
-          variant="ghost"
-          className="px-8 text-white hover:text-white/80 border border-white"
-          onClick={handleDeleteCheckIn}
-        >
-          <Trash2 className="size-4.5" />
-          <span>刪除打卡</span>
         </Button>
       </div>
 

--- a/apps/product/src/components/check-in/display/check-in-stack.tsx
+++ b/apps/product/src/components/check-in/display/check-in-stack.tsx
@@ -544,7 +544,7 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
       {/* 隱藏的 SVG 區域，用於提取幾何數據 */}
       <div className="absolute opacity-0 pointer-events-none invisible h-px overflow-hidden">
         {SVG_CONFIGS.map(({ Component }, i) => (
-          <Component key={Component.name} ref={handleSvgRef(i)} />
+          <Component key={i} ref={handleSvgRef(i)} />
         ))}
       </div>
 

--- a/apps/product/src/components/check-in/form/hooks/use-check-in-submit.ts
+++ b/apps/product/src/components/check-in/form/hooks/use-check-in-submit.ts
@@ -51,7 +51,7 @@ export const useCheckInSubmit = ({
       // API 返回的 data 是 CheckInWithEncouragement 類型，包含 practiceProgressPercentage
       // 使用類型斷言來訪問 practiceProgressPercentage，因為類型定義可能不完整
       const responseData = response.data as
-        | (typeof response.data & { practiceProgressPercentage?: number })
+        | { practiceProgressPercentage?: number }
         | undefined;
       const newProgressPercentage =
         responseData &&

--- a/apps/product/src/components/check-in/form/hooks/use-check-in-submit.ts
+++ b/apps/product/src/components/check-in/form/hooks/use-check-in-submit.ts
@@ -50,8 +50,8 @@ export const useCheckInSubmit = ({
       // 從 API response 中取得新的進度百分比
       // API 返回的 data 是 CheckInWithEncouragement 類型，包含 practiceProgressPercentage
       // 使用類型斷言來訪問 practiceProgressPercentage，因為類型定義可能不完整
-      const responseData = response.data?.data as
-        | (typeof response.data.data & { practiceProgressPercentage?: number })
+      const responseData = response.data as
+        | (typeof response.data & { practiceProgressPercentage?: number })
         | undefined;
       const newProgressPercentage =
         responseData &&

--- a/apps/product/src/components/settings/public-info/basic-info-section.tsx
+++ b/apps/product/src/components/settings/public-info/basic-info-section.tsx
@@ -68,6 +68,16 @@ export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionPro
     checkTimeoutRef.current = setTimeout(async () => {
       try {
         const response = await checkCustomIdAvailability(customId);
+        console.log("checkCustomIdAvailability response:", response);
+
+        // 檢查是否有錯誤
+        if (response.error) {
+          console.error("API error:", response.error);
+          setCustomIdStatus("idle");
+          return;
+        }
+
+        // 檢查可用性
         if (response.data?.data?.available) {
           setCustomIdStatus("available");
         } else {
@@ -77,7 +87,8 @@ export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionPro
             message: "此使用者 ID 已被使用",
           });
         }
-      } catch {
+      } catch (err) {
+        console.error("checkCustomIdAvailability error:", err);
         setCustomIdStatus("idle");
       }
     }, 300);
@@ -134,18 +145,15 @@ export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionPro
                     form.formState.errors.customId && "border-red focus-visible:border-red",
                     customIdStatus === "available" && "border-green focus-visible:border-green"
                   )}
-                  onBlur={(e) => {
-                    field.onBlur();
-                    checkCustomId(e.target.value);
-                  }}
+                  onBlur={field.onBlur}
                   onChange={(e) => {
                     field.onChange(e);
-                    // 當值改變時，重置狀態（如果與原始值相同則設為 idle）
-                    if (e.target.value === initialCustomId) {
+                    // 當使用者輸入時，立即清除舊的驗證狀態
+                    if (customIdStatus === "available" || customIdStatus === "unavailable") {
                       setCustomIdStatus("idle");
-                    } else if (customIdStatus !== "idle") {
-                      setCustomIdStatus("idle");
+                      form.clearErrors("customId");
                     }
+                    checkCustomId(e.target.value);
                   }}
                 />
                 {/* 狀態指示器 */}

--- a/apps/product/src/components/settings/public-info/basic-info-section.tsx
+++ b/apps/product/src/components/settings/public-info/basic-info-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { checkCustomIdAvailability } from "@daodao/api";
 import { useLocale, useTranslations } from "@daodao/i18n";
 import {
   FormControl,
@@ -12,18 +13,23 @@ import {
 import { Input } from "@daodao/ui/components/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@daodao/ui/components/popover";
 import { cn } from "@daodao/ui/lib/utils";
-import { ChevronDownIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { CheckCircleIcon, ChevronDownIcon, LoaderIcon, XCircleIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import type { PublicInfoFormValues } from "./schema";
 
 interface IBasicInfoSectionProps {
   form: UseFormReturn<PublicInfoFormValues>;
+  initialCustomId?: string;
 }
 
-export const BasicInfoSection = ({ form }: IBasicInfoSectionProps) => {
+export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionProps) => {
   const locale = useLocale();
   const t = useTranslations();
+
+  // customId 即時檢查狀態
+  const [customIdStatus, setCustomIdStatus] = useState<"idle" | "checking" | "available" | "unavailable">("idle");
+  const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // 取得城市選項
   const cityOptions = useMemo(() => {
@@ -35,6 +41,56 @@ export const BasicInfoSection = ({ form }: IBasicInfoSectionProps) => {
       }))
       .sort((a, b) => a.label.localeCompare(b.label, locale === "en" ? "en" : "zh-TW"));
   }, [t, locale]);
+
+  // customId 即時檢查函數（debounced）
+  const checkCustomId = useCallback(async (customId: string) => {
+    // 清除之前的 timeout
+    if (checkTimeoutRef.current) {
+      clearTimeout(checkTimeoutRef.current);
+    }
+
+    // 如果是空的或與原始值相同，不檢查
+    if (!customId || customId === initialCustomId) {
+      setCustomIdStatus("idle");
+      return;
+    }
+
+    // 本地格式驗證（基本格式檢查）
+    const customIdRegex = /^[a-z0-9][a-z0-9_-]*[a-z0-9]$|^[a-z0-9]$/i;
+    if (customId.length < 3 || customId.length > 50 || !customIdRegex.test(customId)) {
+      setCustomIdStatus("idle");
+      return;
+    }
+
+    setCustomIdStatus("checking");
+
+    // debounce 300ms
+    checkTimeoutRef.current = setTimeout(async () => {
+      try {
+        const response = await checkCustomIdAvailability(customId);
+        if (response.data?.data?.available) {
+          setCustomIdStatus("available");
+        } else {
+          setCustomIdStatus("unavailable");
+          form.setError("customId", {
+            type: "server",
+            message: "此使用者 ID 已被使用",
+          });
+        }
+      } catch {
+        setCustomIdStatus("idle");
+      }
+    }, 300);
+  }, [initialCustomId, form]);
+
+  // 清理 timeout
+  useEffect(() => {
+    return () => {
+      if (checkTimeoutRef.current) {
+        clearTimeout(checkTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div className="bg-white rounded-xl p-4 space-y-4">
@@ -69,17 +125,49 @@ export const BasicInfoSection = ({ form }: IBasicInfoSectionProps) => {
               使用者 ID<span className="text-red ml-1">*</span>
             </FormLabel>
             <FormControl>
-              <Input
-                {...field}
-                placeholder="請輸入使用者 ID"
-                className={cn(
-                  form.formState.errors.customId && "border-red focus-visible:border-red"
-                )}
-              />
+              <div className="relative">
+                <Input
+                  {...field}
+                  placeholder="請輸入使用者 ID"
+                  className={cn(
+                    "pr-10",
+                    form.formState.errors.customId && "border-red focus-visible:border-red",
+                    customIdStatus === "available" && "border-green focus-visible:border-green"
+                  )}
+                  onBlur={(e) => {
+                    field.onBlur();
+                    checkCustomId(e.target.value);
+                  }}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    // 當值改變時，重置狀態（如果與原始值相同則設為 idle）
+                    if (e.target.value === initialCustomId) {
+                      setCustomIdStatus("idle");
+                    } else if (customIdStatus !== "idle") {
+                      setCustomIdStatus("idle");
+                    }
+                  }}
+                />
+                {/* 狀態指示器 */}
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  {customIdStatus === "checking" && (
+                    <LoaderIcon className="size-4 text-light-gray animate-spin" />
+                  )}
+                  {customIdStatus === "available" && (
+                    <CheckCircleIcon className="size-4 text-green" />
+                  )}
+                  {customIdStatus === "unavailable" && (
+                    <XCircleIcon className="size-4 text-red" />
+                  )}
+                </div>
+              </div>
             </FormControl>
             <FormDescription className="text-xs text-light-gray mt-1">
               ID 開頭及結尾僅可使用字符英文字母 (a-z) 與數字。中間可包含底線 (_) 與連字符 (-), 最少
               3 個字符, 最多 50 個字符。
+              {customIdStatus === "available" && (
+                <span className="text-green ml-1">✓ 此 ID 可以使用</span>
+              )}
             </FormDescription>
             <FormMessage />
           </FormItem>

--- a/apps/product/src/components/settings/public-info/public-info-form.tsx
+++ b/apps/product/src/components/settings/public-info/public-info-form.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  setCurrentUserCustomId,
-  type UpdateUserRequest,
-  uploadImage,
-  useCurrentUser,
-  useUserMutations,
-} from "@daodao/api";
+import { useCurrentUser, useMutate, useUserMutations } from "@daodao/api";
 import { Button } from "@daodao/ui/components/button";
 import { Form } from "@daodao/ui/components/form";
 import { toast } from "@daodao/ui/components/sonner";
@@ -22,7 +16,8 @@ import { SocialLinksSection } from "./social-links-section";
 
 export const PublicInfoForm = () => {
   const { data: userData, isLoading, error: userError } = useCurrentUser();
-  const { updateCurrentUser } = useUserMutations();
+  const { updateCurrentUserWithFormData } = useUserMutations();
+  const mutate = useMutate();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
 
@@ -41,6 +36,8 @@ export const PublicInfoForm = () => {
       linkedin: "",
       github: "",
       discord: "",
+      line: "",
+      threads: "",
     },
   });
 
@@ -57,12 +54,14 @@ export const PublicInfoForm = () => {
         location: user.location || "",
         personalSlogan: user.personalSlogan || "",
         selfIntroduction: user.selfIntroduction || "",
-        personalUrl: "",
+        personalUrl: contactList?.website || "",
         facebook: contactList?.facebook || "",
         instagram: contactList?.instagram || "",
         linkedin: contactList?.linkedin || "",
-        github: "", // API 中沒有此欄位
+        github: contactList?.github || "",
         discord: contactList?.discord || "",
+        line: contactList?.line || "",
+        threads: contactList?.threads || "",
       });
     }
   }, [userData, form.reset]);
@@ -71,26 +70,10 @@ export const PublicInfoForm = () => {
     setIsSubmitting(true);
 
     try {
-      // 先上傳頭像（如果有選擇新頭像）
-      let photoURL = values.photoURL;
-      if (avatarFile) {
-        try {
-          const uploadResponse = await uploadImage(avatarFile);
-          if (uploadResponse.data?.url) {
-            photoURL = uploadResponse.data.url;
-          }
-        } catch (error) {
-          console.error("Failed to upload avatar:", error);
-          toast.error("頭像上傳失敗，請稍後再試");
-          setIsSubmitting(false);
-          return;
-        }
-      }
-
       // 準備 API 請求資料
       const updateData: {
         name?: string;
-        photoURL?: string;
+        customId?: string;
         location?: string;
         personalSlogan?: string;
         selfIntroduction?: string;
@@ -99,6 +82,8 @@ export const PublicInfoForm = () => {
           instagram?: string;
           linkedin?: string;
           discord?: string;
+          github?: string;
+          website?: string;
           line?: string;
           threads?: string;
         };
@@ -109,8 +94,10 @@ export const PublicInfoForm = () => {
         updateData.name = values.name;
       }
 
-      if (photoURL) {
-        updateData.photoURL = photoURL;
+      // 更新 customId（如果改變了）
+      const currentCustomId = userData?.data?.customId || "";
+      if (values.customId && values.customId !== currentCustomId) {
+        updateData.customId = values.customId;
       }
 
       if (values.location) {
@@ -125,110 +112,73 @@ export const PublicInfoForm = () => {
         updateData.selfIntroduction = values.selfIntroduction;
       }
 
-      // 更新社群連結（總是包含所有欄位，允許清空）
-      const contactList: {
-        facebook?: string;
-        instagram?: string;
-        linkedin?: string;
-        discord?: string;
-        line?: string;
-        threads?: string;
-      } = {};
+      // 更新社群連結
+      updateData.contactList = {
+        facebook: values.facebook || undefined,
+        instagram: values.instagram || undefined,
+        linkedin: values.linkedin || undefined,
+        discord: values.discord || undefined,
+        github: values.github || undefined,
+        website: values.personalUrl || undefined,
+        line: values.line || undefined,
+        threads: values.threads || undefined,
+      };
 
-      contactList.facebook = values.facebook;
-      contactList.instagram = values.instagram;
-      contactList.linkedin = values.linkedin;
-      contactList.discord = values.discord;
+      // 調用 FormData API 更新用戶資訊（包含圖片上傳）
+      await updateCurrentUserWithFormData(updateData, avatarFile || undefined);
 
-      updateData.contactList = contactList;
-
-      // 調用 API 更新用戶資訊
-      const response = await updateCurrentUser(updateData as UpdateUserRequest);
-
-      // 檢查錯誤
-      if (response.error) {
-        const error = response.error;
-        let errorMessage = "更新失敗，請稍後再試";
-
-        if (typeof error === "object" && error !== null) {
-          // 檢查是否有 details 陣列
-          if ("details" in error && Array.isArray(error.details)) {
-            const details = error.details as Array<{ path?: string; message?: string }>;
-
-            // 處理每個欄位錯誤
-            details.forEach((detail) => {
-              if (detail.path && detail.message) {
-                // 將錯誤設置到對應的表單欄位
-                const formFieldMap: Record<string, keyof PublicInfoFormValues> = {
-                  name: "name",
-                  photoURL: "photoURL",
-                  location: "location",
-                  personalSlogan: "personalSlogan",
-                  selfIntroduction: "selfIntroduction",
-                  customId: "customId",
-                };
-
-                const formField = formFieldMap[detail.path];
-                if (formField) {
-                  form.setError(formField, {
-                    type: "server",
-                    message: detail.message,
-                  });
-                }
-              }
-            });
-
-            // 使用第一個具體錯誤訊息作為 toast 訊息
-            const firstDetail = details[0];
-            if (firstDetail?.message) {
-              errorMessage = firstDetail.message;
-            }
-          } else if ("message" in error && error.message) {
-            // 如果沒有 details，使用頂層 message
-            errorMessage = String(error.message);
-          }
-        }
-
-        console.error("Failed to update user:", response.error);
-        toast.error(errorMessage);
-        setIsSubmitting(false);
-        return;
-      }
-
-      // 更新 customId（如果改變了）- 放在最後以減少資料不一致風險
-      const currentCustomId = userData?.data?.customId || "";
-      if (values.customId && values.customId !== currentCustomId) {
-        try {
-          const customIdResponse = await setCurrentUserCustomId(values.customId);
-          if (customIdResponse.error) {
-            const error = customIdResponse.error;
-            let errorMessage = "使用者 ID 設置失敗";
-
-            if (typeof error === "object" && error !== null) {
-              if ("message" in error && error.message) {
-                errorMessage = String(error.message);
-              }
-            }
-
-            toast.error(errorMessage);
-            setIsSubmitting(false);
-            return;
-          }
-        } catch (error) {
-          console.error("Failed to set customId:", error);
-          toast.error("使用者 ID 設置失敗，請稍後再試");
-          setIsSubmitting(false);
-          return;
-        }
-      }
+      // 刷新用戶資料
+      await mutate(["/api/v1/users/me"] as const);
 
       // 成功
       toast.success("公開資訊設定已更新");
       form.reset(form.getValues()); // 重置 dirty 狀態
       setAvatarFile(null); // 清除頭像檔案
     } catch (error) {
-      console.error("Unexpected error:", error);
-      toast.error("更新失敗，請稍後再試");
+      console.error("Failed to update user:", error);
+
+      // 處理錯誤
+      let errorMessage = "更新失敗，請稍後再試";
+
+      if (error instanceof Error) {
+        errorMessage = error.message;
+
+        // 處理驗證錯誤詳情
+        const errorWithDetails = error as Error & {
+          details?: Array<{ path?: string; message?: string }>;
+        };
+        if (errorWithDetails.details && Array.isArray(errorWithDetails.details)) {
+          errorWithDetails.details.forEach((detail) => {
+            if (detail.path && detail.message) {
+              // 將錯誤設置到對應的表單欄位
+              const formFieldMap: Record<string, keyof PublicInfoFormValues> = {
+                name: "name",
+                photoURL: "photoURL",
+                location: "location",
+                personalSlogan: "personalSlogan",
+                selfIntroduction: "selfIntroduction",
+                customId: "customId",
+              };
+
+              const formField = formFieldMap[detail.path];
+              if (formField) {
+                form.setError(formField, {
+                  type: "server",
+                  message: detail.message,
+                });
+              }
+            }
+          });
+
+          // 使用第一個具體錯誤訊息作為 toast 訊息
+          const firstDetail = errorWithDetails.details[0];
+          if (firstDetail?.message) {
+            errorMessage = firstDetail.message;
+          }
+        }
+      }
+
+      toast.error(errorMessage);
     } finally {
       setIsSubmitting(false);
     }
@@ -263,7 +213,7 @@ export const PublicInfoForm = () => {
           onAvatarFileChange={setAvatarFile}
         />
 
-        <BasicInfoSection form={form} />
+        <BasicInfoSection form={form} initialCustomId={userData?.data?.customId || ""} />
 
         <IntroductionSection form={form} />
 

--- a/apps/product/src/components/settings/public-info/schema.ts
+++ b/apps/product/src/components/settings/public-info/schema.ts
@@ -30,6 +30,8 @@ export const publicInfoFormSchema = z.object({
   linkedin: z.string().url("請輸入有效的網址").optional().or(z.literal("")),
   github: z.string().url("請輸入有效的網址").optional().or(z.literal("")),
   discord: z.string().optional(),
+  line: z.string().optional(),
+  threads: z.string().url("請輸入有效的網址").optional().or(z.literal("")),
 });
 
 export type PublicInfoFormValues = z.infer<typeof publicInfoFormSchema>;

--- a/apps/product/src/components/settings/public-info/social-links-section.tsx
+++ b/apps/product/src/components/settings/public-info/social-links-section.tsx
@@ -151,6 +151,49 @@ export const SocialLinksSection = ({ form }: ISocialLinksSectionProps) => {
           </FormItem>
         )}
       />
+
+      {/* Line */}
+      <FormField
+        control={form.control}
+        name="line"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">LINE</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="請輸入 LINE ID"
+                className={cn(
+                  form.formState.errors.line && "border-red focus-visible:border-red"
+                )}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Threads */}
+      <FormField
+        control={form.control}
+        name="threads"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">Threads</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="請輸入 Threads 網址"
+                type="url"
+                className={cn(
+                  form.formState.errors.threads && "border-red focus-visible:border-red"
+                )}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
     </div>
   );
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,6 +2,9 @@
 export { getSwrKey, getSwrKeyWithResponse, unauthorizedHandler } from "./client";
 export * from "./errors";
 
+// Export hooks
+export { useMutate } from "./hooks";
+
 // Export domain-specific services
 export * from "./services";
 

--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -5,11 +5,11 @@
  * 提供實踐相關的 React Hooks（用於 Client Components）
  */
 
+import { getRequiredEnv } from "@daodao/config";
 import { useRef } from "react";
-import { client } from "../client";
+import { client, unauthorizedHandler } from "../client";
 import { useMutate, useQuery } from "../hooks";
 import type { components, paths } from "../types";
-import { deleteMultipleImages, uploadMultipleImages } from "./image";
 import type {
   IGetMyPracticesParams,
   IGetPracticeCheckInsParams,
@@ -259,56 +259,57 @@ export const createPracticeCheckIn = async (practiceId: string, data: CreateChec
 };
 
 /**
- * 創建實踐打卡記錄（封裝函數，自動處理圖片上傳和資料轉換）
+ * 打卡 API 回應類型
+ */
+type CreateCheckInResponse =
+  paths["/api/v1/practices/{id}/checkins"]["post"]["responses"]["201"]["content"]["application/json"];
+
+/**
+ * 創建實踐打卡記錄（使用 FormData 統一提交）
  * @param practiceId 實踐 ID
- * @param formData 表單資料（包含圖片檔案）
+ * @param data 表單資料（包含圖片檔案）
  * @returns 創建結果
  */
 export const createPracticeCheckInWithFormData = async (
   practiceId: string,
-  formData: ICheckInFormData
-) => {
-  // 1. 上傳圖片（如果有）
-  let imageUrls: string[] = [];
-  let uploadedFilenames: string[] = [];
+  data: ICheckInFormData
+): Promise<CreateCheckInResponse> => {
+  const formData = new FormData();
 
-  try {
-    if (formData.media && formData.media.length > 0) {
-      const uploadResult = await uploadMultipleImages(formData.media);
-      imageUrls = uploadResult.data.urls.map((item) => item.url);
-      uploadedFilenames = uploadResult.data.urls.map((item) => item.filename);
-    }
+  // 基本欄位
+  if (data.mood) formData.append("mood", data.mood);
+  if (data.description) formData.append("note", data.description);
 
-    // 2. 構建 API 請求資料
-    const checkInRequest: CreateCheckInRequestType = {
-      mood: formData.mood,
-      note: formData.description || undefined,
-      imageUrls,
-      tags: formData.tags,
-    };
-
-    // 3. 調用 API 創建打卡記錄
-    const response = await createPracticeCheckIn(practiceId, checkInRequest);
-
-    // 如果創建失敗，清理已上傳的圖片
-    if (response.error && uploadedFilenames.length > 0) {
-      await deleteMultipleImages(uploadedFilenames).catch((error) => {
-        // 記錄刪除失敗的錯誤，但不影響主要錯誤的拋出
-        console.error("清理已上傳圖片失敗:", error);
-      });
-    }
-
-    return response;
-  } catch (error) {
-    // 如果圖片上傳或創建打卡記錄時發生異常，清理已上傳的圖片
-    if (uploadedFilenames.length > 0) {
-      await deleteMultipleImages(uploadedFilenames).catch((deleteError) => {
-        // 記錄刪除失敗的錯誤，但不影響主要錯誤的拋出
-        console.error("清理已上傳圖片失敗:", deleteError);
-      });
-    }
-    throw error;
+  // 陣列欄位需轉成 JSON 字串
+  if (data.tags && data.tags.length > 0) {
+    formData.append("tags", JSON.stringify(data.tags));
   }
+
+  // 圖片檔案（多張）
+  if (data.media && data.media.length > 0) {
+    data.media.forEach((file) => {
+      formData.append("images", file);
+    });
+  }
+
+  const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
+  const response = await unauthorizedHandler.wrapFetch(
+    `${baseUrl}/api/v1/practices/${practiceId}/checkins`,
+    {
+      method: "POST",
+      body: formData,
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({
+      error: { message: "打卡失敗" },
+    }));
+    throw new Error(error.error?.message || "打卡失敗");
+  }
+
+  return response.json();
 };
 
 /**
@@ -373,16 +374,8 @@ export const useCreatePracticeCheckIn = (practiceId: string) => {
   const mutate = useMutate();
 
   const createCheckIn = async (formData: ICheckInFormData) => {
-    // 創建打卡記錄
+    // 創建打卡記錄（函數會直接拋出錯誤）
     const response = await createPracticeCheckInWithFormData(practiceId, formData);
-
-    if (response.error) {
-      const errorMessage =
-        response.error && typeof response.error === "object" && "message" in response.error
-          ? String(response.error.message)
-          : "打卡失敗";
-      throw new Error(errorMessage);
-    }
 
     // 刷新打卡列表的 cache
     await mutate([

--- a/packages/api/src/services/user-hooks.ts
+++ b/packages/api/src/services/user-hooks.ts
@@ -11,8 +11,10 @@ import type {
   CreateUserRequest,
   IGetUsersParams,
   UpdatePreferencesRequest,
+  UpdateUserFormDataRequest,
   UpdateUserRequest,
 } from "./user";
+import { updateCurrentUserWithFormData } from "./user";
 
 // ============================================================================
 // Query Hooks
@@ -132,12 +134,24 @@ export const useAvailablePreferences = () => {
 export const useUserMutations = () => {
   return {
     /**
-     * 更新當前用戶資訊
+     * 更新當前用戶資訊（JSON 格式，不支援檔案上傳）
      */
     updateCurrentUser: async (data: UpdateUserRequest) => {
       return client.PUT("/api/v1/users/me", {
         body: data,
       });
+    },
+
+    /**
+     * 更新當前用戶資訊（FormData 格式，支援圖片上傳）
+     * @param data 用戶資料
+     * @param photoFile 可選的頭像圖片檔案
+     */
+    updateCurrentUserWithFormData: async (
+      data: UpdateUserFormDataRequest,
+      photoFile?: File
+    ) => {
+      return updateCurrentUserWithFormData(data, photoFile);
     },
 
     /**

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -3,7 +3,8 @@
  * 提供用戶相關的 API 調用函數和 Hooks
  */
 
-import { client } from "../client";
+import { getRequiredEnv } from "@daodao/config";
+import { client, unauthorizedHandler } from "../client";
 import type { components, paths } from "../types";
 
 // ============================================================================
@@ -119,12 +120,127 @@ export const getCurrentUser = async () => {
 };
 
 /**
- * 更新當前用戶資訊
+ * 更新當前用戶資訊（JSON 格式，不支援檔案上傳）
  */
 export const updateCurrentUser = async (data: UpdateUserRequest) => {
   return client.PUT("/api/v1/users/me", {
     body: data,
   });
+};
+
+/**
+ * 更新用戶 API 回應類型
+ */
+type UpdateUserResponse =
+  paths["/api/v1/users/me"]["put"]["responses"]["200"]["content"]["application/json"];
+
+/**
+ * FormData 版本的更新用戶請求類型
+ * 支援直接傳送檔案
+ */
+export interface UpdateUserFormDataRequest {
+  name?: string;
+  customId?: string;
+  location?: string;
+  gender?: string;
+  birthDay?: string;
+  selfIntroduction?: string;
+  personalSlogan?: string;
+  isOpenLocation?: boolean;
+  isOpenProfile?: boolean;
+  isSubscribeEmail?: boolean;
+  tagList?: string[];
+  roleList?: string[];
+  interestList?: string[];
+  contactList?: {
+    instagram?: string;
+    discord?: string;
+    line?: string;
+    facebook?: string;
+    threads?: string;
+    linkedin?: string;
+    website?: string;
+    github?: string;
+  };
+  wantToDoList?: string[];
+  professionalField?: string[];
+  educationStage?: string;
+  share?: string | string[];
+  preferences?: Record<string, string[]>;
+  referralSource?: string;
+}
+
+/**
+ * 更新當前用戶資訊（FormData 格式，支援圖片上傳）
+ * @param data 用戶資料
+ * @param photoFile 可選的頭像圖片檔案
+ * @returns 更新結果
+ */
+export const updateCurrentUserWithFormData = async (
+  data: UpdateUserFormDataRequest,
+  photoFile?: File
+): Promise<UpdateUserResponse> => {
+  const formData = new FormData();
+
+  // 基本欄位（string）
+  if (data.name) formData.append("name", data.name);
+  if (data.customId) formData.append("customId", data.customId);
+  if (data.location) formData.append("location", data.location);
+  if (data.gender) formData.append("gender", data.gender);
+  if (data.birthDay) formData.append("birthDay", data.birthDay);
+  if (data.selfIntroduction) formData.append("selfIntroduction", data.selfIntroduction);
+  if (data.personalSlogan) formData.append("personalSlogan", data.personalSlogan);
+
+  // Boolean 欄位需轉成字串
+  if (data.isOpenLocation !== undefined) {
+    formData.append("isOpenLocation", String(data.isOpenLocation));
+  }
+  if (data.isOpenProfile !== undefined) {
+    formData.append("isOpenProfile", String(data.isOpenProfile));
+  }
+  if (data.isSubscribeEmail !== undefined) {
+    formData.append("isSubscribeEmail", String(data.isSubscribeEmail));
+  }
+
+  // 其他 string 欄位
+  if (data.educationStage) formData.append("educationStage", data.educationStage);
+  if (data.referralSource) formData.append("referralSource", data.referralSource);
+
+  // 陣列/物件欄位需轉成 JSON 字串
+  if (data.tagList) formData.append("tagList", JSON.stringify(data.tagList));
+  if (data.roleList) formData.append("roleList", JSON.stringify(data.roleList));
+  if (data.interestList) formData.append("interestList", JSON.stringify(data.interestList));
+  if (data.contactList) formData.append("contactList", JSON.stringify(data.contactList));
+  if (data.wantToDoList) formData.append("wantToDoList", JSON.stringify(data.wantToDoList));
+  if (data.professionalField) formData.append("professionalField", JSON.stringify(data.professionalField));
+  if (data.share) formData.append("share", JSON.stringify(data.share));
+  if (data.preferences) formData.append("preferences", JSON.stringify(data.preferences));
+
+  // 圖片檔案（後端期望欄位名為 'avatar'）
+  if (photoFile) formData.append("avatar", photoFile);
+
+  const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
+  const response = await unauthorizedHandler.wrapFetch(`${baseUrl}/api/v1/users/me`, {
+    method: "PUT",
+    body: formData,
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({
+      error: { message: "更新失敗" },
+    }));
+    const error = new Error(errorData.error?.message || "更新失敗") as Error & {
+      details?: Array<{ path?: string; message?: string }>;
+    };
+    // 附加驗證錯誤詳情（供表單使用）
+    if (errorData.error?.details && Array.isArray(errorData.error.details)) {
+      error.details = errorData.error.details;
+    }
+    throw error;
+  }
+
+  return response.json();
 };
 
 /**
@@ -235,6 +351,7 @@ export type {
   UserListResponse,
   CreateUserRequest,
   UpdateUserRequest,
+  UpdateUserResponse,
   UpdatePreferencesRequest,
   UserPreferencesResponse,
   AvailablePreferencesResponse,


### PR DESCRIPTION
## Why is this necessary?
  1. 圖片上傳交易性問題：原本打卡和用戶資料更新是先上傳圖片，再呼叫 API，若 API 失敗會產生孤立圖片                                                              
  2. 設定頁面功能不完整：缺少 LINE、Threads 社群連結欄位，以及 customId 即時檢查功能                                                                            
  3. UI/UX 問題修正：                                                                                                                                           
    - 建立實踐成功頁顯示佔位符文字「鼓勵文字鼓勵文字...」                                                                                                       
    - 首頁未顯示最後打卡日期                                                                                                                                    
    - 實踐詳情頁返回按鈕行為不正確                                                                                                                              
  4. 程式碼警告：React key prop 警告 


## How does it address?
  1. 重構 API 為 FormData 統一提交：                                                                                                                            
    - createPracticeCheckInWithFormData：打卡 API 改用 FormData，由後端處理圖片上傳（確保交易性）                                                               
    - updateCurrentUserWithFormData：用戶資料更新 API 改用 FormData，支援頭像上傳                                                                               
  2. 設定頁面增強：                                                                                                                                             
    - basic-info-section.tsx：新增 customId 即時可用性檢查（debounced 300ms）                                                                                   
    - social-links-section.tsx：新增 LINE 和 Threads 輸入欄位                                                                                                   
    - public-info-form.tsx：重構表單提交邏輯，使用新的 FormData API                                                                                             
  3. UI 修正：                                                                                                                                                  
    - 更新成功頁鼓勵文字為正式內容                                                                                                                              
    - 首頁正確解析 lastCheckinAt 並顯示                                                                                                                         
    - 實踐詳情頁返回按鈕導航至首頁                                                                                                                              
    - 修復 check-in-stack.tsx React key 警告                                                                                                                    
  4. 暫時移除刪除打卡功能（目前沒有這個需求）  