### PR TITLE
feat: Map API resources to form format in practice edit page

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -134,8 +134,11 @@ export default function EditPracticePage() {
       executionTiming.length > 0 ? executionTiming : [ExecutionTiming.morning];
 
     // 轉換 resources: API 格式 -> 表單格式
-    // 注意：API 回應中目前沒有 resources 欄位，暫時設為空陣列
-    const resources: Array<{ id: string; name: string; url: string }> = [];
+    const resources = (data.resources || []).map((resource) => ({
+      id: resource.id,
+      name: resource.name,
+      url: resource.url || "",
+    }));
 
     return {
       name: data.title || "",


### PR DESCRIPTION
## Why is this necessary?

The practice edit page was previously hardcoding an empty array for resources during form initialization, ignoring any resources data returned from the API. This change enables the form to properly display and edit existing resources by mapping the API response data to the form's expected format.

## How does it address?

- **Changed**: Replaced the hardcoded empty array with a dynamic mapping function that transforms API resource objects into the form format
- **Implementation**: Uses optional chaining (`data.resources || []`) to safely handle cases where resources may not be present in the API response
- **Data mapping**: Maps each resource's `id`, `name`, and `url` properties, with a fallback to empty string for missing `url` values
- **Impact**: Users can now see and edit existing resources when opening a practice for editing, instead of always starting with an empty resources list

The change is backward compatible - if the API response doesn't include resources, it gracefully falls back to an empty array as before.

https://claude.ai/code/session_01SnRwb1FYnC64xMissQcrCN