### PR TITLE
Dynamically load quiz result animations in banner

### DIFF
--- a/apps/product/src/components/dashboard/banner.tsx
+++ b/apps/product/src/components/dashboard/banner.tsx
@@ -68,8 +68,12 @@ export function Banner() {
           if (type !== "A") {
             const defaultLoader = resultTypeToLottiePathMap.get("A");
             if (defaultLoader) {
-              const defaultData = await defaultLoader();
-              setLottieJson(defaultData);
+              try {
+                const defaultData = await defaultLoader();
+                setLottieJson(defaultData);
+              } catch (fallbackError) {
+                console.error("Failed to load fallback Lottie animation:", fallbackError);
+              }
             }
           }
         }

--- a/apps/product/src/components/dashboard/banner.tsx
+++ b/apps/product/src/components/dashboard/banner.tsx
@@ -6,11 +6,85 @@ import {
   MobileBannerSvg,
   mobileIntersectMaskDataUri,
 } from "@daodao/assets";
-import activeShaper2Json from "@daodao/assets/images/quiz/active-shaper-2.json";
+import { getLatestQuizResult } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { resultDetailMap } from "@daodao/features-quiz";
 import { cn } from "@daodao/ui/lib/utils";
 import Lottie from "lottie-react";
+import { useEffect, useState } from "react";
+
+const resultTypeToLottiePathMap = new Map<string, () => Promise<object>>([
+  ["D", () => import("@daodao/assets/images/quiz/deep-explorer-2.json").then((m) => m.default)],
+  ["O", () => import("@daodao/assets/images/quiz/order-builder-2.json").then((m) => m.default)],
+  ["A", () => import("@daodao/assets/images/quiz/active-shaper-2.json").then((m) => m.default)],
+  ["L", () => import("@daodao/assets/images/quiz/liquid-integrator-2.json").then((m) => m.default)],
+  ["C", () => import("@daodao/assets/images/quiz/community-connector-2.json").then((m) => m.default)],
+]);
+
+// 預設的 slogan（當無測驗結果時使用）
+const DEFAULT_SLOGAN = "先做再說，做中學最快！";
 
 export function Banner() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const [resultType, setResultType] = useState<string | null>(null);
+  const [lottieJson, setLottieJson] = useState<object | null>(null);
+  const [isLoadingResult, setIsLoadingResult] = useState(true);
+
+  // 獲取用戶的測驗結果
+  useEffect(() => {
+    const fetchQuizResult = async () => {
+      if (!isAuthenticated || isAuthLoading) {
+        setIsLoadingResult(false);
+        return;
+      }
+
+      try {
+        const response = await getLatestQuizResult();
+        if (response.data?.data?.resultType) {
+          setResultType(response.data.data.resultType.toUpperCase());
+        }
+      } catch (error) {
+        console.error("Failed to fetch quiz result:", error);
+      } finally {
+        setIsLoadingResult(false);
+      }
+    };
+
+    fetchQuizResult();
+  }, [isAuthenticated, isAuthLoading]);
+
+  // 根據結果類型動態加載 Lottie 動畫
+  useEffect(() => {
+    const loadLottie = async () => {
+      const type = resultType || "A"; // 預設使用動動島 (A)
+      const loader = resultTypeToLottiePathMap.get(type);
+      if (loader) {
+        try {
+          const data = await loader();
+          setLottieJson(data);
+        } catch (error) {
+          console.error("Failed to load Lottie animation:", error);
+          // 如果加載失敗，嘗試加載預設的動動島
+          if (type !== "A") {
+            const defaultLoader = resultTypeToLottiePathMap.get("A");
+            if (defaultLoader) {
+              const defaultData = await defaultLoader();
+              setLottieJson(defaultData);
+            }
+          }
+        }
+      }
+    };
+
+    if (!isLoadingResult) {
+      loadLottie();
+    }
+  }, [resultType, isLoadingResult]);
+
+  // 獲取對應的 slogan
+  const slogan = resultType
+    ? resultDetailMap.get(resultType)?.slogan || DEFAULT_SLOGAN
+    : DEFAULT_SLOGAN;
   return (
     <>
       <header
@@ -44,17 +118,21 @@ export function Banner() {
             "md:top-[42%] md:-translate-y-full md:h-10 md:text-[1.125rem]"
           )}
         >
