### PR TITLE
Allow editing practice start date within creation date range

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -10,7 +10,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { BackgroundAnimation, PageHeader } from "@/components/layout";
-import { type ManualPracticeFormValues, manualPracticeFormSchema } from "@/components/practice";
+import { type ManualPracticeFormValues, createManualPracticeFormSchema } from "@/components/practice";
 import { Step1 } from "@/components/practice/create/manual/steps/step-1";
 import { Step2 } from "@/components/practice/create/manual/steps/step-2";
 import { Step3 } from "@/components/practice/create/manual/steps/step-3";
@@ -85,6 +85,19 @@ export default function EditPracticePage() {
   const isPracticeStarted = useMemo(() => {
     return practiceData?.data?.status === PracticeStatus.active;
   }, [practiceData?.data?.status]);
+
+  // 取得實踐的創建日期，用於日期驗證的最小日期
+  const minStartDate = useMemo(() => {
+    if (practiceData?.data?.createdAt) {
+      return new Date(practiceData.data.createdAt);
+    }
+    return new Date();
+  }, [practiceData?.data?.createdAt]);
+
+  // 使用創建日期作為最小日期來創建 schema
+  const formSchema = useMemo(() => {
+    return createManualPracticeFormSchema({ minStartDate });
+  }, [minStartDate]);
 
   // 將 API 資料轉換為表單值
   const formValues: ManualPracticeFormValues | null = useMemo(() => {
@@ -171,7 +184,7 @@ export default function EditPracticePage() {
   }, []);
 
   const form = useForm<ManualPracticeFormValues>({
-    resolver: zodResolver(manualPracticeFormSchema),
+    resolver: zodResolver(formSchema),
     mode: "onSubmit",
     defaultValues: initialFormValues,
   });
@@ -254,7 +267,7 @@ export default function EditPracticePage() {
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
             <Step1 form={form} />
-            <Step2 form={form} disabled={isPracticeStarted} />
+            <Step2 form={form} disabled={isPracticeStarted} minStartDate={minStartDate} />
             <Step3 form={form} />
             <Step4 form={form} />
 

--- a/apps/product/src/app/[locale]/practices/create/manual/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/manual/page.tsx
@@ -10,10 +10,10 @@ import { Progress } from "@daodao/ui/components/progress";
 import { toast } from "@daodao/ui/components/sonner";
 import { useNavigationBlockerEffect } from "@daodao/ui/hooks/navigation-blocker";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { BackgroundAnimation, PageHeader } from "@/components/layout";
-import { type ManualPracticeFormValues, createManualPracticeFormSchema } from "@/components/practice";
+import { type ManualPracticeFormValues, manualPracticeFormSchema } from "@/components/practice";
 import { Step1 } from "@/components/practice/create/manual/steps/step-1";
 import { Step2 } from "@/components/practice/create/manual/steps/step-2";
 import { Step3 } from "@/components/practice/create/manual/steps/step-3";
@@ -93,11 +93,8 @@ export default function CreateManualPracticePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isRestoreDialogOpenRef = useRef(false);
 
-  // 動態創建 schema，確保 minDate 是當前日期
-  const formSchema = useMemo(() => createManualPracticeFormSchema(), []);
-
   const form = useForm<ManualPracticeFormValues>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(manualPracticeFormSchema),
     defaultValues: defaultFormValues as ManualPracticeFormValues,
     mode: "onSubmit",
   });

--- a/apps/product/src/app/[locale]/practices/create/manual/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/manual/page.tsx
@@ -10,10 +10,10 @@ import { Progress } from "@daodao/ui/components/progress";
 import { toast } from "@daodao/ui/components/sonner";
 import { useNavigationBlockerEffect } from "@daodao/ui/hooks/navigation-blocker";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { BackgroundAnimation, PageHeader } from "@/components/layout";
-import { type ManualPracticeFormValues, manualPracticeFormSchema } from "@/components/practice";
+import { type ManualPracticeFormValues, createManualPracticeFormSchema } from "@/components/practice";
 import { Step1 } from "@/components/practice/create/manual/steps/step-1";
 import { Step2 } from "@/components/practice/create/manual/steps/step-2";
 import { Step3 } from "@/components/practice/create/manual/steps/step-3";
@@ -93,8 +93,11 @@ export default function CreateManualPracticePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isRestoreDialogOpenRef = useRef(false);
 
+  // 動態創建 schema，確保 minDate 是當前日期
+  const formSchema = useMemo(() => createManualPracticeFormSchema(), []);
+
   const form = useForm<ManualPracticeFormValues>({
-    resolver: zodResolver(manualPracticeFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: defaultFormValues as ManualPracticeFormValues,
     mode: "onSubmit",
   });

--- a/apps/product/src/components/practice/create/manual/schema.ts
+++ b/apps/product/src/components/practice/create/manual/schema.ts
@@ -52,14 +52,16 @@ export const EXECUTION_TIMING_OPTIONS = [
   { value: ExecutionTiming.beforeSleep, label: "睡前" },
 ] as const;
 
-// Form Schema
-export const manualPracticeFormSchema = z.object({
-  // Step 1
-  name: z.string().min(1, "請輸入名稱"),
-  actionDescription: z.string().min(1, "請輸入實踐行動").max(50, "最多50字").default(""),
+// Schema 選項
+export interface ManualPracticeSchemaOptions {
+  // 開始日期的最小日期限制（預設為今天）
+  // 編輯模式時可設為實踐的創建日期，允許保留原有的開始日期
+  minStartDate?: Date;
+}
 
-  // Step 2
-  startDate: z
+// 建立開始日期驗證 schema
+const createStartDateSchema = (minDate: Date) => {
+  return z
     .string()
     .min(1, "請選擇開始時間")
     .refine(
@@ -67,20 +69,21 @@ export const manualPracticeFormSchema = z.object({
         if (!val) return false;
         const date = parse(val, "yyyy-MM-dd", new Date());
         if (!isValid(date)) return false;
-        const today = startOfDay(new Date());
+        const minDateStartOfDay = startOfDay(minDate);
         const maxDate = startOfDay(addDays(new Date(), 14));
         const dateStartOfDay = startOfDay(date);
-        return !isBefore(dateStartOfDay, today) && !isAfter(dateStartOfDay, maxDate);
+        return !isBefore(dateStartOfDay, minDateStartOfDay) && !isAfter(dateStartOfDay, maxDate);
       },
       (val) => {
         if (!val) return { message: "請選擇開始時間" };
         const date = parse(val, "yyyy-MM-dd", new Date());
         if (!isValid(date)) return { message: "請選擇有效的日期" };
-        const today = startOfDay(new Date());
+        const minDateStartOfDay = startOfDay(minDate);
         const maxDate = startOfDay(addDays(new Date(), 14));
         const dateStartOfDay = startOfDay(date);
-        if (isBefore(dateStartOfDay, today)) {
-          return { message: "日期不能早於今天" };
+        if (isBefore(dateStartOfDay, minDateStartOfDay)) {
+          const minDateFormatted = format(minDateStartOfDay, "yyyy/MM/dd");
+          return { message: `日期不能早於 ${minDateFormatted}` };
         }
         if (isAfter(dateStartOfDay, maxDate)) {
           const maxDateFormatted = format(maxDate, "yyyy/MM/dd");
@@ -88,37 +91,54 @@ export const manualPracticeFormSchema = z.object({
         }
         return { message: "日期不在允許的範圍內" };
       }
-    ),
-  durationDays: z.nativeEnum(DurationDays, {
-    required_error: "請選擇想要持續多久",
-  }),
-  frequency: z.nativeEnum(Frequency, {
-    required_error: "請選擇每週實踐頻率",
-  }),
+    );
+};
 
-  // Step 3
-  durationMinutes: z.number(),
-  executionTiming: z.array(z.nativeEnum(ExecutionTiming)).min(1, "請至少選擇一個執行時機"),
-  customTiming: z.string(),
+// Form Schema 工廠函數
+export const createManualPracticeFormSchema = (options?: ManualPracticeSchemaOptions) => {
+  const minStartDate = options?.minStartDate ?? new Date();
 
-  // Step 4
-  tags: z.array(z.string()).max(MAX_PRACTICE_TAGS, `標籤最多 ${MAX_PRACTICE_TAGS} 個`).optional(),
-  resources: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string().min(1, "請輸入資源名稱"),
-        url: z
-          .string()
-          .url("請輸入有效的網址")
-          .refine((val) => !val || val.startsWith("https://"), {
-            message: "網址必須使用 HTTPS",
-          })
-          .optional()
-          .or(z.literal("")),
-      })
-    )
-    .optional(),
-});
+  return z.object({
+    // Step 1
+    name: z.string().min(1, "請輸入名稱"),
+    actionDescription: z.string().min(1, "請輸入實踐行動").max(50, "最多50字").default(""),
+
+    // Step 2
+    startDate: createStartDateSchema(minStartDate),
+    durationDays: z.nativeEnum(DurationDays, {
+      required_error: "請選擇想要持續多久",
+    }),
+    frequency: z.nativeEnum(Frequency, {
+      required_error: "請選擇每週實踐頻率",
+    }),
+
+    // Step 3
+    durationMinutes: z.number(),
+    executionTiming: z.array(z.nativeEnum(ExecutionTiming)).min(1, "請至少選擇一個執行時機"),
+    customTiming: z.string(),
+
+    // Step 4
+    tags: z.array(z.string()).max(MAX_PRACTICE_TAGS, `標籤最多 ${MAX_PRACTICE_TAGS} 個`).optional(),
+    resources: z
+      .array(
+        z.object({
+          id: z.string(),
+          name: z.string().min(1, "請輸入資源名稱"),
+          url: z
+            .string()
+            .url("請輸入有效的網址")
+            .refine((val) => !val || val.startsWith("https://"), {
+              message: "網址必須使用 HTTPS",
+            })
+            .optional()
+            .or(z.literal("")),
+        })
+      )
+      .optional(),
+  });
+};
+
+// 預設 schema（用於創建模式）
+export const manualPracticeFormSchema = createManualPracticeFormSchema();
 
 export type ManualPracticeFormValues = z.infer<typeof manualPracticeFormSchema>;

--- a/apps/product/src/components/practice/create/manual/schema.ts
+++ b/apps/product/src/components/practice/create/manual/schema.ts
@@ -54,13 +54,15 @@ export const EXECUTION_TIMING_OPTIONS = [
 
 // Schema 選項
 export interface ManualPracticeSchemaOptions {
-  // 開始日期的最小日期限制（預設為今天）
+  // 開始日期的最小日期限制
   // 編輯模式時可設為實踐的創建日期，允許保留原有的開始日期
+  // 如果未提供，驗證時會動態使用當前日期
   minStartDate?: Date;
 }
 
 // 建立開始日期驗證 schema
-const createStartDateSchema = (minDate: Date) => {
+// minDate 為可選參數，若未提供則在驗證時使用當前日期（確保跨午夜時仍正確）
+const createStartDateSchema = (minDate?: Date) => {
   return z
     .string()
     .min(1, "請選擇開始時間")
@@ -69,7 +71,8 @@ const createStartDateSchema = (minDate: Date) => {
         if (!val) return false;
         const date = parse(val, "yyyy-MM-dd", new Date());
         if (!isValid(date)) return false;
-        const minDateStartOfDay = startOfDay(minDate);
+        // 若有指定 minDate 則使用，否則使用當前日期
+        const minDateStartOfDay = startOfDay(minDate ?? new Date());
         const maxDate = startOfDay(addDays(new Date(), 14));
         const dateStartOfDay = startOfDay(date);
         return !isBefore(dateStartOfDay, minDateStartOfDay) && !isAfter(dateStartOfDay, maxDate);
@@ -78,10 +81,15 @@ const createStartDateSchema = (minDate: Date) => {
         if (!val) return { message: "請選擇開始時間" };
         const date = parse(val, "yyyy-MM-dd", new Date());
         if (!isValid(date)) return { message: "請選擇有效的日期" };
-        const minDateStartOfDay = startOfDay(minDate);
+        // 若有指定 minDate 則使用，否則使用當前日期
+        const minDateStartOfDay = startOfDay(minDate ?? new Date());
         const maxDate = startOfDay(addDays(new Date(), 14));
         const dateStartOfDay = startOfDay(date);
         if (isBefore(dateStartOfDay, minDateStartOfDay)) {
+          // 若是動態日期（今天），顯示「今天」；若是指定日期，顯示具體日期
+          if (!minDate) {
+            return { message: "日期不能早於今天" };
+          }
           const minDateFormatted = format(minDateStartOfDay, "yyyy/MM/dd");
           return { message: `日期不能早於 ${minDateFormatted}` };
         }
@@ -96,7 +104,8 @@ const createStartDateSchema = (minDate: Date) => {
 
 // Form Schema 工廠函數
 export const createManualPracticeFormSchema = (options?: ManualPracticeSchemaOptions) => {
-  const minStartDate = options?.minStartDate ?? new Date();
+  // 不提供預設值，讓 createStartDateSchema 在驗證時動態決定
+  const minStartDate = options?.minStartDate;
 
   return z.object({
     // Step 1

--- a/apps/product/src/components/practice/create/manual/steps/step-2.tsx
+++ b/apps/product/src/components/practice/create/manual/steps/step-2.tsx
@@ -18,9 +18,10 @@ import { DURATION_DAYS_OPTIONS, FREQUENCY_OPTIONS, type ManualPracticeFormValues
 interface Step2Props {
   form: UseFormReturn<ManualPracticeFormValues>;
   disabled?: boolean;
+  minStartDate?: Date;
 }
 
-export const Step2 = ({ form, disabled = false }: Step2Props) => {
+export const Step2 = ({ form, disabled = false, minStartDate }: Step2Props) => {
   const startDate = form.watch("startDate");
   const durationDays = form.watch("durationDays");
 
@@ -54,7 +55,7 @@ export const Step2 = ({ form, disabled = false }: Step2Props) => {
                   placeholder="選擇日期"
                   disabled={disabled}
                   onBlur={field.onBlur}
-                  minDate={new Date()}
+                  minDate={minStartDate ?? new Date()}
                   maxDate={addDays(new Date(), 14)}
                   onError={(errorMessage) => {
                     form.setError("startDate", { message: errorMessage });


### PR DESCRIPTION
## Why is this necessary?

When editing an existing practice, users should be able to keep or adjust the original start date without being restricted to today's date. Currently, the form validation only allows selecting dates from today onwards, which prevents users from maintaining the original start date if they edit the practice after creation.

This change enables a better editing experience by allowing start dates within a valid range based on when the practice was created, rather than forcing users to select a date from today onwards.

## How does it address?

### Main Changes:

1. **Refactored schema into a factory function** (`createManualPracticeFormSchema`)
   - Converted the static `manualPracticeFormSchema` into a factory function that accepts configuration options
   - Added `ManualPracticeSchemaOptions` interface to support `minStartDate` parameter
   - The factory function now generates dynamic validation rules based on the provided minimum date

2. **Dynamic date validation**
   - Extracted `createStartDateSchema` helper function that creates date validation logic
   - The validation now checks against a configurable `minStartDate` instead of hardcoded "today"
   - Error messages dynamically display the minimum allowed date when validation fails

3. **Updated edit page to use creation date as minimum**
   - Added `minStartDate` memo that retrieves the practice's creation date from API data
   - Generates the form schema dynamically using the creation date as the minimum allowed start date
   - Passes `minStartDate` to the `Step2` component for UI date picker constraints

4. **Updated Step2 component**
   - Added `minStartDate` prop to the component interface
   - Uses the provided `minStartDate` for the date picker's minimum date constraint
   - Falls back to today's date if not provided (for create mode)

5. **Maintained backward compatibility**
   - Exported a default `manualPracticeFormSchema` that uses today's date as minimum
   - This ensures create mode continues to work without changes
   - Existing code using the old schema reference continues to function

### Impact:
- **Edit mode**: Users can now select start dates from the practice creation date up to 14 days in the future
- **Create mode**: Unchanged behavior - users can select dates from today up to 14 days in the future
- **No breaking changes**: All existing imports and usage patterns remain compatible

https://claude.ai/code/session_01NgVtqyzHy8fSpPP1FdsQKz