### PR TITLE
Improve error handling in practice edit form submission

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -8,7 +8,7 @@ import { toast } from "@daodao/ui/components/sonner";
 import { useNavigationBlockerEffect } from "@daodao/ui/hooks/navigation-blocker";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
-import { useForm } from "react-hook-form";
+import { type Path, useForm } from "react-hook-form";
 import { BackgroundAnimation, PageHeader } from "@/components/layout";
 import { type ManualPracticeFormValues, createManualPracticeFormSchema } from "@/components/practice";
 import { Step1 } from "@/components/practice/create/manual/steps/step-1";
@@ -24,6 +24,15 @@ import {
   parseFrequency,
 } from "@/constants/practice-form";
 import { PracticeStatus } from "@/constants/practice-status";
+
+// API 錯誤響應類型
+interface ApiErrorResponse {
+  error?: {
+    message?: string;
+    details?: Array<{ path?: string; message?: string }>;
+  };
+  message?: string;
+}
 
 // 將表單資料轉換成 API 請求格式
 const convertFormValuesToApiRequest = (
@@ -210,15 +219,7 @@ export default function EditPracticePage() {
 
       // 檢查是否有錯誤
       if (response.error) {
-        // response.error 是整個響應物件，實際錯誤在 response.error.error
-        const errorResponse = response.error as {
-          error?: {
-            message?: string;
-            details?: Array<{ path?: string; message?: string }>;
-          };
-          message?: string;
-        };
-
+        const errorResponse = response.error as ApiErrorResponse;
         const error = errorResponse.error || errorResponse;
         let errorMessage = "儲存失敗，請稍後再試";
 
@@ -231,8 +232,8 @@ export default function EditPracticePage() {
 
             details.forEach((detail) => {
               if (detail.path && detail.message) {
-                // 將錯誤設置到對應的表單欄位
-                form.setError(detail.path as keyof ManualPracticeFormValues, {
+                // 將錯誤設置到對應的表單欄位（使用 Path 支援嵌套路徑如 resources.0.name）
+                form.setError(detail.path as Path<ManualPracticeFormValues>, {
                   type: "server",
                   message: detail.message,
                 });

--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -210,8 +210,48 @@ export default function EditPracticePage() {
 
       // 檢查是否有錯誤
       if (response.error) {
+        // response.error 是整個響應物件，實際錯誤在 response.error.error
+        const errorResponse = response.error as {
+          error?: {
+            message?: string;
+            details?: Array<{ path?: string; message?: string }>;
+          };
+          message?: string;
+        };
+
+        const error = errorResponse.error || errorResponse;
+        let errorMessage = "儲存失敗，請稍後再試";
+
+        // 處理錯誤訊息
+        if (typeof error === "object" && error !== null) {
+          // 檢查是否有 details 陣列
+          if ("details" in error && Array.isArray(error.details)) {
+            // 處理 details 陣列中的每個錯誤
+            const details = error.details;
+
+            details.forEach((detail) => {
+              if (detail.path && detail.message) {
+                // 將錯誤設置到對應的表單欄位
+                form.setError(detail.path as keyof ManualPracticeFormValues, {
+                  type: "server",
+                  message: detail.message,
+                });
+              }
+            });
+
+            // 使用第一個具體錯誤訊息作為 toast 訊息
+            const firstDetail = details[0];
+            if (firstDetail?.message) {
+              errorMessage = firstDetail.message;
+            }
+          } else if ("message" in error && error.message) {
+            // 如果沒有 details，使用頂層 message
+            errorMessage = String(error.message);
+          }
+        }
+
         console.error("Failed to update practice:", response.error);
-        toast.error("儲存失敗，請稍後再試");
+        toast.error(errorMessage);
         setIsSubmitting(false);
         return;
       }


### PR DESCRIPTION
## Why is this necessary?

The current error handling in the practice edit form only displays a generic error message to users, regardless of the actual error details returned from the server. This makes it difficult for users to understand what went wrong and how to fix it. The server response may contain specific validation errors for individual form fields that should be displayed to the user.

## How does it address?

This change enhances the error handling logic to:

1. **Parse nested error responses**: Properly extract error information from the response object structure, handling cases where errors are nested under `response.error.error`

2. **Display field-level validation errors**: When the server returns validation errors in a `details` array with `path` and `message` properties, these are now set as form field errors using `form.setError()`, allowing users to see exactly which fields have issues

3. **Show contextual error messages**: Instead of a generic "儲存失敗，請稍後再試" message, the toast now displays:
   - The first specific validation error message if details are available
   - The top-level error message if no details are provided
   - Falls back to the generic message only if no other message is available

4. **Maintain backward compatibility**: The error handling gracefully handles different error response formats, ensuring the form doesn't break with unexpected error structures

**Main changes:**
- Added TypeScript type definition for the error response structure
- Implemented logic to extract and process the `details` array from server errors
- Set individual form field errors for better UX
- Display the most relevant error message in the toast notification

## Screenshots/Demo

No UI changes - this is an internal improvement to error handling that will be visible when form submission fails with validation errors.

https://claude.ai/code/session_01AYhuwW4fhWBWsGUrSNwihc