### PR TITLE
feat(practice): display resources section on practice detail page

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   type ManualPracticeFormValues,
   PracticeDetailTitle,
   PracticeOverviewCard,
+  ResourceCard,
 } from "@/components/practice";
 import {
   DurationDays,
@@ -62,9 +63,10 @@ export default function PracticeDetailPage() {
 
   // 將 API 資料轉換為頁面需要的格式
   const practice:
-    | (ManualPracticeFormValues & {
+    | (Omit<ManualPracticeFormValues, "resources"> & {
         total: number;
         currentProgress: number;
+        resources: { id: string; name: string; url?: string }[];
       })
     | null = useMemo(() => {
     if (!practiceData?.data) {
@@ -129,7 +131,11 @@ export default function PracticeDetailPage() {
 
       // Step 4
       tags: data.tags || [],
-      resources: [], // TODO: 需要從 API 取得資源列表
+      resources: (data.resources || []).map((resource) => ({
+        id: resource.id,
+        name: resource.name,
+        url: resource.url,
+      })),
 
       total: data.durationDays ?? 0,
       currentProgress: data.progressPercentage ?? 0,
@@ -300,6 +306,22 @@ export default function PracticeDetailPage() {
             showRemaining
           />
         </div>
+
+        {/* Resources Section */}
+        {practice.resources.length > 0 && (
+          <div className="mb-6">
+            <p className="text-base font-medium text-text-dark mb-4">使用的資源</p>
+            <div className="grid grid-cols-2 gap-3">
+              {practice.resources.map((resource) => (
+                <ResourceCard
+                  key={resource.id}
+                  resource={resource}
+                  onClick={resource.url ? () => window.open(resource.url, "_blank") : undefined}
+                />
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Check-in Record Card */}
         <CheckInRecordCard checkInsData={checkInsData} isLoading={isLoadingCheckIns} />

--- a/apps/product/src/app/[locale]/practices/create/template/[templateId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/template/[templateId]/page.tsx
@@ -104,7 +104,11 @@ const convertTemplateToFormValues = (template: PracticeTemplateType): ManualPrac
 
     // Step 4
     tags: template.suggestedTags || [],
-    resources: [], // API 目前沒有 resources，先設為空陣列
+    resources: (template.resources || []).map((resource) => ({
+      id: resource.id,
+      name: resource.name,
+      url: resource.url,
+    }))
   };
 };
 


### PR DESCRIPTION
## Why is this necessary?

  練習詳情頁面原先無法顯示與練習相關聯的資源列表。雖然 API 已經回傳 resources                                                                                        
  資料，但前端沒有正確映射和顯示這些資源，導致使用者無法查看練習所需的參考資源（如文章、影片、網站連結等）。 

## How does it address?

  1. 新增 ResourceCard 元件：在練習詳情頁 (practices/[id]/page.tsx) 引入 ResourceCard 元件來顯示資源卡片                                                             
  2. 正確映射 API 資料：將 API 回傳的 resources 陣列轉換為前端所需的格式（包含 id、name、url）                                                                       
  3. 新增資源區塊 UI：在頁面中新增「使用的資源」區塊，以 2 欄 grid 佈局顯示資源卡片，點擊有 URL 的資源會在新分頁開啟                                                 
  4. 同步修正模板頁面：更新 practices/create/template/[templateId]/page.tsx 的資料轉換邏輯，確保從模板建立練習時也能正確帶入資源資料    

