### PR TITLE
Use dedicated unarchive API endpoint for practice restoration

### DIFF
--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -6,7 +6,6 @@
  */
 
 import { getRequiredEnv } from "@daodao/config";
-import { useRef } from "react";
 import { client, unauthorizedHandler } from "../client";
 import { useMutate, useQuery } from "../hooks";
 import type { components, paths } from "../types";
@@ -405,15 +404,8 @@ export const useCreatePracticeCheckIn = (practiceId: string) => {
  */
 export const useArchivePractice = (practiceId: string) => {
   const mutate = useMutate();
-  const { data: practiceData } = usePracticeById(practiceId);
-
-  // 使用 useRef 保存原始狀態，供復原時使用
-  const originalStatusRef = useRef<string | null>(null);
 
   const archivePractice = async () => {
-    // 先獲取當前狀態作為原始狀態
-    originalStatusRef.current = practiceData?.data?.status || "active";
-
     const response = await updatePractice(practiceId, {
       status: "archived",
     } as UpdatePracticeRequestType);
@@ -453,9 +445,6 @@ export const useArchivePractice = (practiceId: string) => {
 
     // 刷新相關的 cache
     await refreshPracticeCaches(mutate, practiceId);
-
-    // 清除保存的原始狀態
-    originalStatusRef.current = null;
 
     return response;
   };

--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -433,18 +433,15 @@ export const useArchivePractice = (practiceId: string) => {
   };
 
   const restorePractice = async () => {
-    if (!originalStatusRef.current) {
-      throw new Error("無法復原：找不到原始狀態");
-    }
-
-    const response = await updatePractice(practiceId, {
-      status: originalStatusRef.current as
-        | "draft"
-        | "not_started"
-        | "active"
-        | "completed"
-        | "archived",
-    } as UpdatePracticeRequestType);
+    // 使用專門的 unarchive API 端點，而不是 PUT 更新狀態
+    // 後端會根據是否有打卡記錄自動決定恢復後的狀態（active 或 not_started）
+    const response = await client.POST("/api/v1/practices/{id}/unarchive", {
+      params: {
+        path: {
+          id: practiceId,
+        },
+      },
+    });
 
     if (response.error) {
       const errorMessage =


### PR DESCRIPTION
## Why is this necessary?

The current implementation of practice restoration relies on storing and restoring the original status in a ref, which is fragile and doesn't account for business logic changes. The backend should have the intelligence to determine the appropriate status when unarchiving a practice based on whether check-in records exist.

## How does it address?

- Replaced the manual status restoration logic with a dedicated `/api/v1/practices/{id}/unarchive` API endpoint
- Removed the dependency on `originalStatusRef.current` which could be undefined or stale
- The backend now automatically determines the correct restored status:
  - `active` if check-in records exist
  - `not_started` if no check-in records exist
- This centralizes the business logic on the backend and makes the frontend simpler and more maintainable
- Eliminates the need to track and manage original status state in the frontend

## Technical Changes

- Modified `restorePractice()` function in `packages/api/src/services/practice-hooks.ts`
- Changed from `updatePractice()` with manual status assignment to direct API call using `client.POST()`
- Removed the error check for missing `originalStatusRef.current`
- Removed the type casting for status field as it's now handled by the backend

https://claude.ai/code/session_01TZSLWziQW1ZzbGUdiaWcyA