### PR TITLE
Fix: Allow editing scheduled practices with past start dates

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import { Form } from "@daodao/ui/components/form";
 import { toast } from "@daodao/ui/components/sonner";
 import { useNavigationBlockerEffect } from "@daodao/ui/hooks/navigation-blocker";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { startOfDay } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { type Path, useForm } from "react-hook-form";
 import { BackgroundAnimation, PageHeader } from "@/components/layout";
@@ -95,15 +96,18 @@ export default function EditPracticePage() {
     return practiceData?.data?.status === PracticeStatus.active;
   }, [practiceData?.data?.status]);
 
-  // 取得實踐的創建日期，用於日期驗證的最小日期
+  // 取得日期驗證的最小日期
+  // 對於已排程的實踐，應該允許保留原本的開始日期（即使已經過去）
   const minStartDate = useMemo(() => {
-    if (practiceData?.data?.createdAt) {
-      return new Date(practiceData.data.createdAt);
-    }
-    return new Date();
-  }, [practiceData?.data?.createdAt]);
+    const today = startOfDay(new Date());
+    const practiceStartDate = practiceData?.data?.startDate
+      ? startOfDay(new Date(practiceData.data.startDate))
+      : today;
 
-  // 使用創建日期作為最小日期來創建 schema
+    return practiceStartDate < today ? practiceStartDate : today;
+  }, [practiceData?.data?.startDate]);
+
+  // 使用 minStartDate 來創建 schema
   const formSchema = useMemo(() => {
     return createManualPracticeFormSchema({ minStartDate });
   }, [minStartDate]);


### PR DESCRIPTION
## Why is this necessary?

When editing a scheduled practice that has already started (past start date), the date picker was preventing users from keeping the original start date. This created a poor user experience where users couldn't save changes to a practice without modifying its start date to today or later.

The previous implementation used the practice creation date as the minimum allowed date, which didn't account for practices that were scheduled in the past but are still active.

## How does it address?

Changed the `minStartDate` logic to:
1. Compare today's date with the practice's original start date
2. Use the earlier of the two dates as the minimum allowed date
3. This allows users to preserve the original start date when editing, even if it's in the past
4. Updated the dependency array from `createdAt` to `startDate` for more accurate reactivity

**Key changes:**
- Replaced `practiceData?.data?.createdAt` with `practiceData?.data?.startDate`
- Added logic to return the minimum of today's date and the practice's original start date
- Updated comments to clarify the new behavior in Traditional Chinese

This ensures that scheduled practices can be edited without forcing a date change, while still preventing users from selecting dates before the practice was originally scheduled to start.

## Screenshots/Demo

No UI changes - this is a logic fix for date validation in the edit form.

https://claude.ai/code/session_01YLL1KJeGZYFjjq6ie81bNz