-          先做再說，做中學最快！
-          <div className="md:hidden absolute -bottom-8 left-full w-24 rotate-3">
-            <Lottie animationData={activeShaper2Json} className="*:w-full *:h-full" />
-          </div>
-          <div className="hidden md:block absolute top-4 -right-[27px] size-4.5 rounded-full bg-white/70 border border-white">
-            <div className="absolute -bottom-[11px] -right-3 w-3 h-[11px] rounded-full bg-white/70 border border-white">
-              <div className="absolute -bottom-[30px] left-full w-32 lg:w-[168px] rotate-3">
-                <Lottie animationData={activeShaper2Json} className="*:w-full *:h-full" />
+          {slogan}
+          {lottieJson && (
+            <>
+              <div className="md:hidden absolute -bottom-8 left-full w-24 rotate-3">
+                <Lottie animationData={lottieJson} className="*:w-full *:h-full" />
               </div>
-            </div>
-          </div>
+              <div className="hidden md:block absolute top-4 -right-[27px] size-4.5 rounded-full bg-white/70 border border-white">
+                <div className="absolute -bottom-[11px] -right-3 w-3 h-[11px] rounded-full bg-white/70 border border-white">
+                  <div className="absolute -bottom-[30px] left-full w-32 lg:w-[168px] rotate-3">
+                    <Lottie animationData={lottieJson} className="*:w-full *:h-full" />
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
         </h2>
       </header>
 

--- a/packages/features/quiz/src/utils/store.ts
+++ b/packages/features/quiz/src/utils/store.ts
@@ -49,5 +49,6 @@ export const calculateQuizAnalysis = (
 
 export const getResultId = (analysis: Record<AnswerKeyType, number>): AnswerKeyType => {
   // analysis 物件必定包含所有 AnswerKeyType 鍵，因此排序後直接取第一個元素的鍵
-  return Object.entries(analysis).sort((a, b) => b[1] - a[1])[0][0] as AnswerKeyType;
+  const sorted = Object.entries(analysis).sort((a, b) => b[1] - a[1]);
+  return sorted[0]![0] as AnswerKeyType;
 };

--- a/packages/features/quiz/src/utils/store.ts
+++ b/packages/features/quiz/src/utils/store.ts
@@ -50,5 +50,9 @@ export const calculateQuizAnalysis = (
 export const getResultId = (analysis: Record<AnswerKeyType, number>): AnswerKeyType => {
   // analysis 物件必定包含所有 AnswerKeyType 鍵，因此排序後直接取第一個元素的鍵
   const sorted = Object.entries(analysis).sort((a, b) => b[1] - a[1]);
-  return sorted[0]![0] as AnswerKeyType;
+  const topResult = sorted[0];
+  if (!topResult) {
+    throw new Error("Cannot determine result from an empty analysis object.");
+  }
+  return topResult[0] as AnswerKeyType;
 };


### PR DESCRIPTION
## Why is this necessary?

The banner component currently displays a hardcoded "Active Shaper" animation regardless of the user's actual quiz result type. This change enables the banner to dynamically display the appropriate animation and slogan based on the user's latest quiz result, providing a personalized experience.

## How does it address?

### Main Changes:

1. **Dynamic Quiz Result Fetching**
   - Added `useAuth()` hook to check authentication status
   - Integrated `getLatestQuizResult()` API call to fetch the user's latest quiz result
   - Implemented state management for `resultType`, `lottieJson`, and loading states

2. **Dynamic Lottie Animation Loading**
   - Created `resultTypeToLottiePathMap` to map quiz result types (D, O, A, L, C) to their corresponding Lottie animation files
   - Implemented dynamic import of Lottie JSON files based on result type
   - Added fallback mechanism to load default "Active Shaper" animation if loading fails

3. **Personalized Slogan Display**
   - Integrated `resultDetailMap` from `@daodao/features-quiz` to fetch result-specific slogans
   - Displays default slogan "先做再說，做中學最快！" when no quiz result is available

4. **Code Quality Improvement**
   - Fixed potential null reference issue in `getResultId()` function by adding non-null assertion operator

### Technical Implementation:
- Used two `useEffect` hooks: one for fetching quiz results, another for loading animations
- Conditional rendering of Lottie components only when animation data is available
- Proper error handling and fallback strategies for failed API calls or animation loads

### Impact:
- Non-breaking change - maintains existing UI structure and styling
- Graceful degradation with fallback animations and default slogan
- Improved user experience with personalized content based on quiz results

https://claude.ai/code/session_01KW5BZLnxq1mGmz3GZCDGEt