### PR TITLE
Use dedicated unarchive API endpoint for practice restoration

### DIFF
--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -475,9 +475,15 @@ export const useUnarchivePractice = () => {
   const mutate = useMutate();
 
   const unarchivePractice = async (practiceId: string) => {
-    const response = await updatePractice(practiceId, {
-      status: "active",
-    } as UpdatePracticeRequestType);
+    // 使用專門的 unarchive API 端點，而不是 PUT 更新狀態
+    // 後端會根據是否有打卡記錄自動決定恢復後的狀態（active 或 not_started）
+    const response = await client.POST("/api/v1/practices/{id}/unarchive", {
+      params: {
+        path: {
+          id: practiceId,
+        },
+      },
+    });
 
     if (response.error) {
       const errorMessage =


### PR DESCRIPTION
## Why is this necessary?

The current implementation uses a generic `updatePractice` call to set the status to "active" when unarchiving a practice. However, the backend needs to intelligently determine the appropriate status based on whether the practice has any time tracking records. Using a dedicated unarchive endpoint allows the backend to handle this logic properly and restore practices to the correct state (either "active" or "not_started").

## How does it address?

- Replaced the generic `updatePractice` call with a dedicated `POST /api/v1/practices/{id}/unarchive` endpoint
- The backend now automatically determines the correct status based on existing time tracking records
- Added clarifying comments explaining the new behavior
- Maintains the same error handling and response structure as before

**Main changes:**
- Changed from `PUT` request (via `updatePractice`) to `POST` request (via dedicated unarchive endpoint)
- Backend now has control over the final status of unarchived practices
- Improved separation of concerns by using a specialized endpoint instead of a generic update

**Impact on existing code:**
- No breaking changes to the frontend API
- The unarchive operation now behaves more intelligently based on practice history
- Error handling remains unchanged

## Screenshots/Demo

N/A - Backend API behavior change

https://claude.ai/code/session_01PtSgtXagyscLwaCdy1yAvP