### PR TITLE
fix(quiz): save quiz results to backend when user is authenticated

### DIFF
--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -342,6 +342,27 @@ export const getLatestQuizResult = async () => {
   return client.GET("/api/v1/quiz/latest");
 };
 
+/**
+ * 保存測驗結果請求類型
+ */
+type SaveQuizResultRequest = components["schemas"]["SaveQuizResultRequest"];
+
+/**
+ * 保存測驗結果回應類型
+ */
+type SaveQuizResultResponse =
+  paths["/api/v1/quiz"]["post"]["responses"]["201"]["content"]["application/json"];
+
+/**
+ * 保存當前用戶的測驗結果
+ * @param data 測驗結果數據，包括 resultType、scores 和 answers
+ */
+export const saveQuizResult = async (data: SaveQuizResultRequest) => {
+  return client.POST("/api/v1/quiz", {
+    body: data,
+  });
+};
+
 // ============================================================================
 // Export Types
 // ============================================================================
@@ -359,4 +380,6 @@ export type {
   PreferenceCategory,
   PreferenceType,
   PreferenceOption,
+  SaveQuizResultRequest,
+  SaveQuizResultResponse,
 };

--- a/packages/features/quiz/src/components/quiz-result.tsx
+++ b/packages/features/quiz/src/components/quiz-result.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { saveQuizResult } from "@daodao/api";
 import { HorizontalFullSvg, VerticalFullSvg } from "@daodao/assets";
 import favicon256Png from "@daodao/assets/images/brand/favicon256.png";
-import { AuthButton } from "@daodao/auth";
+import { AuthButton, useAuth } from "@daodao/auth";
 import { useRouter } from "@daodao/i18n/navigation";
 import {
   type CapturedImageData,
@@ -20,8 +21,10 @@ import { List, Slogan, Title } from "./styled";
 
 export const QuizResult = () => {
   const router = useRouter();
+  const { isAuthenticated } = useAuth();
   const [resultImg, setResultImg] = useState<CapturedImageData | null>(null);
-  const { detail, theme, analysis, hasAnalysis } = useQuiz();
+  const [hasSavedResult, setHasSavedResult] = useState(false);
+  const { detail, theme, analysis, hasAnalysis, result } = useQuiz();
   const { rootStyle } = useResultStyles(theme);
   const mainRef = useRef<HTMLDivElement>(null);
 
@@ -50,6 +53,36 @@ export const QuizResult = () => {
       clearTimeout(timer);
     };
   }, [hasAnalysis, router]);
+
+  // 當用戶已登入且有測驗結果時，自動儲存到後端
+  useEffect(() => {
+    const saveResult = async () => {
+      if (!isAuthenticated || !hasAnalysis || !detail || hasSavedResult) {
+        return;
+      }
+
+      try {
+        // 轉換答案格式：從 { q1: { selectedAnswer: 'A' } } 轉為 { "1": { selectedAnswer: "A" } }
+        const formattedAnswers: Record<string, { selectedAnswer: string }> = {};
+        for (const [questionId, answer] of Object.entries(result)) {
+          const questionNumber = questionId.replace("q", "");
+          formattedAnswers[questionNumber] = { selectedAnswer: answer.selectedAnswer };
+        }
+
+        await saveQuizResult({
+          resultType: detail.id,
+          scores: analysis,
+          answers: formattedAnswers,
+        });
+        setHasSavedResult(true);
+      } catch (error) {
+        // 儲存失敗時靜默處理，不影響用戶體驗
+        console.error("Failed to save quiz result:", error);
+      }
+    };
+
+    saveResult();
+  }, [isAuthenticated, hasAnalysis, detail, hasSavedResult, result, analysis]);
 
   useEffect(() => {
     const renderResultImg = async () => {


### PR DESCRIPTION
Previously, quiz results were only stored in local storage and not
persisted to the backend. This fix adds automatic saving of quiz
results when:
- User is authenticated
- Quiz has been completed (hasAnalysis is true)

Changes:
- Add saveQuizResult API function in user.ts
- Call saveQuizResult in QuizResult component via useEffect
- Use hasSavedResult state to prevent duplicate saves

https://claude.ai/code/session_011RyRr4ZecpVXokyGMbqK6A