### PR TITLE
feat(auth): add onboarding flow, email verification, and location

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/users/[identifier]/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/users/[identifier]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata({
 export default async function UserProfilePage({
   params,
 }: PageProps<"/[locale]/users/[identifier]">) {
-  const { identifier } = await params;
+  const { identifier, locale } = await params;
 
   // 使用緩存版本避免重複請求（與 generateMetadata 共享）
   const userResponse = await getCachedUserByIdentifier(identifier);
@@ -93,7 +93,9 @@ export default async function UserProfilePage({
         {/* 用戶個人資訊卡片 */}
         <UserInfoCard
           name={userData.name || "未命名用戶"}
-          location={userData.location || undefined}
+          location={
+            (locale === "en" ? userData.locationNameEn : userData.locationNameZh) || undefined
+          }
           selfIntroduction={userData.selfIntroduction || undefined}
           photoURL={userData.photoURL || undefined}
           socialLinks={userData.contactList || undefined}

--- a/apps/product/src/app/[locale]/auth/onboarding/page.tsx
+++ b/apps/product/src/app/[locale]/auth/onboarding/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { BackgroundAnimation, PageHeader } from "@/components/layout";
+import { OnboardingForm } from "@/components/onboarding";
+import { useAuth } from "@daodao/auth";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+/**
+ * Onboarding 頁面
+ * 新用戶完成註冊後的引導流程
+ */
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading } = useAuth();
+  // 追蹤是否已經初始化過，避免 refreshAuth 導致組件重新掛載
+  const [hasInitialized, setHasInitialized] = useState(false);
+
+  // 初始化完成後記錄狀態
+  useEffect(() => {
+    if (!isLoading && isAuthenticated && !hasInitialized) {
+      setHasInitialized(true);
+    }
+  }, [isLoading, isAuthenticated, hasInitialized]);
+
+  // 未登入則重定向到首頁（只在初次載入時檢查）
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated && !hasInitialized) {
+      router.replace("/");
+    }
+  }, [isLoading, isAuthenticated, hasInitialized, router]);
+
+  // 初次載入時顯示載入狀態（之後不再顯示，避免 OnboardingForm 被卸載）
+  if (!hasInitialized && (isLoading || !isAuthenticated)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="mb-4 text-lg text-text-dark">Loading...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
+      <PageHeader leftAction={null} rightActionTo="/" />
+
+      <BackgroundAnimation />
+
+      <main className="max-w-[448px] mx-auto px-5 pb-[128px] pt-3 md:pt-12">
+        <OnboardingForm initialEmail={user?.email || ""} />
+      </main>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/auth/onboarding/page.tsx
+++ b/apps/product/src/app/[locale]/auth/onboarding/page.tsx
@@ -16,17 +16,14 @@ export default function OnboardingPage() {
   // 追蹤是否已經初始化過，避免 refreshAuth 導致組件重新掛載
   const [hasInitialized, setHasInitialized] = useState(false);
 
-  // 初始化完成後記錄狀態
+  // 處理初次載入邏輯：已登入則記錄狀態，未登入則重定向到首頁
   useEffect(() => {
-    if (!isLoading && isAuthenticated && !hasInitialized) {
-      setHasInitialized(true);
-    }
-  }, [isLoading, isAuthenticated, hasInitialized]);
-
-  // 未登入則重定向到首頁（只在初次載入時檢查）
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated && !hasInitialized) {
-      router.replace("/");
+    if (!isLoading && !hasInitialized) {
+      if (isAuthenticated) {
+        setHasInitialized(true);
+      } else {
+        router.replace("/");
+      }
     }
   }, [isLoading, isAuthenticated, hasInitialized, router]);
 

--- a/apps/product/src/app/[locale]/auth/verify-email/page.tsx
+++ b/apps/product/src/app/[locale]/auth/verify-email/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { BackgroundAnimation, PageHeader } from "@/components/layout";
+import { resendVerificationEmail } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { useTranslations } from "@daodao/i18n";
+import { Button } from "@daodao/ui/components/button";
+import { toast } from "@daodao/ui/components/sonner";
+import { CheckCircle, Mail, XCircle } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useState } from "react";
+
+type VerificationStatus = "success" | "error";
+type VerificationMessage =
+  | "verified"
+  | "already_verified"
+  | "missing_token"
+  | "invalid_token"
+  | "user_not_found"
+  | "verification_failed"
+  | "unknown_error";
+
+interface VerificationResult {
+  type: "success" | "error";
+  title: string;
+  description: string;
+}
+
+/**
+ * 郵件驗證結果頁面
+ * 用戶點擊郵件中的驗證連結後，後端會重定向到這個頁面
+ */
+export default function VerifyEmailPage() {
+  const t = useTranslations("auth.verifyEmail");
+  const router = useRouter();
+  const { refreshAuth } = useAuth();
+  const searchParams = useSearchParams();
+  const status = searchParams.get("status") as VerificationStatus | null;
+  const message = searchParams.get("message") as VerificationMessage | null;
+  const email = searchParams.get("email");
+
+  const [isResending, setIsResending] = useState(false);
+  const [isNavigating, setIsNavigating] = useState(false);
+
+  // 驗證成功後，先刷新認證狀態再導航到首頁
+  const handleGoToHome = useCallback(async () => {
+    setIsNavigating(true);
+    try {
+      // 先刷新認證狀態，確保 isEmailVerified 更新
+      await refreshAuth();
+      router.push("/");
+    } catch (error) {
+      console.error("Failed to refresh auth:", error);
+      router.push("/");
+    }
+  }, [refreshAuth, router]);
+
+  const getResult = (): VerificationResult => {
+    if (status === "success") {
+      switch (message) {
+        case "verified":
+          return {
+            type: "success",
+            title: t("success.verified.title"),
+            description: t("success.verified.description"),
+          };
+        case "already_verified":
+          return {
+            type: "success",
+            title: t("success.alreadyVerified.title"),
+            description: t("success.alreadyVerified.description"),
+          };
+        default:
+          return {
+            type: "success",
+            title: t("success.default.title"),
+            description: t("success.default.description"),
+          };
+      }
+    } else {
+      switch (message) {
+        case "missing_token":
+          return {
+            type: "error",
+            title: t("error.missingToken.title"),
+            description: t("error.missingToken.description"),
+          };
+        case "invalid_token":
+          return {
+            type: "error",
+            title: t("error.invalidToken.title"),
+            description: t("error.invalidToken.description"),
+          };
+        case "user_not_found":
+          return {
+            type: "error",
+            title: t("error.userNotFound.title"),
+            description: t("error.userNotFound.description"),
+          };
+        case "verification_failed":
+          return {
+            type: "error",
+            title: t("error.verificationFailed.title"),
+            description: t("error.verificationFailed.description"),
+          };
+        default:
+          return {
+            type: "error",
+            title: t("error.unknown.title"),
+            description: t("error.unknown.description"),
+          };
+      }
+    }
+  };
+
+  const handleResendVerification = async () => {
+    if (!email) {
+      toast.error(t("resend.noEmail"));
+      return;
+    }
+
+    setIsResending(true);
+    try {
+      const response = await resendVerificationEmail({ email });
+      if (response.data?.success) {
+        toast.success(t("resend.success"));
+      } else {
+        toast.error(t("resend.failed"));
+      }
+    } catch (error) {
+      console.error("Failed to resend verification email:", error);
+      toast.error(t("resend.failed"));
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  const result = getResult();
+  const isSuccess = result.type === "success";
+  const showResendButton = status === "error" && message === "invalid_token" && email;
+
+  return (
+    <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
+      <PageHeader leftAction={null} rightActionTo="/" />
+
+      <BackgroundAnimation />
+
+      <main className="max-w-[448px] mx-auto px-5 pb-[128px] pt-12 md:pt-24">
+        <div className="flex flex-col items-center text-center space-y-6">
+          {/* Icon */}
+          <div
+            className={`w-20 h-20 rounded-full flex items-center justify-center ${
+              isSuccess ? "bg-green-100" : "bg-red-100"
+            }`}
+          >
+            {isSuccess ? (
+              <CheckCircle className="w-10 h-10 text-green-600" />
+            ) : (
+              <XCircle className="w-10 h-10 text-red-600" />
+            )}
+          </div>
+
+          {/* Title */}
+          <h1 className="text-2xl font-bold text-text-dark">{result.title}</h1>
+
+          {/* Description */}
+          <p className="text-text-gray">{result.description}</p>
+
+          {/* Actions */}
+          <div className="flex flex-col gap-3 w-full mt-8">
+            {isSuccess && (
+              <Button
+                variant="orange"
+                className="w-full"
+                onClick={handleGoToHome}
+                disabled={isNavigating}
+              >
+                {isNavigating ? "..." : t("actions.goToHome")}
+              </Button>
+            )}
+
+            {showResendButton && (
+              <Button
+                variant="orange"
+                className="w-full"
+                onClick={handleResendVerification}
+                disabled={isResending}
+              >
+                <Mail className="w-4 h-4 mr-2" />
+                {isResending ? t("resend.sending") : t("resend.button")}
+              </Button>
+            )}
+
+            {!isSuccess && (
+              <Button variant="ghost" className="w-full" asChild>
+                <Link href="/">{t("actions.backToHome")}</Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/auth/verify-email/pending/page.tsx
+++ b/apps/product/src/app/[locale]/auth/verify-email/pending/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { BackgroundAnimation, PageHeader } from "@/components/layout";
+import { resendVerificationEmail } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { useTranslations } from "@daodao/i18n";
+import { Button } from "@daodao/ui/components/button";
+import { toast } from "@daodao/ui/components/sonner";
+import { Mail, RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+const RESEND_COOLDOWN_SECONDS = 60;
+
+/**
+ * Email 驗證等待頁面
+ * 用戶未驗證 email 時會被重定向到這個頁面
+ */
+export default function VerifyEmailPendingPage() {
+  const t = useTranslations("auth.verifyEmail.pending");
+  const router = useRouter();
+  const { user, isEmailVerified, logout, refreshAuth } = useAuth();
+  const [isResending, setIsResending] = useState(false);
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+
+  // 如果 email 已驗證，跳轉到首頁
+  useEffect(() => {
+    if (isEmailVerified) {
+      router.replace("/");
+    }
+  }, [isEmailVerified, router]);
+
+  // 定期檢查 email 驗證狀態
+  useEffect(() => {
+    const checkInterval = setInterval(() => {
+      refreshAuth();
+    }, 5000); // 每 5 秒檢查一次
+
+    return () => clearInterval(checkInterval);
+  }, [refreshAuth]);
+
+  // 冷卻計時器
+  useEffect(() => {
+    if (cooldownSeconds > 0) {
+      const timer = setTimeout(() => {
+        setCooldownSeconds((prev) => prev - 1);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [cooldownSeconds]);
+
+  const handleResendVerification = useCallback(async () => {
+    if (!user?.email || isResending || cooldownSeconds > 0) {
+      return;
+    }
+
+    setIsResending(true);
+    try {
+      const response = await resendVerificationEmail({ email: user.email });
+      if (response.data?.success) {
+        toast.success(t("resendSuccess"));
+        setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+      } else {
+        toast.error(t("resendFailed"));
+      }
+    } catch (error) {
+      console.error("Failed to resend verification email:", error);
+      toast.error(t("resendFailed"));
+    } finally {
+      setIsResending(false);
+    }
+  }, [user?.email, isResending, cooldownSeconds, t]);
+
+  const handleLogout = useCallback(async () => {
+    await logout();
+    router.replace("/");
+  }, [logout, router]);
+
+  const description = user?.email
+    ? t("description", { email: user.email })
+    : t("descriptionNoEmail");
+
+  return (
+    <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
+      <PageHeader leftAction={null} />
+
+      <BackgroundAnimation />
+
+      <main className="max-w-[448px] mx-auto px-5 pb-[128px] pt-12 md:pt-24">
+        <div className="flex flex-col items-center text-center space-y-6">
+          {/* Icon */}
+          <div className="w-20 h-20 rounded-full flex items-center justify-center bg-orange-100">
+            <Mail className="w-10 h-10 text-orange-500" />
+          </div>
+
+          {/* Title */}
+          <h1 className="text-2xl font-bold text-text-dark">{t("title")}</h1>
+
+          {/* Description */}
+          <p className="text-text-gray">{description}</p>
+
+          {/* Check spam hint */}
+          <p className="text-sm text-text-gray">{t("checkSpam")}</p>
+
+          {/* Actions */}
+          <div className="flex flex-col gap-3 w-full mt-8">
+            <Button
+              variant="orange"
+              className="w-full"
+              onClick={handleResendVerification}
+              disabled={isResending || cooldownSeconds > 0}
+            >
+              {isResending ? (
+                <>
+                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                  {t("resending")}
+                </>
+              ) : cooldownSeconds > 0 ? (
+                t("resendCooldown", { seconds: cooldownSeconds })
+              ) : (
+                <>
+                  <Mail className="w-4 h-4 mr-2" />
+                  {t("resendButton")}
+                </>
+              )}
+            </Button>
+
+            <Button variant="ghost" className="w-full" onClick={handleLogout}>
+              {t("logout")}
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/product/src/app/global-provider.tsx
+++ b/apps/product/src/app/global-provider.tsx
@@ -47,9 +47,17 @@ function GlobalProvider({
                   <SheetManagerProvider>
                     <AuthProvider
                       defaultProtected
-                      publicPattern={["^/auth/login", "^/auth/callback", "^/users/"]}
+                      publicPattern={["^/auth/login", "^/auth/callback", "^/auth/onboarding", "^/auth/verify-email(/.*)?$", "^/users/"]}
                       onAuthRequired={(currentPath) => {
                         router.push(`/auth/login?redirect=${encodeURIComponent(currentPath)}`);
+                      }}
+                      onboardingPath="/auth/onboarding"
+                      onTemporaryUser={() => {
+                        router.push("/auth/onboarding");
+                      }}
+                      emailVerificationPath="/auth/verify-email"
+                      onEmailUnverified={() => {
+                        router.push("/auth/verify-email/pending");
                       }}
                     >
                       <Toaster />

--- a/apps/product/src/components/onboarding/index.ts
+++ b/apps/product/src/components/onboarding/index.ts
@@ -1,0 +1,26 @@
+// Main form component
+export { OnboardingForm } from "./onboarding-form";
+
+// Section components
+export { InterestsSection } from "./interests-section";
+export { ProfileSection } from "./profile-section";
+export { ReferralSection } from "./referral-section";
+export { SuccessSection } from "./success-section";
+
+// Stepper component
+export { OnboardingStepper } from "./onboarding-stepper";
+
+// Hooks
+export { useOnboardingStep } from "./use-onboarding-step";
+
+// Schema and types
+export {
+  AVAILABLE_FIELDS,
+  INTEREST_CATEGORIES,
+  interestsStepSchema,
+  type OnboardingFormValues,
+  onboardingFormSchema,
+  profileStepSchema,
+  REFERRAL_SOURCE_OPTIONS,
+  referralStepSchema,
+} from "./schema";

--- a/apps/product/src/components/onboarding/interests-section.tsx
+++ b/apps/product/src/components/onboarding/interests-section.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useTranslations } from "@daodao/i18n";
+import { Badge } from "@daodao/ui/components/badge";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@daodao/ui/components/form";
+import { cn } from "@daodao/ui/lib/utils";
+import { useCallback } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { AVAILABLE_FIELDS, INTEREST_CATEGORIES, type OnboardingFormValues } from "./schema";
+
+interface InterestsSectionProps {
+  form: UseFormReturn<OnboardingFormValues>;
+}
+
+/**
+ * Onboarding Step 2: 興趣領域區塊
+ * 包含專業領域和興趣領域選擇
+ */
+export const InterestsSection = ({ form }: InterestsSectionProps) => {
+  const t = useTranslations("onboarding");
+
+  const selectedProfessional = form.watch("professionalFields") || [];
+  const selectedInterests = form.watch("interests") || [];
+
+  const handleToggle = useCallback(
+    (fieldName: "professionalFields" | "interests", value: string, maxSelection: number) => {
+      const current = form.getValues(fieldName) || [];
+      const isSelected = current.includes(value);
+
+      if (isSelected) {
+        form.setValue(
+          fieldName,
+          current.filter((v) => v !== value),
+          { shouldValidate: true, shouldDirty: true }
+        );
+      } else if (current.length < maxSelection) {
+        form.setValue(fieldName, [...current, value], { shouldValidate: true, shouldDirty: true });
+      }
+    },
+    [form]
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* 標題 */}
+      <div className="text-center mb-8">
+        <h1 className="heading-lg text-text-dark mb-2">{t("steps.interests.title")}</h1>
+      </div>
+
+      {/* 專業領域 */}
+      <FormField
+        control={form.control}
+        name="professionalFields"
+        render={() => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-4">
+              {t("steps.interests.professionalFieldsLabel")}
+              <span className="text-light-gray text-sm font-normal ml-2">
+                ({selectedProfessional.length}/5)
+              </span>
+            </FormLabel>
+            <FormControl>
+              <div className="flex flex-wrap gap-2">
+                {AVAILABLE_FIELDS.map((field) => {
+                  const isSelected = selectedProfessional.includes(field.value);
+                  const isDisabled = !isSelected && selectedProfessional.length >= 5;
+
+                  return (
+                    <Badge
+                      key={field.value}
+                      variant={isSelected ? "outline-blue" : "outline-ghost"}
+                      className={cn(
+                        "cursor-pointer transition-all px-4 py-2 rounded-lg",
+                        isSelected && "border-logo-cyan bg-light-blue",
+                        isDisabled && "opacity-50 cursor-not-allowed"
+                      )}
+                      onClick={() => {
+                        if (!isDisabled) {
+                          handleToggle("professionalFields", field.value, 5);
+                        }
+                      }}
+                    >
+                      {field.label}
+                    </Badge>
+                  );
+                })}
+              </div>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 興趣領域 */}
+      <FormField
+        control={form.control}
+        name="interests"
+        render={() => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-4">
+              {t("steps.interests.interestsLabel")}
+              <span className="text-red ml-1">*</span>
+              <span className="text-light-gray text-sm font-normal ml-2">
+                ({selectedInterests.length}/5)
+              </span>
+            </FormLabel>
+            <FormControl>
+              <div className="flex flex-wrap gap-2">
+                {INTEREST_CATEGORIES.map((category) => {
+                  const isSelected = selectedInterests.includes(category.value);
+                  const isDisabled = !isSelected && selectedInterests.length >= 5;
+
+                  return (
+                    <Badge
+                      key={category.value}
+                      variant={isSelected ? "outline-blue" : "outline-ghost"}
+                      className={cn(
+                        "cursor-pointer transition-all px-4 py-2 rounded-lg",
+                        isSelected && "border-logo-cyan bg-light-blue",
+                        isDisabled && "opacity-50 cursor-not-allowed"
+                      )}
+                      onClick={() => {
+                        if (!isDisabled) {
+                          handleToggle("interests", category.value, 5);
+                        }
+                      }}
+                    >
+                      {category.label}
+                    </Badge>
+                  );
+                })}
+              </div>
+            </FormControl>
+            {selectedInterests.length >= 5 && (
+              <p className="text-xs text-logo-cyan mt-2">{t("steps.interests.maxReached")}</p>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};

--- a/apps/product/src/components/onboarding/interests-section.tsx
+++ b/apps/product/src/components/onboarding/interests-section.tsx
@@ -61,6 +61,7 @@ export const InterestsSection = ({ form }: InterestsSectionProps) => {
           <FormItem>
             <FormLabel className="block font-medium text-text-dark mb-4">
               {t("steps.interests.professionalFieldsLabel")}
+              <span className="text-red ml-1">*</span>
               <span className="text-light-gray text-sm font-normal ml-2">
                 ({selectedProfessional.length}/5)
               </span>

--- a/apps/product/src/components/onboarding/onboarding-form.tsx
+++ b/apps/product/src/components/onboarding/onboarding-form.tsx
@@ -119,28 +119,16 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
     setIsSubmitting(true);
 
     try {
-      // 組裝 API 請求資料
+      // 組裝 API 請求資料（所有欄位都是必填）
       const updateData: Parameters<typeof updateCurrentUserWithFormData>[0] = {
-        referralSource: values.referralSource,
+        birthDay: format(values.birthDate, "yyyy-MM-dd"),
+        name: values.name,
+        customId: values.customId,
+        personalSlogan: values.personalSlogan,
+        professionalField: values.professionalFields,
         interestList: values.interests,
+        referralSource: values.referralSource,
       };
-
-      // 選填欄位只有在有值時才加入
-      if (values.birthDate) {
-        updateData.birthDay = format(values.birthDate, "yyyy-MM-dd");
-      }
-      if (values.name) {
-        updateData.name = values.name;
-      }
-      if (values.customId) {
-        updateData.customId = values.customId;
-      }
-      if (values.personalSlogan) {
-        updateData.personalSlogan = values.personalSlogan;
-      }
-      if (values.professionalFields && values.professionalFields.length > 0) {
-        updateData.professionalField = values.professionalFields;
-      }
 
       // 臨時用戶使用 POST 創建，正常用戶使用 PUT 更新
       if (isTemporary) {

--- a/apps/product/src/components/onboarding/onboarding-form.tsx
+++ b/apps/product/src/components/onboarding/onboarding-form.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useUserMutations } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { useTranslations } from "@daodao/i18n";
+import { Button } from "@daodao/ui/components/button";
+import { Form } from "@daodao/ui/components/form";
+import { toast } from "@daodao/ui/components/sonner";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { format } from "date-fns";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { InterestsSection } from "./interests-section";
+import { OnboardingStepper } from "./onboarding-stepper";
+import { ProfileSection } from "./profile-section";
+import { ReferralSection } from "./referral-section";
+import {
+  interestsStepSchema,
+  type OnboardingFormValues,
+  onboardingFormSchema,
+  profileStepSchema,
+  referralStepSchema,
+} from "./schema";
+import { SuccessSection } from "./success-section";
+import { useOnboardingStep } from "./use-onboarding-step";
+
+interface OnboardingFormProps {
+  /** 用戶的 email，從 OAuth 取得 */
+  initialEmail?: string;
+}
+
+/**
+ * Onboarding 主表單元件
+ * 管理整個 onboarding 流程，包含步驟導航和資料提交
+ */
+export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
+  const t = useTranslations("onboarding");
+  const { isTemporary, refreshAuth, refreshToken } = useAuth();
+  const { updateCurrentUserWithFormData, createCurrentUserWithFormData } = useUserMutations();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { currentStep, nextStep, prevStep, totalSteps, isFirstStep, isLastInputStep, isSuccessStep } =
+    useOnboardingStep();
+
+  const form = useForm<OnboardingFormValues>({
+    resolver: zodResolver(onboardingFormSchema),
+    defaultValues: {
+      email: initialEmail || "",
+      birthDate: undefined,
+      name: "",
+      customId: "",
+      personalSlogan: "",
+      professionalFields: [],
+      interests: [],
+      referralSource: "",
+      otherReferralText: "",
+    },
+    mode: "onChange",
+  });
+
+  /**
+   * 驗證當前步驟的欄位
+   */
+  const validateCurrentStep = async (): Promise<boolean> => {
+    const values = form.getValues();
+
+    try {
+      switch (currentStep) {
+        case 1:
+          // Profile 步驟：所有欄位都是選填的，但如果有填寫則需驗證格式
+          await profileStepSchema.parseAsync({
+            email: values.email,
+            birthDate: values.birthDate,
+            name: values.name,
+            customId: values.customId,
+            personalSlogan: values.personalSlogan,
+          });
+          return true;
+
+        case 2:
+          // Interests 步驟：interests 是必填
+          await interestsStepSchema.parseAsync({
+            professionalFields: values.professionalFields,
+            interests: values.interests,
+          });
+          return true;
+
+        case 3:
+          // Referral 步驟：referralSource 是必填
+          await referralStepSchema.parseAsync({
+            referralSource: values.referralSource,
+            otherReferralText: values.otherReferralText,
+          });
+          return true;
+
+        default:
+          return true;
+      }
+    } catch {
+      // 觸發表單驗證以顯示錯誤訊息
+      await form.trigger();
+      return false;
+    }
+  };
+
+  /**
+   * 處理「下一步」按鈕
+   */
+  const handleNext = async () => {
+    const isValid = await validateCurrentStep();
+    if (isValid) {
+      nextStep();
+    }
+  };
+
+  /**
+   * 處理表單提交
+   */
+  const handleSubmit = async (values: OnboardingFormValues) => {
+    setIsSubmitting(true);
+
+    try {
+      // 組裝 API 請求資料
+      const updateData: Parameters<typeof updateCurrentUserWithFormData>[0] = {
+        referralSource: values.referralSource,
+        interestList: values.interests,
+      };
+
+      // 選填欄位只有在有值時才加入
+      if (values.birthDate) {
+        updateData.birthDay = format(values.birthDate, "yyyy-MM-dd");
+      }
+      if (values.name) {
+        updateData.name = values.name;
+      }
+      if (values.customId) {
+        updateData.customId = values.customId;
+      }
+      if (values.personalSlogan) {
+        updateData.personalSlogan = values.personalSlogan;
+      }
+      if (values.professionalFields && values.professionalFields.length > 0) {
+        updateData.professionalField = values.professionalFields;
+      }
+
+      // 臨時用戶使用 POST 創建，正常用戶使用 PUT 更新
+      if (isTemporary) {
+        await createCurrentUserWithFormData(updateData);
+        // 臨時用戶完成 onboarding 後，後端會發新的 token
+        // 需要先刷新 token 再檢查認證狀態
+        await refreshToken();
+      } else {
+        await updateCurrentUserWithFormData(updateData);
+      }
+
+      // 重新檢查認證狀態，更新 isTemporary 為 false
+      await refreshAuth();
+
+      // 成功後前往成功頁面
+      nextStep();
+    } catch (error) {
+      console.error("Failed to submit onboarding:", error);
+
+      // 處理伺服器驗證錯誤
+      if (error instanceof Error) {
+        const apiError = error as Error & {
+          details?: Array<{ path?: string; message?: string }>;
+        };
+
+        if (apiError.details && Array.isArray(apiError.details)) {
+          apiError.details.forEach((detail) => {
+            if (detail.path && detail.message) {
+              // 嘗試將 API 錯誤路徑映射到表單欄位
+              const fieldName = mapApiPathToFormField(detail.path);
+              if (fieldName) {
+                form.setError(fieldName as keyof OnboardingFormValues, {
+                  type: "server",
+                  message: detail.message,
+                });
+              }
+            }
+          });
+        }
+
+        toast.error(error.message || t("errors.submitFailed"));
+      } else {
+        toast.error(t("errors.submitFailed"));
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * 將 API 錯誤路徑映射到表單欄位名稱
+   */
+  const mapApiPathToFormField = (apiPath: string): string | null => {
+    const mapping: Record<string, string> = {
+      birthDay: "birthDate",
+      customId: "customId",
+      name: "name",
+      personalSlogan: "personalSlogan",
+      professionalField: "professionalFields",
+      interestList: "interests",
+      referralSource: "referralSource",
+    };
+
+    for (const [apiField, formField] of Object.entries(mapping)) {
+      if (apiPath.includes(apiField)) {
+        return formField;
+      }
+    }
+
+    return null;
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        {/* 步驟指示器 */}
+        <OnboardingStepper currentStep={currentStep} totalSteps={totalSteps} />
+
+        {/* 步驟內容 */}
+        {currentStep === 1 && <ProfileSection form={form} />}
+        {currentStep === 2 && <InterestsSection form={form} />}
+        {currentStep === 3 && <ReferralSection form={form} />}
+        {currentStep === 4 && <SuccessSection userName={form.getValues("name") || undefined} />}
+
+        {/* 導航按鈕（成功頁面不顯示） */}
+        {!isSuccessStep && (
+          <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-4 p-6 border-t border-light-gray bg-very-light-gray">
+            <div className="w-full max-w-[448px] flex gap-4">
+              {!isFirstStep && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="flex-1"
+                  onClick={prevStep}
+                >
+                  {t("navigation.previous")}
+                </Button>
+              )}
+              {!isLastInputStep ? (
+                <Button
+                  type="button"
+                  variant="orange"
+                  className="flex-1"
+                  onClick={handleNext}
+                >
+                  {t("navigation.next")}
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  variant="orange"
+                  className="flex-1"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? t("navigation.submitting") : t("navigation.complete")}
+                </Button>
+              )}
+            </div>
+          </footer>
+        )}
+      </form>
+    </Form>
+  );
+};

--- a/apps/product/src/components/onboarding/onboarding-form.tsx
+++ b/apps/product/src/components/onboarding/onboarding-form.tsx
@@ -204,13 +204,13 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
       referralSource: "referralSource",
     };
 
-    for (const [apiField, formField] of Object.entries(mapping)) {
-      if (apiPath.includes(apiField)) {
-        return formField;
-      }
-    }
+    // 從 API 路徑中提取欄位名稱（例如 "/birthDay" -> "birthDay"）
+    const pathParts = apiPath.split("/").filter(Boolean);
+    const fieldName = pathParts[pathParts.length - 1];
 
-    return null;
+    // 使用完全相等比對，避免子字串誤判
+    if (!fieldName) return null;
+    return mapping[fieldName] ?? null;
   };
 
   return (

--- a/apps/product/src/components/onboarding/onboarding-stepper.tsx
+++ b/apps/product/src/components/onboarding/onboarding-stepper.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { cn } from "@daodao/ui/lib/utils";
+import { CheckIcon } from "lucide-react";
+
+interface OnboardingStepperProps {
+  /** 當前步驟 (1-4) */
+  currentStep: number;
+  /** 總步驟數 */
+  totalSteps: number;
+}
+
+/**
+ * Onboarding 步驟指示器
+ * 顯示當前進度和步驟圓點
+ */
+export const OnboardingStepper = ({ currentStep, totalSteps }: OnboardingStepperProps) => {
+  // 排除成功頁面，所以是 1-3 步驟
+  const inputSteps = totalSteps - 1;
+
+  // 成功頁面不顯示步驟指示器
+  if (currentStep === totalSteps) {
+    return null;
+  }
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center justify-center">
+        {Array.from({ length: inputSteps }, (_, index) => {
+          const stepNumber = index + 1;
+          const isActive = stepNumber === currentStep;
+          const isCompleted = stepNumber < currentStep;
+          const isLast = stepNumber === inputSteps;
+
+          return (
+            <div key={stepNumber} className="flex items-center">
+              {/* 步驟圓點 */}
+              <div className="flex flex-col items-center">
+                <div
+                  className={cn(
+                    "size-8 rounded-full flex items-center justify-center transition-all duration-300 text-sm font-medium",
+                    isActive && "bg-logo-cyan text-white shadow-lg shadow-logo-cyan/30",
+                    isCompleted && "bg-logo-cyan text-white",
+                    !isActive && !isCompleted && "bg-basic-200 text-light-gray"
+                  )}
+                >
+                  {isCompleted ? <CheckIcon className="size-4" /> : stepNumber}
+                </div>
+              </div>
+
+              {/* 連接線 */}
+              {!isLast && (
+                <div
+                  className={cn(
+                    "w-16 sm:w-24 h-0.5 mx-2 transition-colors duration-300",
+                    isCompleted ? "bg-logo-cyan" : "bg-basic-200"
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/apps/product/src/components/onboarding/profile-section.tsx
+++ b/apps/product/src/components/onboarding/profile-section.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { checkCustomIdAvailability } from "@daodao/api";
+import { useTranslations } from "@daodao/i18n";
+import { DatePicker } from "@daodao/ui/components/date-picker";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@daodao/ui/components/form";
+import { Input } from "@daodao/ui/components/input";
+import { Textarea } from "@daodao/ui/components/textarea";
+import { cn } from "@daodao/ui/lib/utils";
+import { differenceInYears } from "date-fns";
+import { CheckCircleIcon, LoaderIcon, LockIcon, XCircleIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import type { OnboardingFormValues } from "./schema";
+
+interface ProfileSectionProps {
+  form: UseFormReturn<OnboardingFormValues>;
+}
+
+/**
+ * Onboarding Step 1: 個人資料區塊
+ * 包含 email、生日、名字、username、個人標語欄位
+ */
+export const ProfileSection = ({ form }: ProfileSectionProps) => {
+  const t = useTranslations("onboarding");
+
+  // customId 即時檢查狀態
+  const [customIdStatus, setCustomIdStatus] = useState<
+    "idle" | "checking" | "available" | "unavailable"
+  >("idle");
+  const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // 生日驗證狀態
+  const birthDate = form.watch("birthDate");
+  const birthDateAge = birthDate ? differenceInYears(new Date(), birthDate) : null;
+  const isBirthDateValid = birthDateAge === null || birthDateAge >= 16;
+
+  // customId 即時檢查函數（debounced）
+  const checkCustomId = useCallback(
+    async (customId: string) => {
+      // 清除之前的 timeout
+      if (checkTimeoutRef.current) {
+        clearTimeout(checkTimeoutRef.current);
+      }
+
+      // 如果是空的，不檢查
+      if (!customId) {
+        setCustomIdStatus("idle");
+        return;
+      }
+
+      // 本地格式驗證
+      const customIdRegex = /^[a-zA-Z0-9]+$/;
+      if (customId.length < 3 || customId.length > 15 || !customIdRegex.test(customId)) {
+        setCustomIdStatus("idle");
+        return;
+      }
+
+      setCustomIdStatus("checking");
+
+      // debounce 300ms
+      checkTimeoutRef.current = setTimeout(async () => {
+        try {
+          const response = await checkCustomIdAvailability(customId);
+
+          // 檢查是否有錯誤
+          if (response.error) {
+            console.error("API error:", response.error);
+            setCustomIdStatus("idle");
+            return;
+          }
+
+          // 檢查可用性
+          if (response.data?.data?.available) {
+            setCustomIdStatus("available");
+          } else {
+            setCustomIdStatus("unavailable");
+            form.setError("customId", {
+              type: "server",
+              message: t("steps.profile.usernameUnavailable"),
+            });
+          }
+        } catch (err) {
+          console.error("checkCustomIdAvailability error:", err);
+          setCustomIdStatus("idle");
+        }
+      }, 300);
+    },
+    [form, t]
+  );
+
+  // 清理 timeout
+  useEffect(() => {
+    return () => {
+      if (checkTimeoutRef.current) {
+        clearTimeout(checkTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      {/* 標題 */}
+      <div className="text-center mb-8">
+        <h1 className="heading-lg text-text-dark mb-2">{t("steps.profile.title")}</h1>
+      </div>
+
+      {/* Email (readonly) */}
+      <FormField
+        control={form.control}
+        name="email"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">
+              {t("steps.profile.email")}
+            </FormLabel>
+            <FormControl>
+              <div className="relative">
+                <Input
+                  {...field}
+                  readOnly
+                  disabled
+                  className="bg-very-light-gray pr-10"
+                />
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  <LockIcon className="size-4 text-light-gray" />
+                </div>
+              </div>
+            </FormControl>
+            <FormDescription className="text-xs text-light-gray mt-1">
+              {t("steps.profile.emailLinked")}
+            </FormDescription>
+          </FormItem>
+        )}
+      />
+
+      {/* 生日 */}
+      <FormField
+        control={form.control}
+        name="birthDate"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">
+              {t("steps.profile.birthDate")}
+            </FormLabel>
+            <FormControl>
+              <DatePicker
+                value={field.value}
+                onChange={field.onChange}
+                placeholder={t("steps.profile.birthDatePlaceholder")}
+                minDate={new Date(1900, 0, 1)}
+                maxDate={new Date()}
+                invalid={!isBirthDateValid}
+              />
+            </FormControl>
+            {birthDate && (
+              <FormDescription
+                className={cn(
+                  "text-xs mt-1",
+                  isBirthDateValid ? "text-green" : "text-red"
+                )}
+              >
+                {isBirthDateValid ? (
+                  <>
+                    <CheckCircleIcon className="size-3 inline mr-1" />
+                    {t("steps.profile.ageValid")}
+                  </>
+                ) : (
+                  <>
+                    <XCircleIcon className="size-3 inline mr-1" />
+                    {t("steps.profile.ageInvalid")}
+                  </>
+                )}
+              </FormDescription>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 名字 */}
+      <FormField
+        control={form.control}
+        name="name"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">
+              {t("steps.profile.name")}
+            </FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder={t("steps.profile.namePlaceholder")}
+                className={cn(form.formState.errors.name && "border-red focus-visible:border-red")}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 使用者帳號 */}
+      <FormField
+        control={form.control}
+        name="customId"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">
+              {t("steps.profile.username")}
+            </FormLabel>
+            <FormControl>
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-light-gray pointer-events-none">@</span>
+                <Input
+                  {...field}
+                  placeholder={t("steps.profile.usernamePlaceholder")}
+                  className={cn(
+                    "pl-10 pr-10 focus-visible:pl-[39px]",
+                    form.formState.errors.customId && "border-red focus-visible:border-red",
+                    customIdStatus === "available" && "border-green focus-visible:border-green"
+                  )}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    // 當使用者輸入時，立即清除舊的驗證狀態
+                    if (customIdStatus === "available" || customIdStatus === "unavailable") {
+                      setCustomIdStatus("idle");
+                      form.clearErrors("customId");
+                    }
+                    checkCustomId(e.target.value);
+                  }}
+                />
+                {/* 狀態指示器 */}
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  {customIdStatus === "checking" && (
+                    <LoaderIcon className="size-4 text-light-gray animate-spin" />
+                  )}
+                  {customIdStatus === "available" && (
+                    <CheckCircleIcon className="size-4 text-green" />
+                  )}
+                  {customIdStatus === "unavailable" && (
+                    <XCircleIcon className="size-4 text-red" />
+                  )}
+                </div>
+              </div>
+            </FormControl>
+            <FormDescription className="text-xs text-light-gray mt-1">
+              {t("steps.profile.usernameHint")}
+              {customIdStatus === "available" && (
+                <span className="text-green ml-1">
+                  <CheckCircleIcon className="size-3 inline mr-1" />
+                  {t("steps.profile.usernameValid")}
+                </span>
+              )}
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 個人標語 */}
+      <FormField
+        control={form.control}
+        name="personalSlogan"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">
+              {t("steps.profile.bio")}
+            </FormLabel>
+            <FormControl>
+              <Textarea
+                {...field}
+                placeholder={t("steps.profile.bioPlaceholder")}
+                className={cn(
+                  "resize-none",
+                  form.formState.errors.personalSlogan && "border-red focus-visible:border-red"
+                )}
+                rows={3}
+              />
+            </FormControl>
+            <FormDescription className="text-xs text-light-gray mt-1 text-right">
+              {(field.value || "").length}/150
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};

--- a/apps/product/src/components/onboarding/profile-section.tsx
+++ b/apps/product/src/components/onboarding/profile-section.tsx
@@ -149,6 +149,7 @@ export const ProfileSection = ({ form }: ProfileSectionProps) => {
           <FormItem>
             <FormLabel className="block font-medium text-text-dark mb-3">
               {t("steps.profile.birthDate")}
+              <span className="text-red ml-1">*</span>
             </FormLabel>
             <FormControl>
               <DatePicker
@@ -193,6 +194,7 @@ export const ProfileSection = ({ form }: ProfileSectionProps) => {
           <FormItem>
             <FormLabel className="block font-medium text-text-dark mb-3">
               {t("steps.profile.name")}
+              <span className="text-red ml-1">*</span>
             </FormLabel>
             <FormControl>
               <Input
@@ -214,6 +216,7 @@ export const ProfileSection = ({ form }: ProfileSectionProps) => {
           <FormItem>
             <FormLabel className="block font-medium text-text-dark mb-3">
               {t("steps.profile.username")}
+              <span className="text-red ml-1">*</span>
             </FormLabel>
             <FormControl>
               <div className="relative">
@@ -272,6 +275,7 @@ export const ProfileSection = ({ form }: ProfileSectionProps) => {
           <FormItem>
             <FormLabel className="block font-medium text-text-dark mb-3">
               {t("steps.profile.bio")}
+              <span className="text-red ml-1">*</span>
             </FormLabel>
             <FormControl>
               <Textarea

--- a/apps/product/src/components/onboarding/referral-section.tsx
+++ b/apps/product/src/components/onboarding/referral-section.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useTranslations } from "@daodao/i18n";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@daodao/ui/components/form";
+import { Input } from "@daodao/ui/components/input";
+import { RadioGroup, RadioGroupItem } from "@daodao/ui/components/radio-group";
+import { cn } from "@daodao/ui/lib/utils";
+import type { UseFormReturn } from "react-hook-form";
+import { REFERRAL_SOURCE_OPTIONS, type OnboardingFormValues } from "./schema";
+
+interface ReferralSectionProps {
+  form: UseFormReturn<OnboardingFormValues>;
+}
+
+/**
+ * Onboarding Step 3: 來源調查區塊
+ * 讓用戶選擇如何得知島島阿學
+ */
+export const ReferralSection = ({ form }: ReferralSectionProps) => {
+  const t = useTranslations("onboarding");
+
+  const selectedSource = form.watch("referralSource");
+  const isOthersSelected = selectedSource === "others";
+
+  return (
+    <div className="space-y-6">
+      {/* 標題 */}
+      <div className="text-center mb-8">
+        <h1 className="heading-lg text-text-dark mb-2">{t("steps.referral.title")}</h1>
+        <p className="text-light-gray">{t("steps.referral.subtitle")}</p>
+      </div>
+
+      {/* 來源選項 */}
+      <FormField
+        control={form.control}
+        name="referralSource"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <RadioGroup
+                value={field.value}
+                onValueChange={field.onChange}
+                className="space-y-3"
+              >
+                {REFERRAL_SOURCE_OPTIONS.map((option) => (
+                  <label
+                    key={option.value}
+                    htmlFor={`referral-${option.value}`}
+                    className={cn(
+                      "flex items-center gap-3 p-4 rounded-xl border cursor-pointer transition-all",
+                      "hover:border-logo-cyan",
+                      field.value === option.value
+                        ? "border-logo-cyan bg-light-blue"
+                        : "border-basic-200 bg-white"
+                    )}
+                  >
+                    <RadioGroupItem id={`referral-${option.value}`} value={option.value} />
+                    <span className="text-text-dark">{option.label}</span>
+                  </label>
+                ))}
+              </RadioGroup>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 「其他」的詳細說明輸入框 */}
+      {isOthersSelected && (
+        <FormField
+          control={form.control}
+          name="otherReferralText"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="block font-medium text-text-dark mb-3">
+                {t("steps.referral.otherLabel")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder={t("steps.referral.otherPlaceholder")}
+                  className={cn(
+                    form.formState.errors.otherReferralText && "border-red focus-visible:border-red"
+                  )}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/product/src/components/onboarding/schema.ts
+++ b/apps/product/src/components/onboarding/schema.ts
@@ -25,30 +25,27 @@ export const onboardingFormSchema = z.object({
   // Step 1: Profile
   email: z.string().email(),
   birthDate: z
-    .date()
+    .date({ required_error: "請選擇生日" })
     .refine(
       (date) => {
         const age = differenceInYears(new Date(), date);
         return age >= 16;
       },
       { message: "島島阿學目前僅開放給年滿 16 歲的使用者註冊" }
-    )
-    .optional(),
-  name: z.string().max(50, "名字最多 50 字").optional().or(z.literal("")),
+    ),
+  name: z.string().min(1, "請輸入名字").max(50, "名字最多 50 字"),
   customId: z
     .string()
     .min(3, "帳號最少需要 3 個字符")
     .max(15, "帳號最多 15 個字符")
-    .refine((val) => customIdRegex.test(val), "僅限使用英文字母和數字")
-    .optional()
-    .or(z.literal("")),
-  personalSlogan: z.string().max(150, "個人標語最多 150 字").optional().or(z.literal("")),
+    .refine((val) => customIdRegex.test(val), "僅限使用英文字母和數字"),
+  personalSlogan: z.string().min(1, "請輸入個人標語").max(150, "個人標語最多 150 字"),
 
   // Step 2: Interests
   professionalFields: z
     .array(z.string())
-    .max(5, "最多只能選擇 5 個專業領域")
-    .default([]),
+    .min(1, "請至少選擇 1 個專業領域")
+    .max(5, "最多只能選擇 5 個專業領域"),
   interests: z
     .array(z.string())
     .min(1, "請至少選擇 1 個興趣領域")

--- a/apps/product/src/components/onboarding/schema.ts
+++ b/apps/product/src/components/onboarding/schema.ts
@@ -1,0 +1,84 @@
+import { differenceInYears } from "date-fns";
+import { z } from "zod";
+import { INTEREST_CATEGORIES } from "@/constants/interest-categories";
+import { AVAILABLE_FIELDS } from "@/constants/professional-fields";
+import { REFERRAL_SOURCE_OPTIONS } from "@/constants/referral-source";
+
+// Re-export constants for convenience
+export { AVAILABLE_FIELDS, INTEREST_CATEGORIES, REFERRAL_SOURCE_OPTIONS };
+
+/**
+ * CustomId 驗證規則
+ * - 最少 3 個字符，最多 15 個字符
+ * - 僅可使用英文字母 (a-z) 與數字
+ */
+const customIdRegex = /^[a-zA-Z0-9]+$/;
+
+/**
+ * Onboarding 表單 Schema
+ *
+ * Step 1: Profile - 個人資料
+ * Step 2: Interests - 專業與興趣領域
+ * Step 3: Referral - 如何得知島島阿學
+ */
+export const onboardingFormSchema = z.object({
+  // Step 1: Profile
+  email: z.string().email(),
+  birthDate: z
+    .date()
+    .refine(
+      (date) => {
+        const age = differenceInYears(new Date(), date);
+        return age >= 16;
+      },
+      { message: "島島阿學目前僅開放給年滿 16 歲的使用者註冊" }
+    )
+    .optional(),
+  name: z.string().max(50, "名字最多 50 字").optional().or(z.literal("")),
+  customId: z
+    .string()
+    .min(3, "帳號最少需要 3 個字符")
+    .max(15, "帳號最多 15 個字符")
+    .refine((val) => customIdRegex.test(val), "僅限使用英文字母和數字")
+    .optional()
+    .or(z.literal("")),
+  personalSlogan: z.string().max(150, "個人標語最多 150 字").optional().or(z.literal("")),
+
+  // Step 2: Interests
+  professionalFields: z
+    .array(z.string())
+    .max(5, "最多只能選擇 5 個專業領域")
+    .default([]),
+  interests: z
+    .array(z.string())
+    .min(1, "請至少選擇 1 個興趣領域")
+    .max(5, "最多只能選擇 5 個興趣領域"),
+
+  // Step 3: Referral
+  referralSource: z.string().min(1, "請選擇如何得知島島阿學"),
+  otherReferralText: z.string().optional().or(z.literal("")),
+});
+
+export type OnboardingFormValues = z.infer<typeof onboardingFormSchema>;
+
+/**
+ * 步驟驗證 Schema
+ * 用於分步驟驗證，每個步驟只驗證對應的欄位
+ */
+export const profileStepSchema = onboardingFormSchema.pick({
+  email: true,
+  birthDate: true,
+  name: true,
+  customId: true,
+  personalSlogan: true,
+});
+
+export const interestsStepSchema = onboardingFormSchema.pick({
+  professionalFields: true,
+  interests: true,
+});
+
+export const referralStepSchema = onboardingFormSchema.pick({
+  referralSource: true,
+  otherReferralText: true,
+});

--- a/apps/product/src/components/onboarding/success-section.tsx
+++ b/apps/product/src/components/onboarding/success-section.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import featureHappyJson from "@daodao/assets/images/quiz/feature-happy.json";
+import { useTranslations } from "@daodao/i18n";
+import { Button } from "@daodao/ui/components/button";
+import { ConfettiAnimation } from "@daodao/ui/components/confetti-animation";
+import Lottie from "lottie-react";
+import { MailIcon } from "lucide-react";
+import { motion } from "motion/react";
+import { useRouter } from "next/navigation";
+
+interface SuccessSectionProps {
+  /** 用戶名稱，用於個人化歡迎訊息 */
+  userName?: string;
+}
+
+/**
+ * Onboarding Step 4: 完成頁面
+ * 顯示歡迎訊息和後續引導
+ */
+export const SuccessSection = ({ userName }: SuccessSectionProps) => {
+  const t = useTranslations("onboarding");
+  const router = useRouter();
+
+  const handleGoToPreferences = () => {
+    router.push("/settings/preferences");
+  };
+
+  const handleSkip = () => {
+    router.push("/");
+  };
+
+  return (
+    <>
+      {/* Confetti 彩帶動畫 */}
+      <ConfettiAnimation />
+
+      <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
+        {/* Lottie 動畫 */}
+        <motion.div
+          className="w-[200px] h-[150px] mb-4"
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.5 }}
+        >
+          <Lottie
+            animationData={featureHappyJson}
+            className="w-full h-full"
+            loop={true}
+            autoplay={true}
+          />
+        </motion.div>
+
+        {/* 歡迎標題 */}
+        <motion.h1
+          className="heading-xl text-text-dark mb-4"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+        >
+          {userName ? t("steps.success.titleWithName", { name: userName }) : t("steps.success.title")}
+        </motion.h1>
+
+        {/* Email 提醒 */}
+        <motion.div
+          className="flex items-center gap-2 text-light-gray mb-8"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.4 }}
+        >
+          <MailIcon className="size-4" />
+          <span>{t("steps.success.emailReminder")}</span>
+        </motion.div>
+
+        {/* CTA 按鈕 */}
+        <motion.div
+          className="w-full max-w-sm space-y-3"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.6 }}
+        >
+          <Button
+            variant="ctaPrimary"
+            className="w-full"
+            onClick={handleGoToPreferences}
+          >
+            {t("steps.success.primaryButton")}
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={handleSkip}
+          >
+            {t("steps.success.secondaryButton")}
+          </Button>
+        </motion.div>
+      </div>
+    </>
+  );
+};

--- a/apps/product/src/components/onboarding/use-onboarding-step.ts
+++ b/apps/product/src/components/onboarding/use-onboarding-step.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+
+interface UseOnboardingStepReturn {
+  /** 當前步驟 (1-4) */
+  currentStep: number;
+  /** 總步驟數 */
+  totalSteps: number;
+  /** 前往下一步 */
+  nextStep: () => void;
+  /** 返回上一步 */
+  prevStep: () => void;
+  /** 跳轉到指定步驟 */
+  goToStep: (step: number) => void;
+  /** 是否為第一步 */
+  isFirstStep: boolean;
+  /** 是否為最後一步（提交前） */
+  isLastInputStep: boolean;
+  /** 是否為成功頁面 */
+  isSuccessStep: boolean;
+}
+
+/**
+ * Onboarding 步驟管理 Hook
+ *
+ * 管理 Onboarding 流程的步驟狀態：
+ * - Step 1: Profile (個人資料)
+ * - Step 2: Interests (興趣領域)
+ * - Step 3: Referral (來源調查)
+ * - Step 4: Success (完成頁面)
+ */
+export const useOnboardingStep = (initialStep = 1): UseOnboardingStepReturn => {
+  const [currentStep, setCurrentStep] = useState(initialStep);
+  const totalSteps = 4;
+
+  const nextStep = useCallback(() => {
+    setCurrentStep((prev) => Math.min(prev + 1, totalSteps));
+  }, []);
+
+  const prevStep = useCallback(() => {
+    setCurrentStep((prev) => Math.max(prev - 1, 1));
+  }, []);
+
+  const goToStep = useCallback(
+    (step: number) => {
+      if (step >= 1 && step <= totalSteps) {
+        setCurrentStep(step);
+      }
+    },
+    []
+  );
+
+  return {
+    currentStep,
+    totalSteps,
+    nextStep,
+    prevStep,
+    goToStep,
+    isFirstStep: currentStep === 1,
+    isLastInputStep: currentStep === 3,
+    isSuccessStep: currentStep === 4,
+  };
+};

--- a/apps/product/src/components/settings/account/account-form.tsx
+++ b/apps/product/src/components/settings/account/account-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { type UpdateUserRequest, useCurrentUser, useUserMutations } from "@daodao/api";
+import { type UpdateUserRequest, useCities, useCurrentUser, useUserMutations } from "@daodao/api";
+import { useLocale } from "@daodao/i18n";
 import { Button } from "@daodao/ui/components/button";
 import { Form } from "@daodao/ui/components/form";
 import { toast } from "@daodao/ui/components/sonner";
@@ -21,15 +22,23 @@ import {
 } from "./schema";
 
 export const AccountForm = () => {
+  const locale = useLocale();
   const { data: userData, isLoading, error: userError } = useCurrentUser();
   const { updateCurrentUser } = useUserMutations();
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 獲取城市列表以找到用戶 location 對應的 countryCode（傳入 locale 以支援多語系）
+  const { data: citiesData } = useCities({
+    locale: locale === "en" ? "en" : "zh-TW",
+  });
 
   const form = useForm<AccountFormValues>({
     resolver: zodResolver(accountFormSchema),
     defaultValues: {
       email: "",
       birthday: undefined,
+      country: "",
+      location: "",
       position: [],
       educationStage: "",
       professionalFields: [],
@@ -41,16 +50,28 @@ export const AccountForm = () => {
   useEffect(() => {
     if (userData?.data) {
       const user = userData.data;
+
+      // 根據 location 找到對應的 countryCode
+      let countryCode = "";
+      if (user.location && citiesData?.data) {
+        const city = citiesData.data.find((c) => c.code === user.location);
+        if (city?.countryCode) {
+          countryCode = city.countryCode;
+        }
+      }
+
       form.reset({
         email: user.email || "",
         birthday: user.birthDay ? parse(user.birthDay, "yyyy-MM-dd", new Date()) : undefined,
+        country: countryCode,
+        location: user.location || "",
         position: user.positionList || [],
         educationStage: user.educationStage || "",
-        professionalFields: user.tagList || [],
+        professionalFields: user.professionalField || [],
         explorationFields: user.interestList || [],
       });
     }
-  }, [userData, form.reset]);
+  }, [userData, citiesData, form.reset]);
 
   const handleSubmit = async (values: AccountFormValues) => {
     setIsSubmitting(true);
@@ -59,15 +80,21 @@ export const AccountForm = () => {
       // 準備 API 請求資料
       const updateData: {
         birthDay?: string;
+        location?: string;
         positionList?: string[];
         educationStage?: string;
-        tagList?: string[];
+        professionalField?: string[];
         interestList?: string[];
       } = {};
 
       // 轉換生日
       if (values.birthday) {
         updateData.birthDay = format(values.birthday, "yyyy-MM-dd");
+      }
+
+      // 居住地（城市代碼）
+      if (values.location) {
+        updateData.location = values.location;
       }
 
       // 身份（直接對應資料庫值，允許多選）
@@ -79,7 +106,7 @@ export const AccountForm = () => {
       }
 
       // 轉換專業領域和探索領域（總是包含，允許清空）
-      updateData.tagList = values.professionalFields;
+      updateData.professionalField = values.professionalFields;
       updateData.interestList = values.explorationFields;
 
       // 調用 API
@@ -101,9 +128,10 @@ export const AccountForm = () => {
                 // 將錯誤設置到對應的表單欄位
                 const formFieldMap: Record<string, keyof AccountFormValues> = {
                   birthDay: "birthday",
+                  location: "location",
                   positionList: "position",
                   educationStage: "educationStage",
-                  tagList: "professionalFields",
+                  professionalField: "professionalFields",
                   interestList: "explorationFields",
                 };
 

--- a/apps/product/src/components/settings/account/personal-info-section.tsx
+++ b/apps/product/src/components/settings/account/personal-info-section.tsx
@@ -52,15 +52,6 @@ export const PersonalInfoSection = ({
   const countries = (countriesData?.data ?? []).filter((c) => c.code);
   const cities = (citiesData?.data ?? []).filter((c) => c.code);
 
-  // Debug: 檢查城市選擇器的狀態
-  console.log("[City Select Debug]", {
-    selectedCountry,
-    isLoadingCities,
-    citiesDataLength: citiesData?.data?.length,
-    filteredCitiesLength: cities.length,
-    rawCitiesData: citiesData?.data?.slice(0, 3), // 只顯示前3筆
-  });
-
   // 當國家變更時，清空城市選擇
   const handleCountryChange = (value: string) => {
     form.setValue("country", value);

--- a/apps/product/src/components/settings/account/personal-info-section.tsx
+++ b/apps/product/src/components/settings/account/personal-info-section.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCities, useCountries } from "@daodao/api";
+import { useLocale } from "@daodao/i18n";
 import {
   FormControl,
   FormField,
@@ -17,7 +19,7 @@ import {
 } from "@daodao/ui/components/select";
 import { cn } from "@daodao/ui/lib/utils";
 import { format } from "date-fns";
-import { Calendar, Mail } from "lucide-react";
+import { Calendar, Mail, MapPin } from "lucide-react";
 import type { UseFormReturn } from "react-hook-form";
 import type { AccountFormValues } from "./schema";
 
@@ -35,6 +37,36 @@ export const PersonalInfoSection = ({
   form,
   educationStageOptions,
 }: PersonalInfoSectionProps) => {
+  const locale = useLocale();
+  const selectedCountry = form.watch("country");
+
+  // 獲取國家列表
+  const { data: countriesData, isLoading: isLoadingCountries } = useCountries();
+
+  // 根據選擇的國家獲取城市列表（傳入 locale 以支援多語系）
+  const { data: citiesData, isLoading: isLoadingCities } = useCities({
+    country: selectedCountry || undefined,
+    locale: locale === "en" ? "en" : "zh-TW",
+  });
+
+  const countries = (countriesData?.data ?? []).filter((c) => c.code);
+  const cities = (citiesData?.data ?? []).filter((c) => c.code);
+
+  // Debug: 檢查城市選擇器的狀態
+  console.log("[City Select Debug]", {
+    selectedCountry,
+    isLoadingCities,
+    citiesDataLength: citiesData?.data?.length,
+    filteredCitiesLength: cities.length,
+    rawCitiesData: citiesData?.data?.slice(0, 3), // 只顯示前3筆
+  });
+
+  // 當國家變更時，清空城市選擇
+  const handleCountryChange = (value: string) => {
+    form.setValue("country", value);
+    form.setValue("location", "");
+  };
+
   return (
     <div className="bg-white rounded-xl p-4 space-y-4">
       {/* Email */}
@@ -78,7 +110,7 @@ export const PersonalInfoSection = ({
                     value={date ? format(date, "yyyy/MM/dd") : ""}
                     disabled
                     className="pl-11 bg-very-light-gray"
-                    placeholder="Email"
+                    placeholder="尚未設定"
                   />
                 </div>
               </FormControl>
@@ -86,6 +118,102 @@ export const PersonalInfoSection = ({
             </FormItem>
           );
         }}
+      />
+
+      {/* 居住地 - 國家 */}
+      <FormField
+        control={form.control}
+        name="country"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">居住地</FormLabel>
+            <FormControl>
+              <div className="relative">
+                <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-light-gray z-10" />
+                <Select
+                  value={field.value || ""}
+                  onValueChange={handleCountryChange}
+                  disabled={field.disabled || isLoadingCountries}
+                >
+                  <SelectTrigger
+                    className={cn(
+                      "w-full h-10 pl-11 pr-4 py-2 text-left font-normal text-sm",
+                      "border border-bg-gray hover:border-logo-cyan bg-background rounded-lg",
+                      "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
+                      form.formState.errors.country && "border-red",
+                      "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray",
+                      "data-placeholder:text-light-gray"
+                    )}
+                    aria-invalid={!!form.formState.errors.country}
+                  >
+                    <SelectValue placeholder={isLoadingCountries ? "載入中..." : "請選擇國家"} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {countries.map((country) => (
+                      <SelectItem key={country.code} value={country.code}>
+                        {locale === "en" ? (country.nameEn || country.name) : country.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 居住地 - 城市 */}
+      <FormField
+        control={form.control}
+        name="location"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <div className="relative">
+                <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-light-gray z-10" />
+                <Select
+                  value={field.value || ""}
+                  onValueChange={(value) => {
+                    field.onChange(value);
+                    field.onBlur();
+                  }}
+                  disabled={field.disabled || !selectedCountry || isLoadingCities}
+                >
+                  <SelectTrigger
+                    className={cn(
+                      "w-full h-10 pl-11 pr-4 py-2 text-left font-normal text-sm",
+                      "border border-bg-gray hover:border-logo-cyan bg-background rounded-lg",
+                      "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
+                      form.formState.errors.location && "border-red",
+                      "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray",
+                      "data-placeholder:text-light-gray"
+                    )}
+                    aria-invalid={!!form.formState.errors.location}
+                  >
+                    <SelectValue
+                      placeholder={
+                        !selectedCountry
+                          ? "請先選擇國家"
+                          : isLoadingCities
+                            ? "載入中..."
+                            : "請選擇城市"
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {cities.map((city) => (
+                      <SelectItem key={city.code} value={city.code}>
+                        {city.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
       />
 
       {/* 教育階段 */}

--- a/apps/product/src/components/settings/account/schema.ts
+++ b/apps/product/src/components/settings/account/schema.ts
@@ -21,6 +21,8 @@ export const accountFormSchema = z.object({
       { message: "必須年滿16歲" }
     )
     .optional(),
+  country: z.string().optional(),
+  location: z.string().optional(),
   position: z.array(z.string()).min(1, "請至少選擇一個身份").default([]),
   educationStage: z.string().min(1, "請選擇教育階段"),
   professionalFields: z.array(z.string()).max(5, "最多只能選擇5個專業領域").default([]),

--- a/apps/product/src/components/settings/settings-list.tsx
+++ b/apps/product/src/components/settings/settings-list.tsx
@@ -2,7 +2,8 @@
 
 import { ArrowRightOutlineSvg } from "@daodao/assets";
 import { CustomLink } from "@daodao/ui/components/custom-link";
-import { Archive, LibraryBig, Settings, SquareUser } from "lucide-react";
+import { Archive, LibraryBig, LogOut, Settings, SquareUser } from "lucide-react";
+import { useLogoutDialog } from "@/hooks/use-logout-dialog";
 
 type SettingsItem = {
   id: string;
@@ -39,25 +40,47 @@ const settingsItems: SettingsItem[] = [
 ];
 
 export const SettingsList = () => {
-  return (
-    <ul className="flex flex-col gap-2">
-      {settingsItems.map((item) => {
-        const Icon = item.icon;
+  const { openLogoutDialog, isLoggingOut } = useLogoutDialog();
 
-        return (
-          <li key={item.id}>
-            <CustomLink
-              href={item.href}
-              className="flex items-center gap-2 p-3 rounded bg-white hover:bg-light-blue transition-colors"
-              aria-label={item.label}
-            >
-              <Icon className="size-4.5 text-light-gray shrink-0" />
-              <span className="flex-1 text-base text-text-dark">{item.label}</span>
-              <ArrowRightOutlineSvg className="size-4.5 text-bg-dark shrink-0" />
-            </CustomLink>
-          </li>
-        );
-      })}
-    </ul>
+  const handleLogout = async () => {
+    await openLogoutDialog();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <ul className="flex flex-col gap-2">
+        {settingsItems.map((item) => {
+          const Icon = item.icon;
+
+          return (
+            <li key={item.id}>
+              <CustomLink
+                href={item.href}
+                className="flex items-center gap-2 p-3 rounded bg-white hover:bg-light-blue transition-colors"
+                aria-label={item.label}
+              >
+                <Icon className="size-4.5 text-light-gray shrink-0" />
+                <span className="flex-1 text-base text-text-dark">{item.label}</span>
+                <ArrowRightOutlineSvg className="size-4.5 text-bg-dark shrink-0" />
+              </CustomLink>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* 登出按鈕 */}
+      <button
+        type="button"
+        onClick={handleLogout}
+        disabled={isLoggingOut}
+        className="flex items-center gap-2 p-3 rounded bg-white hover:bg-red/10 transition-colors text-red disabled:opacity-50 disabled:cursor-not-allowed"
+        aria-label="登出"
+      >
+        <LogOut className="size-4.5 shrink-0" />
+        <span className="flex-1 text-base text-left">
+          {isLoggingOut ? "登出中..." : "登出"}
+        </span>
+      </button>
+    </div>
   );
 };

--- a/apps/product/src/constants/referral-source.ts
+++ b/apps/product/src/constants/referral-source.ts
@@ -1,0 +1,17 @@
+/**
+ * 推薦來源選項列表
+ * 對應 API referralSource enum
+ * value: 英文鍵值（傳送給後端）
+ * label: 中文顯示名稱（前端顯示）
+ */
+export const REFERRAL_SOURCE_OPTIONS = [
+  { value: "instagram", label: "Instagram" },
+  { value: "facebook", label: "FB" },
+  { value: "discord", label: "Discord" },
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "friend_referral", label: "朋友介紹" },
+  { value: "others", label: "其他" },
+] as const;
+
+export type ReferralSourceValue = (typeof REFERRAL_SOURCE_OPTIONS)[number]["value"];
+export type ReferralSourceLabel = (typeof REFERRAL_SOURCE_OPTIONS)[number]["label"];

--- a/apps/product/src/hooks/use-logout-dialog.tsx
+++ b/apps/product/src/hooks/use-logout-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useAuth } from "@daodao/auth";
+import { useRouter } from "@daodao/i18n/navigation";
+import { useDialog } from "@daodao/ui/hooks/use-dialog";
+import { useCallback, useState } from "react";
+import { useSWRConfig } from "swr";
+
+export enum LogoutResult {
+  /** 用戶已成功登出 */
+  LoggedOut,
+  /** 用戶取消了操作 */
+  Cancelled,
+}
+
+/**
+ * 使用全局 DialogManager 來顯示登出確認對話框的 Hook
+ *
+ * @example
+ * ```tsx
+ * const { openLogoutDialog, isLoggingOut } = useLogoutDialog();
+ *
+ * // 當需要顯示對話框時
+ * const result = await openLogoutDialog();
+ *
+ * if (result === LogoutResult.LoggedOut) {
+ *   // 用戶已成功登出
+ * }
+ * ```
+ */
+export function useLogoutDialog() {
+  const { openWarningDialog } = useDialog();
+  const { logout } = useAuth();
+  const { cache } = useSWRConfig();
+  const router = useRouter();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const openLogoutDialog = useCallback(async (): Promise<LogoutResult> => {
+    // 顯示確認對話框
+    const result = await openWarningDialog({
+      title: "確定要登出嗎？",
+      message: "登出後需要重新登入才能使用完整功能。",
+      textAlign: "left",
+      buttons: [
+        { label: "確定登出", value: "confirm", variant: "outline" },
+        { label: "取消", value: "cancel", variant: "orange" },
+      ],
+    });
+
+    // 如果用戶取消，直接返回
+    if (result.value !== "confirm") {
+      return LogoutResult.Cancelled;
+    }
+
+    // 用戶確認登出
+    setIsLoggingOut(true);
+    try {
+      // 執行登出
+      await logout();
+
+      // 清除 SWR cache
+      if (cache instanceof Map) {
+        cache.clear();
+      }
+
+      // 重定向到首頁
+      router.push("/");
+
+      return LogoutResult.LoggedOut;
+    } finally {
+      setIsLoggingOut(false);
+    }
+  }, [openWarningDialog, logout, cache, router]);
+
+  return { openLogoutDialog, isLoggingOut };
+}

--- a/apps/website/src/components/layout/footer.tsx
+++ b/apps/website/src/components/layout/footer.tsx
@@ -1,15 +1,54 @@
 "use client";
 
+import { useState } from "react";
 import { useTranslations } from "@daodao/i18n";
 import { ANCHOR_IDS, SOCIAL_LINKS } from "@daodao/shared";
 import { Button } from "@daodao/ui/components/button";
 import { CustomLink } from "@daodao/ui/components/custom-link";
 import { Image } from "@daodao/ui/components/image";
 import { LanguageSwitcher } from "@daodao/ui/components/language-switcher";
-import { ChevronRight } from "lucide-react";
+import { Check, ChevronRight } from "lucide-react";
+
+type SubscribeStatus = "idle" | "loading" | "success" | "error";
 
 export const Footer = () => {
   const t = useTranslations("common");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<SubscribeStatus>("idle");
+
+  const handleSubscribe = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const formId = process.env.NEXT_PUBLIC_KIT_FORM_ID;
+    if (!email || !formId) return;
+
+    setStatus("loading");
+    try {
+      const formData = new FormData();
+      formData.append("email_address", email);
+      if (name) {
+        formData.append("first_name", name);
+      }
+
+      const response = await fetch(
+        `https://app.kit.com/forms/${formId}/subscriptions`,
+        {
+          method: "POST",
+          body: formData,
+        }
+      );
+
+      if (response.ok) {
+        setStatus("success");
+        setName("");
+        setEmail("");
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    }
+  };
 
   return (
     <footer className="bg-basic-600 pb-20 pt-12 text-white md:pb-12">
@@ -108,16 +147,51 @@ export const Footer = () => {
           </div>
           <div className="space-y-4">
             <p className="text-lg text-primary-lighter">{t("footer_newsletter_title")}</p>
-            <form className="space-y-3">
+            <form className="space-y-3" onSubmit={handleSubscribe}>
               <input
-                className="w-full rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-white placeholder:text-white/50 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-base"
-                type="email"
-                placeholder={t("footer_email_placeholder")}
+                className="w-full rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-white placeholder:text-white/50 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-base disabled:opacity-50"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t("footer_name_placeholder")}
+                disabled={status === "loading" || status === "success"}
               />
-              <Button type="submit" variant="ctaPrimary" size="huge" className="w-full">
-                {t("footer_subscribe_button")}
-                <ChevronRight className="ml-2 size-5" />
+              <input
+                className="w-full rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-white placeholder:text-white/50 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-base disabled:opacity-50"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder={t("footer_email_placeholder")}
+                disabled={status === "loading" || status === "success"}
+                required
+              />
+              <Button
+                type="submit"
+                variant="ctaPrimary"
+                size="huge"
+                className="w-full"
+                disabled={status === "loading" || status === "success" || !email}
+              >
+                {status === "loading" && t("footer_subscribing")}
+                {status === "success" && (
+                  <>
+                    {t("footer_subscribed")}
+                    <Check className="ml-2 size-5" />
+                  </>
+                )}
+                {(status === "idle" || status === "error") && (
+                  <>
+                    {t("footer_subscribe_button")}
+                    <ChevronRight className="ml-2 size-5" />
+                  </>
+                )}
               </Button>
+              {status === "success" && (
+                <p className="text-sm text-primary-lighter">{t("footer_subscribe_confirm_hint")}</p>
+              )}
+              {status === "error" && (
+                <p className="text-sm text-red-400">{t("footer_subscribe_error")}</p>
+              )}
             </form>
           </div>
         </div>

--- a/packages/api/src/services/auth-hooks.ts
+++ b/packages/api/src/services/auth-hooks.ts
@@ -10,6 +10,7 @@ import type {
   ForgotPasswordRequest,
   LoginRequest,
   RegisterRequest,
+  ResendVerificationRequest,
   ResetPasswordRequest,
   VerifyEmailRequest,
 } from "./auth";
@@ -80,6 +81,22 @@ export const useAuthMutations = () => {
       return client.POST("/api/v1/auth/verify-email", {
         body: data,
       });
+    },
+
+    /**
+     * 重新發送驗證郵件
+     */
+    resendVerificationEmail: async (data: ResendVerificationRequest) => {
+      return client.POST("/api/v1/auth/resend-verification", {
+        body: data,
+      });
+    },
+
+    /**
+     * 獲取當前認證用戶資訊
+     */
+    getAuthMe: async () => {
+      return client.GET("/api/v1/auth/me");
     },
   };
 };

--- a/packages/api/src/services/auth.ts
+++ b/packages/api/src/services/auth.ts
@@ -3,8 +3,11 @@
  * 提供認證相關的 API 調用函數
  */
 
+import { getRequiredEnv } from "@daodao/config";
 import { client } from "../client";
 import type { paths } from "../types";
+
+const API_URL = getRequiredEnv("NEXT_PUBLIC_API_URL");
 
 // ============================================================================
 // Types
@@ -31,6 +34,13 @@ type ResetPasswordRequest = paths["/api/v1/auth/reset-password"]["post"]["reques
   ? T
   : never;
 type VerifyEmailRequest = paths["/api/v1/auth/verify-email"]["post"]["requestBody"] extends {
+  content: { "application/json": infer T };
+}
+  ? T
+  : never;
+type ResendVerificationRequest = NonNullable<
+  paths["/api/v1/auth/resend-verification"]["post"]["requestBody"]
+> extends {
   content: { "application/json": infer T };
 }
   ? T
@@ -100,13 +110,30 @@ export const verifyEmail = async (data: VerifyEmailRequest) => {
 };
 
 /**
+ * 重新發送驗證郵件
+ */
+export const resendVerificationEmail = async (data: ResendVerificationRequest) => {
+  return client.POST("/api/v1/auth/resend-verification", {
+    body: data,
+  });
+};
+
+/**
+ * 獲取當前認證用戶資訊（支援臨時用戶）
+ * 使用 /api/v1/auth/me 端點，可正確處理臨時用戶狀態
+ */
+export const getAuthMe = async () => {
+  return client.GET("/api/v1/auth/me");
+};
+
+/**
  * 啟動 Google OAuth 登入（重定向到後端）
  * 注意：這會觸發瀏覽器重定向，不返回 Response
  */
 export const initiateGoogleOAuth = (state?: string) => {
   const url = state
-    ? `/api/v1/auth/google?state=${encodeURIComponent(state)}`
-    : "/api/v1/auth/google";
+    ? `${API_URL}/api/v1/auth/google?state=${encodeURIComponent(state)}`
+    : `${API_URL}/api/v1/auth/google`;
   // 這會由瀏覽器處理重定向，不需要返回 Response
   if (typeof window !== "undefined") {
     window.location.href = url;
@@ -123,4 +150,5 @@ export type {
   ForgotPasswordRequest,
   ResetPasswordRequest,
   VerifyEmailRequest,
+  ResendVerificationRequest,
 };

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -23,3 +23,5 @@ export * from "./resource-hooks";
 // User Service
 export * from "./user";
 export * from "./user-hooks";
+// Location Service
+export * from "./location-hooks";

--- a/packages/api/src/services/location-hooks.ts
+++ b/packages/api/src/services/location-hooks.ts
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * Location API Hooks
+ * 提供國家和城市相關的 React Hooks（用於 Client Components）
+ */
+
+import { useQuery } from "../hooks";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface IGetCitiesParams {
+  /** 國家代碼（ISO 3166-1 alpha-2） */
+  country?: string;
+  /** 搜尋關鍵字（支援城市代碼、中文名、英文名） */
+  search?: string;
+  /** 語系，決定城市名稱顯示語言 */
+  locale?: "zh-TW" | "en" | "default";
+  /** 回傳數量限制 */
+  limit?: number;
+}
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * 獲取國家列表的 Hook
+ */
+export const useCountries = () => {
+  return useQuery("/api/v1/cities/countries");
+};
+
+/**
+ * 獲取城市列表的 Hook
+ * @param params 查詢參數
+ * @param params.country 國家代碼篩選（ISO 3166-1 alpha-2，如 TW, JP, US）
+ * @param params.search 搜尋關鍵字
+ * @param params.locale 語系
+ * @param params.limit 回傳數量限制
+ */
+export const useCities = (params?: IGetCitiesParams) => {
+  return useQuery("/api/v1/cities", {
+    params: {
+      query: params,
+    },
+  });
+};

--- a/packages/api/src/services/user-hooks.ts
+++ b/packages/api/src/services/user-hooks.ts
@@ -14,7 +14,7 @@ import type {
   UpdateUserFormDataRequest,
   UpdateUserRequest,
 } from "./user";
-import { updateCurrentUserWithFormData } from "./user";
+import { createCurrentUserWithFormData, updateCurrentUserWithFormData } from "./user";
 
 // ============================================================================
 // Query Hooks
@@ -152,6 +152,18 @@ export const useUserMutations = () => {
       photoFile?: File
     ) => {
       return updateCurrentUserWithFormData(data, photoFile);
+    },
+
+    /**
+     * 創建當前用戶（用於臨時用戶完成 onboarding）
+     * @param data 用戶資料
+     * @param photoFile 可選的頭像圖片檔案
+     */
+    createCurrentUserWithFormData: async (
+      data: UpdateUserFormDataRequest,
+      photoFile?: File
+    ) => {
+      return createCurrentUserWithFormData(data, photoFile);
     },
 
     /**

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -171,15 +171,10 @@ export interface UpdateUserFormDataRequest {
 }
 
 /**
- * 更新當前用戶資訊（FormData 格式，支援圖片上傳）
- * @param data 用戶資料
- * @param photoFile 可選的頭像圖片檔案
- * @returns 更新結果
+ * 建立用戶資料的 FormData
+ * 將 UpdateUserFormDataRequest 轉換為 FormData 格式
  */
-export const updateCurrentUserWithFormData = async (
-  data: UpdateUserFormDataRequest,
-  photoFile?: File
-): Promise<UpdateUserResponse> => {
+const buildUserFormData = (data: UpdateUserFormDataRequest, photoFile?: File): FormData => {
   const formData = new FormData();
 
   // 基本欄位（string）
@@ -219,18 +214,29 @@ export const updateCurrentUserWithFormData = async (
   // 圖片檔案（後端期望欄位名為 'avatar'）
   if (photoFile) formData.append("avatar", photoFile);
 
+  return formData;
+};
+
+/**
+ * 發送用戶 FormData 請求的共用邏輯
+ */
+const sendUserFormDataRequest = async <T>(
+  method: "POST" | "PUT",
+  formData: FormData,
+  errorMessage: string
+): Promise<T> => {
   const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
   const response = await unauthorizedHandler.wrapFetch(`${baseUrl}/api/v1/users/me`, {
-    method: "PUT",
+    method,
     body: formData,
     credentials: "include",
   });
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({
-      error: { message: "更新失敗" },
+      error: { message: errorMessage },
     }));
-    const error = new Error(errorData.error?.message || "更新失敗") as Error & {
+    const error = new Error(errorData.error?.message || errorMessage) as Error & {
       details?: Array<{ path?: string; message?: string }>;
     };
     // 附加驗證錯誤詳情（供表單使用）
@@ -241,6 +247,20 @@ export const updateCurrentUserWithFormData = async (
   }
 
   return response.json();
+};
+
+/**
+ * 更新當前用戶資訊（FormData 格式，支援圖片上傳）
+ * @param data 用戶資料
+ * @param photoFile 可選的頭像圖片檔案
+ * @returns 更新結果
+ */
+export const updateCurrentUserWithFormData = async (
+  data: UpdateUserFormDataRequest,
+  photoFile?: File
+): Promise<UpdateUserResponse> => {
+  const formData = buildUserFormData(data, photoFile);
+  return sendUserFormDataRequest<UpdateUserResponse>("PUT", formData, "更新失敗");
 };
 
 /**
@@ -259,67 +279,8 @@ export const createCurrentUserWithFormData = async (
   data: UpdateUserFormDataRequest,
   photoFile?: File
 ): Promise<CreateUserResponse> => {
-  const formData = new FormData();
-
-  // 基本欄位（string）
-  if (data.name) formData.append("name", data.name);
-  if (data.customId) formData.append("customId", data.customId);
-  if (data.location) formData.append("location", data.location);
-  if (data.gender) formData.append("gender", data.gender);
-  if (data.birthDay) formData.append("birthDay", data.birthDay);
-  if (data.selfIntroduction) formData.append("selfIntroduction", data.selfIntroduction);
-  if (data.personalSlogan) formData.append("personalSlogan", data.personalSlogan);
-
-  // Boolean 欄位需轉成字串
-  if (data.isOpenLocation !== undefined) {
-    formData.append("isOpenLocation", String(data.isOpenLocation));
-  }
-  if (data.isOpenProfile !== undefined) {
-    formData.append("isOpenProfile", String(data.isOpenProfile));
-  }
-  if (data.isSubscribeEmail !== undefined) {
-    formData.append("isSubscribeEmail", String(data.isSubscribeEmail));
-  }
-
-  // 其他 string 欄位
-  if (data.educationStage) formData.append("educationStage", data.educationStage);
-  if (data.referralSource) formData.append("referralSource", data.referralSource);
-
-  // 陣列/物件欄位需轉成 JSON 字串
-  if (data.tagList) formData.append("tagList", JSON.stringify(data.tagList));
-  if (data.roleList) formData.append("roleList", JSON.stringify(data.roleList));
-  if (data.interestList) formData.append("interestList", JSON.stringify(data.interestList));
-  if (data.contactList) formData.append("contactList", JSON.stringify(data.contactList));
-  if (data.wantToDoList) formData.append("wantToDoList", JSON.stringify(data.wantToDoList));
-  if (data.professionalField) formData.append("professionalField", JSON.stringify(data.professionalField));
-  if (data.share) formData.append("share", JSON.stringify(data.share));
-  if (data.preferences) formData.append("preferences", JSON.stringify(data.preferences));
-
-  // 圖片檔案（後端期望欄位名為 'avatar'）
-  if (photoFile) formData.append("avatar", photoFile);
-
-  const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
-  const response = await unauthorizedHandler.wrapFetch(`${baseUrl}/api/v1/users/me`, {
-    method: "POST",
-    body: formData,
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({
-      error: { message: "創建失敗" },
-    }));
-    const error = new Error(errorData.error?.message || "創建失敗") as Error & {
-      details?: Array<{ path?: string; message?: string }>;
-    };
-    // 附加驗證錯誤詳情（供表單使用）
-    if (errorData.error?.details && Array.isArray(errorData.error.details)) {
-      error.details = errorData.error.details;
-    }
-    throw error;
-  }
-
-  return response.json();
+  const formData = buildUserFormData(data, photoFile);
+  return sendUserFormDataRequest<CreateUserResponse>("POST", formData, "創建失敗");
 };
 
 /**

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -244,6 +244,85 @@ export const updateCurrentUserWithFormData = async (
 };
 
 /**
+ * 創建用戶 API 回應類型
+ */
+type CreateUserResponse =
+  paths["/api/v1/users/me"]["post"]["responses"]["201"]["content"]["application/json"];
+
+/**
+ * 創建當前用戶（用於臨時用戶完成 onboarding）
+ * @param data 用戶資料
+ * @param photoFile 可選的頭像圖片檔案
+ * @returns 創建結果
+ */
+export const createCurrentUserWithFormData = async (
+  data: UpdateUserFormDataRequest,
+  photoFile?: File
+): Promise<CreateUserResponse> => {
+  const formData = new FormData();
+
+  // 基本欄位（string）
+  if (data.name) formData.append("name", data.name);
+  if (data.customId) formData.append("customId", data.customId);
+  if (data.location) formData.append("location", data.location);
+  if (data.gender) formData.append("gender", data.gender);
+  if (data.birthDay) formData.append("birthDay", data.birthDay);
+  if (data.selfIntroduction) formData.append("selfIntroduction", data.selfIntroduction);
+  if (data.personalSlogan) formData.append("personalSlogan", data.personalSlogan);
+
+  // Boolean 欄位需轉成字串
+  if (data.isOpenLocation !== undefined) {
+    formData.append("isOpenLocation", String(data.isOpenLocation));
+  }
+  if (data.isOpenProfile !== undefined) {
+    formData.append("isOpenProfile", String(data.isOpenProfile));
+  }
+  if (data.isSubscribeEmail !== undefined) {
+    formData.append("isSubscribeEmail", String(data.isSubscribeEmail));
+  }
+
+  // 其他 string 欄位
+  if (data.educationStage) formData.append("educationStage", data.educationStage);
+  if (data.referralSource) formData.append("referralSource", data.referralSource);
+
+  // 陣列/物件欄位需轉成 JSON 字串
+  if (data.tagList) formData.append("tagList", JSON.stringify(data.tagList));
+  if (data.roleList) formData.append("roleList", JSON.stringify(data.roleList));
+  if (data.interestList) formData.append("interestList", JSON.stringify(data.interestList));
+  if (data.contactList) formData.append("contactList", JSON.stringify(data.contactList));
+  if (data.wantToDoList) formData.append("wantToDoList", JSON.stringify(data.wantToDoList));
+  if (data.professionalField) formData.append("professionalField", JSON.stringify(data.professionalField));
+  if (data.share) formData.append("share", JSON.stringify(data.share));
+  if (data.preferences) formData.append("preferences", JSON.stringify(data.preferences));
+
+  // 圖片檔案（後端期望欄位名為 'avatar'）
+  if (photoFile) formData.append("avatar", photoFile);
+
+  const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
+  const response = await unauthorizedHandler.wrapFetch(`${baseUrl}/api/v1/users/me`, {
+    method: "POST",
+    body: formData,
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({
+      error: { message: "創建失敗" },
+    }));
+    const error = new Error(errorData.error?.message || "創建失敗") as Error & {
+      details?: Array<{ path?: string; message?: string }>;
+    };
+    // 附加驗證錯誤詳情（供表單使用）
+    if (errorData.error?.details && Array.isArray(errorData.error.details)) {
+      error.details = errorData.error.details;
+    }
+    throw error;
+  }
+
+  return response.json();
+};
+
+/**
  * 更新指定用戶資訊
  */
 export const updateUser = async (id: string, data: UpdateUserRequest) => {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -4343,7 +4343,34 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * 驗證電子郵件（連結點擊）
+         * @description 用於郵件中的點擊連結驗證，驗證後重定向到前端頁面
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description 電子郵件驗證令牌 */
+                    token: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 驗證後重定向到前端頁面 */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequestError"];
+                404: components["responses"]["NotFoundError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
         put?: never;
         /**
          * 驗證電子郵件
@@ -4373,6 +4400,52 @@ export interface paths {
                 };
                 400: components["responses"]["BadRequestError"];
                 401: components["responses"]["UnauthorizedError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/resend-verification": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 重新發送驗證郵件
+         * @description 重新發送電子郵件驗證連結到指定郵箱
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ResendVerificationRequest"];
+                };
+            };
+            responses: {
+                /** @description 驗證郵件已重新發送 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResendVerificationResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                404: components["responses"]["NotFoundError"];
                 500: components["responses"]["InternalServerError"];
             };
         };
@@ -18416,6 +18489,107 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/cities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得城市列表
+         * @description 取得可用的城市列表。支援按國家篩選、關鍵字搜尋、指定語系。
+         *
+         *     **查詢參數：**
+         *     - `country`: 國家代碼篩選 (ISO 3166-1 alpha-2，如 TW, JP, US)
+         *     - `search`: 搜尋關鍵字（支援城市代碼、中文名、英文名）
+         *     - `locale`: 語系 (zh-TW, en, default)，決定城市名稱顯示語言
+         *     - `limit`: 回傳數量限制 (預設 50，最大 200)
+         *
+         *     **使用範例：**
+         *     - 取得台灣所有城市: `?country=TW`
+         *     - 搜尋東京: `?search=tokyo` 或 `?search=東京`
+         *     - 英文顯示: `?locale=en`
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 國家代碼（ISO 3166-1 alpha-2） */
+                    country?: string;
+                    /** @description 搜尋關鍵字（支援城市代碼、中文名、英文名） */
+                    search?: string;
+                    /** @description 語系，決定城市名稱顯示語言 */
+                    locale?: "zh-TW" | "en" | "default";
+                    /** @description 回傳數量限制 */
+                    limit?: string | number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得城市列表 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GetCitiesResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/cities/countries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得國家列表
+         * @description 取得所有可用的國家列表，用於國家選擇下拉選單。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得國家列表 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GetCountriesResponse"];
+                    };
+                };
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/health": {
         parameters: {
             query?: never;
@@ -18624,6 +18798,20 @@ export interface components {
              * @example verify@example.com
              * @example user@company.com
              * @example newuser@gmail.com
+             */
+            email: string;
+        };
+        /**
+         * @description 重新發送驗證郵件請求資料
+         * @example {
+         *       "email": "user@example.com"
+         *     }
+         */
+        ResendVerificationRequest: {
+            /**
+             * Format: email
+             * @description 需要重新發送驗證郵件的電子郵件地址
+             * @example user@example.com
              */
             email: string;
         };
@@ -19413,6 +19601,108 @@ export interface components {
                 /**
                  * @description 驗證結果訊息
                  * @example 郵件驗證成功
+                 */
+                message: string;
+            };
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description 重新發送驗證郵件回應
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "message": "驗證郵件已重新發送"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        ResendVerificationResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            /** @description The main response data */
+            data: {
+                /**
+                 * @description 發送結果訊息
+                 * @example 驗證郵件已重新發送
                  */
                 message: string;
             };
@@ -21652,24 +21942,24 @@ export interface components {
              */
             isSendEmail?: boolean;
             /**
-             * @description ESCO 專業領域分類 (可複選，最多 3 個)
+             * @description 專業領域分類 (可複選，最多 3 個)
              * @example [
-             *       "information_and_communication_technologies_icts"
+             *       "technology_ict"
              *     ]
              * @example [
-             *       "information_and_communication_technologies_icts"
+             *       "technology_ict"
              *     ]
              * @example [
-             *       "education",
-             *       "business_administration_and_law"
+             *       "education_learning",
+             *       "business_management"
              *     ]
              * @example [
-             *       "arts_and_humanities",
-             *       "social_sciences_journalism_and_information",
-             *       "language_skills_and_knowledge"
+             *       "arts_creative_design",
+             *       "social_sciences",
+             *       "languages"
              *     ]
              */
-            professionalField?: ("information_and_communication_technologies_icts" | "business_administration_and_law" | "arts_and_humanities" | "natural_sciences_mathematics_and_statistics" | "engineering_manufacturing_and_construction" | "health_and_welfare" | "education" | "social_sciences_journalism_and_information" | "language_skills_and_knowledge" | "services" | "agriculture_forestry_fisheries_and_veterinary" | "others")[];
+            professionalField?: ("technology_ict" | "business_management" | "arts_creative_design" | "science_research" | "engineering_manufacturing" | "health_medicine" | "education_learning" | "social_sciences" | "languages" | "law" | "customer_service_hospitality" | "agriculture_environmental_sciences" | "others")[];
             /**
              * @description 個人標語 (一句話介紹自己)
              * @example 終身學習者,熱愛程式設計與教育
@@ -21865,24 +22155,24 @@ export interface components {
                 [key: string]: string[];
             };
             /**
-             * @description ESCO 專業領域分類 (可複選，最多 3 個)
+             * @description 專業領域分類 (可複選，最多 3 個)
              * @example [
-             *       "information_and_communication_technologies_icts"
+             *       "technology_ict"
              *     ]
              * @example [
-             *       "information_and_communication_technologies_icts"
+             *       "technology_ict"
              *     ]
              * @example [
-             *       "education",
-             *       "business_administration_and_law"
+             *       "education_learning",
+             *       "business_management"
              *     ]
              * @example [
-             *       "arts_and_humanities",
-             *       "social_sciences_journalism_and_information",
-             *       "language_skills_and_knowledge"
+             *       "arts_creative_design",
+             *       "social_sciences",
+             *       "languages"
              *     ]
              */
-            professionalField?: ("information_and_communication_technologies_icts" | "business_administration_and_law" | "arts_and_humanities" | "natural_sciences_mathematics_and_statistics" | "engineering_manufacturing_and_construction" | "health_and_welfare" | "education" | "social_sciences_journalism_and_information" | "language_skills_and_knowledge" | "services" | "agriculture_forestry_fisheries_and_veterinary" | "others")[];
+            professionalField?: ("technology_ict" | "business_management" | "arts_creative_design" | "science_research" | "engineering_manufacturing" | "health_medicine" | "education_learning" | "social_sciences" | "languages" | "law" | "customer_service_hospitality" | "agriculture_environmental_sciences" | "others")[];
             /**
              * @description 個人標語 (一句話介紹自己)
              * @example 終身學習者,熱愛程式設計與教育
@@ -21968,9 +22258,19 @@ export interface components {
             isSubscribeEmail: boolean;
             /**
              * @description 地區代碼
-             * @example taipei
+             * @example taipei_city
              */
             location: string | null;
+            /**
+             * @description 地區顯示名稱（繁體中文）
+             * @example 台北市, 台灣
+             */
+            locationNameZh: string | null;
+            /**
+             * @description 地區顯示名稱（英文）
+             * @example Taipei City, Taiwan
+             */
+            locationNameEn: string | null;
             /**
              * @description 自我介紹
              * @example 我是一名前端工程師，熱愛學習新技術
@@ -22135,12 +22435,12 @@ export interface components {
              */
             customIdCreatedAt: string | null;
             /**
-             * @description ESCO 專業領域分類 (陣列)
+             * @description 專業領域分類 (陣列)
              * @example [
-             *       "information_and_communication_technologies_icts"
+             *       "technology_ict"
              *     ]
              */
-            professionalField: ("information_and_communication_technologies_icts" | "business_administration_and_law" | "arts_and_humanities" | "natural_sciences_mathematics_and_statistics" | "engineering_manufacturing_and_construction" | "health_and_welfare" | "education" | "social_sciences_journalism_and_information" | "language_skills_and_knowledge" | "services" | "agriculture_forestry_fisheries_and_veterinary" | "others")[] | null;
+            professionalField: ("technology_ict" | "business_management" | "arts_creative_design" | "science_research" | "engineering_manufacturing" | "health_medicine" | "education_learning" | "social_sciences" | "languages" | "law" | "customer_service_hospitality" | "agriculture_environmental_sciences" | "others")[] | null;
             /**
              * @description 個人標語
              * @example 終身學習者,熱愛程式設計與教育
@@ -25909,6 +26209,92 @@ export interface components {
              */
             userId: string;
         };
+        /**
+         * @description 城市資料
+         * @example {
+         *       "id": 1,
+         *       "code": "taipei_city",
+         *       "name": "台北市",
+         *       "nameEn": "Taipei City",
+         *       "nameZhTw": "台北市",
+         *       "countryCode": "TW",
+         *       "countryName": "Taiwan",
+         *       "isActive": true
+         *     }
+         */
+        CityData: {
+            /**
+             * @description 城市 ID
+             * @example 1
+             */
+            id: number;
+            /**
+             * @description 城市代碼（唯一識別）
+             * @example taipei_city
+             */
+            code: string;
+            /**
+             * @description 城市顯示名稱（依語系）
+             * @example 台北市
+             */
+            name: string;
+            /**
+             * @description 英文名稱
+             * @example Taipei City
+             */
+            nameEn: string | null;
+            /**
+             * @description 繁體中文名稱
+             * @example 台北市
+             */
+            nameZhTw: string | null;
+            /**
+             * @description 國家代碼
+             * @example TW
+             */
+            countryCode: string | null;
+            /**
+             * @description 國家名稱
+             * @example Taiwan
+             */
+            countryName: string | null;
+            /**
+             * @description 是否啟用
+             * @example true
+             */
+            isActive: boolean;
+        };
+        /**
+         * @description 國家資料
+         * @example {
+         *       "id": 1,
+         *       "code": "TW",
+         *       "name": "Taiwan",
+         *       "nameEn": "Taiwan"
+         *     }
+         */
+        CountryData: {
+            /**
+             * @description 國家 ID
+             * @example 1
+             */
+            id: number;
+            /**
+             * @description 國家代碼（ISO 3166-1 alpha-2）
+             * @example TW
+             */
+            code: string;
+            /**
+             * @description 國家名稱
+             * @example Taiwan
+             */
+            name: string;
+            /**
+             * @description 英文名稱
+             * @example Taiwan
+             */
+            nameEn: string | null;
+        };
         /** @description 我的實踐項目 */
         MyPracticeItem: {
             /**
@@ -26582,6 +26968,93 @@ export interface components {
              * @example true
              */
             deleted: boolean;
+        };
+        /**
+         * @description 城市列表回應
+         * @example {
+         *       "success": true,
+         *       "data": [
+         *         {
+         *           "id": 1,
+         *           "code": "taipei_city",
+         *           "name": "台北市",
+         *           "nameEn": "Taipei City",
+         *           "nameZhTw": "台北市",
+         *           "countryCode": "TW",
+         *           "countryName": "Taiwan",
+         *           "isActive": true
+         *         },
+         *         {
+         *           "id": 2,
+         *           "code": "new_taipei_city",
+         *           "name": "新北市",
+         *           "nameEn": "New Taipei City",
+         *           "nameZhTw": "新北市",
+         *           "countryCode": "TW",
+         *           "countryName": "Taiwan",
+         *           "isActive": true
+         *         }
+         *       ],
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         */
+        GetCitiesResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            /** @description 城市資料陣列 */
+            data: components["schemas"]["CityData"][];
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /** @description Optional metadata */
+            meta?: {
+                searchQuery?: string;
+                processingTime?: number;
+            };
+        };
+        /**
+         * @description 國家列表回應
+         * @example {
+         *       "success": true,
+         *       "data": [
+         *         {
+         *           "id": 1,
+         *           "code": "TW",
+         *           "name": "Taiwan",
+         *           "nameEn": "Taiwan"
+         *         },
+         *         {
+         *           "id": 2,
+         *           "code": "JP",
+         *           "name": "Japan",
+         *           "nameEn": "Japan"
+         *         }
+         *       ],
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         */
+        GetCountriesResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            /** @description 國家資料陣列 */
+            data: components["schemas"]["CountryData"][];
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /** @description Optional metadata */
+            meta?: {
+                processingTime?: number;
+            };
         };
     };
     responses: {

--- a/packages/auth/src/hooks/use-redirect-after-login.ts
+++ b/packages/auth/src/hooks/use-redirect-after-login.ts
@@ -3,11 +3,17 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { decodeOAuthState, verifyAndConsumeOAuthState } from "../lib/auth-client";
-import { DEFAULT_REDIRECT_URL } from "../lib/auth-constants";
+import { DEFAULT_REDIRECT_URL, ONBOARDING_URL } from "../lib/auth-constants";
 
 /**
  * 登入後跳轉的 Hook
  * 在 OAuth callback 頁面使用，處理登入後的跳轉邏輯
+ *
+ * 流程說明：
+ * 1. 解碼並驗證 OAuth state 參數
+ * 2. 檢查是否為新用戶（isNewUser URL 參數）
+ * 3. 新用戶跳轉到 onboarding 流程
+ * 4. 舊用戶跳轉到原目標頁面
  *
  * @example
  * ```typescript
@@ -23,29 +29,48 @@ export const useRedirectAfterLogin = () => {
 
   useEffect(() => {
     const stateParam = searchParams.get("state");
+    const isNewUser = searchParams.get("isNewUser") === "true";
 
     if (!stateParam) {
-      // 沒有 state 參數，跳轉到預設頁面
-      router.push(DEFAULT_REDIRECT_URL);
+      // 沒有 state 參數，根據是否為新用戶決定跳轉
+      if (isNewUser) {
+        router.push(ONBOARDING_URL);
+      } else {
+        router.push(DEFAULT_REDIRECT_URL);
+      }
       return;
     }
 
     // 解碼 state 參數
     const state = decodeOAuthState(stateParam);
     if (!state) {
-      // State 格式錯誤，跳轉到預設頁面
-      router.push(DEFAULT_REDIRECT_URL);
+      // State 格式錯誤，根據是否為新用戶決定跳轉
+      if (isNewUser) {
+        router.push(ONBOARDING_URL);
+      } else {
+        router.push(DEFAULT_REDIRECT_URL);
+      }
       return;
     }
 
     // 驗證並消費 state（會驗證 nonce 並清除，防止重放攻擊）
     if (!verifyAndConsumeOAuthState(state)) {
-      // State 無效、過期或 nonce 不匹配，跳轉到預設頁面
-      router.push(DEFAULT_REDIRECT_URL);
+      // State 無效、過期或 nonce 不匹配，根據是否為新用戶決定跳轉
+      if (isNewUser) {
+        router.push(ONBOARDING_URL);
+      } else {
+        router.push(DEFAULT_REDIRECT_URL);
+      }
       return;
     }
 
-    // 驗證成功，跳轉到目標頁面
-    router.push(state.redirectUrl);
+    // 驗證成功
+    if (isNewUser) {
+      // 新用戶跳轉到 onboarding 流程
+      router.push(ONBOARDING_URL);
+    } else {
+      // 舊用戶跳轉到原目標頁面
+      router.push(state.redirectUrl);
+    }
   }, [searchParams, router]);
 };

--- a/packages/auth/src/lib/auth-constants.ts
+++ b/packages/auth/src/lib/auth-constants.ts
@@ -6,3 +6,8 @@
  * 預設登入後跳轉 URL
  */
 export const DEFAULT_REDIRECT_URL = "/";
+
+/**
+ * 新用戶 Onboarding 流程 URL
+ */
+export const ONBOARDING_URL = "/auth/onboarding";

--- a/packages/auth/src/lib/auth-provider.tsx
+++ b/packages/auth/src/lib/auth-provider.tsx
@@ -3,7 +3,7 @@
 import {
   logout as apiLogout,
   refreshToken as apiRefreshToken,
-  getCurrentUser,
+  getAuthMe,
   unauthorizedHandler,
 } from "@daodao/api";
 import { usePathname } from "@daodao/i18n/navigation";
@@ -66,6 +66,34 @@ export interface AuthProviderRouteConfig {
    * @param currentPath 當前路徑（包含 query string）
    */
   onAuthRequired?: (currentPath: string) => void;
+
+  /**
+   * Onboarding 頁面路徑（用於臨時用戶跳轉）
+   * 當用戶是臨時用戶時，會自動跳轉到此路徑
+   * 例如："/auth/onboarding"
+   */
+  onboardingPath?: string;
+
+  /**
+   * 當偵測到臨時用戶時的回調函數
+   * 如果提供了此函數，則會呼叫此函數而不是使用 onboardingPath 跳轉
+   * @param currentPath 當前路徑（包含 query string）
+   */
+  onTemporaryUser?: (currentPath: string) => void;
+
+  /**
+   * Email 驗證頁面路徑（用於未驗證 email 的用戶跳轉）
+   * 當用戶未驗證 email 時，會自動跳轉到此路徑
+   * 例如："/auth/verify-email"
+   */
+  emailVerificationPath?: string;
+
+  /**
+   * 當偵測到未驗證 email 的用戶時的回調函數
+   * 如果提供了此函數，則會呼叫此函數而不是使用 emailVerificationPath 跳轉
+   * @param currentPath 當前路徑（包含 query string）
+   */
+  onEmailUnverified?: (currentPath: string) => void;
 }
 
 interface AuthProviderProps {
@@ -75,6 +103,10 @@ interface AuthProviderProps {
   defaultProtected?: boolean;
   enableRouteProtection?: boolean;
   onAuthRequired?: (currentPath: string) => void;
+  onboardingPath?: string;
+  onTemporaryUser?: (currentPath: string) => void;
+  emailVerificationPath?: string;
+  onEmailUnverified?: (currentPath: string) => void;
 }
 
 /**
@@ -162,10 +194,16 @@ export const AuthProvider = ({
   defaultProtected = false,
   enableRouteProtection = true,
   onAuthRequired,
+  onboardingPath,
+  onTemporaryUser,
+  emailVerificationPath,
+  onEmailUnverified,
 }: AuthProviderProps) => {
   const [user, setUser] = useState<StoredUser | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [isTemporary, setIsTemporary] = useState(false);
+  const [isEmailVerified, setIsEmailVerified] = useState(true); // 預設為 true，避免閃爍
   const [isLoginDialogOpen, setIsLoginDialogOpen] = useState(false);
   const [loginDialogRedirectUrl, setLoginDialogRedirectUrl] = useState<string | undefined>();
   const [loginDialogSource, setLoginDialogSource] = useState<"website" | "app" | undefined>();
@@ -181,6 +219,14 @@ export const AuthProvider = ({
     setUser(null);
     setIsAuthenticated(false);
     userInfoStorage.remove();
+
+    // 清除可能的認證相關 cookies（僅限非 HttpOnly）
+    if (typeof document !== "undefined") {
+      const cookiesToClear = ["access_token", "refresh_token", "session", "auth_token"];
+      cookiesToClear.forEach((name) => {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      });
+    }
   }, [userInfoStorage]);
 
   /**
@@ -198,33 +244,42 @@ export const AuthProvider = ({
 
   /**
    * 檢查登入狀態
-   * 使用統一的 API 服務獲取當前用戶資訊
+   * 使用 /api/v1/auth/me 端點獲取當前用戶資訊（支援臨時用戶）
    */
   const checkAuth = useCallback(async () => {
     try {
       setIsLoading(true);
-      const response = await getCurrentUser();
+      const response = await getAuthMe();
 
-      if (response.data && response.response.ok && response.data.data) {
-        const userData = response.data.data;
-        // 將完整的 API 使用者資訊轉換為簡化的存儲版本，避免記住敏感資訊
+      if (response.data?.data?.user) {
+        const userData = response.data.data.user;
+        const temporary = response.data.data.isTemporary ?? false;
+        const emailVerified = userData.email_verified ?? false;
+
+        setIsTemporary(temporary);
+        setIsEmailVerified(emailVerified);
+
+        // 即使是臨時用戶也要設置基本的認證狀態
         const storedUser: StoredUser = {
           id: userData.id,
-          customId: userData.customId ?? null,
+          customId: null,
           email: userData.email ?? null,
           name: userData.name ?? null,
-          photoUrl: userData.photoURL ?? null,
+          photoUrl: userData.photo_url ?? null,
         };
         setAuthState(storedUser);
       } else {
         // 未登入或 Token 無效
         clearAuthState();
+        setIsTemporary(false);
+        setIsEmailVerified(true); // 重置為 true
       }
     } catch (error) {
       console.error("Failed to check auth status:", error);
       clearAuthState();
+      setIsTemporary(false);
+      setIsEmailVerified(true); // 重置為 true
     } finally {
-      console.log("checkAuth finally");
       setIsLoading(false);
     }
   }, [clearAuthState, setAuthState]);
@@ -341,6 +396,87 @@ export const AuthProvider = ({
   ]);
 
   /**
+   * 臨時用戶處理：如果用戶是臨時用戶，跳轉到 onboarding 頁面
+   */
+  useEffect(() => {
+    // 如果還在載入中，不進行檢查
+    if (isLoading) {
+      return;
+    }
+
+    // 只處理已登入的臨時用戶
+    if (!isAuthenticated || !isTemporary) {
+      return;
+    }
+
+    // 移除 locale 前綴後檢查是否已在 onboarding 頁面
+    const pathnameWithoutLocale = removeLocalePrefix(pathname);
+    const isOnOnboardingPage = onboardingPath
+      ? pathnameWithoutLocale.startsWith(onboardingPath)
+      : false;
+
+    // 如果已在 onboarding 頁面，不需要跳轉
+    if (isOnOnboardingPage) {
+      return;
+    }
+
+    const currentUrl = pathname + (typeof window !== "undefined" ? window.location.search : "");
+
+    // 優先使用 onTemporaryUser 回調
+    if (onTemporaryUser) {
+      onTemporaryUser(currentUrl);
+    } else if (onboardingPath && typeof window !== "undefined") {
+      // 否則跳轉到 onboardingPath
+      window.location.href = onboardingPath;
+    }
+  }, [pathname, isAuthenticated, isLoading, isTemporary, onboardingPath, onTemporaryUser]);
+
+  /**
+   * Email 未驗證處理：如果用戶未驗證 email，跳轉到驗證頁面
+   * 注意：這個 effect 只在用戶不是臨時用戶時才執行（臨時用戶優先處理 onboarding）
+   */
+  useEffect(() => {
+    // 如果還在載入中，不進行檢查
+    if (isLoading) {
+      return;
+    }
+
+    // 只處理已登入、非臨時用戶、且未驗證 email 的用戶
+    if (!isAuthenticated || isTemporary || isEmailVerified) {
+      return;
+    }
+
+    // 移除 locale 前綴後檢查路徑
+    const pathnameWithoutLocale = removeLocalePrefix(pathname);
+
+    // 如果在 email 驗證頁面，不需要跳轉
+    const isOnVerificationPage = emailVerificationPath
+      ? pathnameWithoutLocale.startsWith(emailVerificationPath)
+      : false;
+    if (isOnVerificationPage) {
+      return;
+    }
+
+    // 如果在 onboarding 頁面，不需要跳轉（讓用戶看完 Success 頁面）
+    const isOnOnboardingPage = onboardingPath
+      ? pathnameWithoutLocale.startsWith(onboardingPath)
+      : false;
+    if (isOnOnboardingPage) {
+      return;
+    }
+
+    const currentUrl = pathname + (typeof window !== "undefined" ? window.location.search : "");
+
+    // 優先使用 onEmailUnverified 回調
+    if (onEmailUnverified) {
+      onEmailUnverified(currentUrl);
+    } else if (emailVerificationPath && typeof window !== "undefined") {
+      // 否則跳轉到 emailVerificationPath
+      window.location.href = emailVerificationPath;
+    }
+  }, [pathname, isAuthenticated, isLoading, isTemporary, isEmailVerified, onboardingPath, emailVerificationPath, onEmailUnverified]);
+
+  /**
    * 開啟登入 Dialog
    */
   const openLoginDialog = useCallback(
@@ -436,13 +572,16 @@ export const AuthProvider = ({
       user,
       isAuthenticated,
       isLoading,
+      isTemporary,
+      isEmailVerified,
       login,
       logout,
       refreshToken,
       openLoginDialog,
       requireAuth,
+      refreshAuth: checkAuth,
     }),
-    [user, isAuthenticated, isLoading, login, logout, refreshToken, openLoginDialog, requireAuth]
+    [user, isAuthenticated, isLoading, isTemporary, isEmailVerified, login, logout, refreshToken, openLoginDialog, requireAuth, checkAuth]
   );
 
   return (

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -29,6 +29,10 @@ export interface AuthContextValue {
   user: StoredUser | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  /** 是否為臨時用戶（需要完成 onboarding） */
+  isTemporary: boolean;
+  /** Email 是否已驗證 */
+  isEmailVerified: boolean;
 
   // 方法
   login: (redirectUrl?: string) => Promise<void>;
@@ -45,4 +49,6 @@ export interface AuthContextValue {
     callback: () => T | Promise<T>,
     options?: { redirectUrl?: string; source?: "website" | "app" }
   ) => T | Promise<T> | undefined;
+  /** 重新檢查認證狀態（用於 onboarding 完成後刷新 isTemporary 狀態） */
+  refreshAuth: () => Promise<void>;
 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -22,8 +22,13 @@
     "footer_terms_of_service": "Terms of Service",
     "footer_intellectual_property": "Intellectual Property Rights",
     "footer_newsletter_title": "Subscribe to Newsletter",
+    "footer_name_placeholder": "Enter your name",
     "footer_email_placeholder": "Enter your email",
     "footer_subscribe_button": "Subscribe",
+    "footer_subscribing": "Subscribing...",
+    "footer_subscribed": "Subscribed!",
+    "footer_subscribe_confirm_hint": "Please check your inbox and click the confirmation link",
+    "footer_subscribe_error": "Failed to subscribe, please try again",
     "footer_social_title": "Follow DaoDao",
     "footer_instagram_alt": "Instagram",
     "footer_facebook_alt": "Facebook",
@@ -4092,6 +4097,119 @@
     "login_dialog_terms_prefix": "By registering, you agree to DaoDao's",
     "login_dialog_terms_link": "Terms of Service",
     "login_dialog_terms_and": "and",
-    "login_dialog_privacy_link": "Privacy Policy"
+    "login_dialog_privacy_link": "Privacy Policy",
+    "verifyEmail": {
+      "success": {
+        "verified": {
+          "title": "Email Verified!",
+          "description": "Welcome to DaoDao! Start exploring your learning journey."
+        },
+        "alreadyVerified": {
+          "title": "Email Already Verified",
+          "description": "Your email has already been verified. You can use all features."
+        },
+        "default": {
+          "title": "Verification Successful",
+          "description": "Your email has been successfully verified."
+        }
+      },
+      "error": {
+        "missingToken": {
+          "title": "Invalid Verification Link",
+          "description": "The verification link is missing required parameters. Please check if the link is complete."
+        },
+        "invalidToken": {
+          "title": "Verification Link Expired",
+          "description": "This verification link has expired or is invalid. Please request a new verification email."
+        },
+        "userNotFound": {
+          "title": "User Not Found",
+          "description": "Cannot find the user account associated with this verification link."
+        },
+        "verificationFailed": {
+          "title": "Verification Failed",
+          "description": "An error occurred during verification. Please try again later."
+        },
+        "unknown": {
+          "title": "Error Occurred",
+          "description": "An unknown error occurred. Please try again later."
+        }
+      },
+      "actions": {
+        "goToHome": "Go to Home",
+        "backToHome": "Back to Home"
+      },
+      "resend": {
+        "button": "Resend Verification Email",
+        "sending": "Sending...",
+        "success": "Verification email has been resent. Please check your inbox.",
+        "failed": "Failed to send. Please try again later.",
+        "noEmail": "Unable to get email address. Please contact support."
+      },
+      "pending": {
+        "title": "Please Verify Your Email",
+        "description": "We've sent a verification email to {email}. Please click the link in the email to complete verification.",
+        "descriptionNoEmail": "We've sent a verification email to your inbox. Please click the link in the email to complete verification.",
+        "checkSpam": "Didn't receive the email? Please check your spam folder",
+        "resendButton": "Resend Verification Email",
+        "resending": "Sending...",
+        "resendSuccess": "Verification email has been resent",
+        "resendFailed": "Failed to send. Please try again later.",
+        "resendCooldown": "Resend available in {seconds} seconds",
+        "logout": "Sign in with another account"
+      }
+    }
+  },
+  "onboarding": {
+    "steps": {
+      "profile": {
+        "title": "Personal Information",
+        "email": "Email",
+        "emailLinked": "This account is linked to your Google account",
+        "birthDate": "Birthday",
+        "birthDatePlaceholder": "Select your birthday",
+        "ageValid": "Age meets registration requirements",
+        "ageInvalid": "DaoDao is currently only available for users aged 16 and above. Please come back when you meet the age requirement!",
+        "name": "Your Name",
+        "namePlaceholder": "How would you like others to call you",
+        "username": "Username",
+        "usernamePlaceholder": "Set your unique username",
+        "usernameHint": "Only letters and numbers allowed, 3-15 characters",
+        "usernameValid": "Username is available",
+        "usernameInvalid": "Username must be 3-15 characters, letters and numbers only",
+        "usernameUnavailable": "This username is already taken",
+        "bio": "Personal Tagline",
+        "bioPlaceholder": "Introduce yourself in one sentence"
+      },
+      "interests": {
+        "title": "Professional & Interest Fields",
+        "professionalFieldsLabel": "Your professional or learning fields (optional, max 5)",
+        "interestsLabel": "Fields you're interested in exploring",
+        "interestsRequired": "Required",
+        "maxReached": "Great! We have enough info to personalize your learning experience"
+      },
+      "referral": {
+        "title": "How did you hear about DaoDao?",
+        "subtitle": "Help us understand how to reach more people",
+        "otherLabel": "Please specify",
+        "otherPlaceholder": "Tell us how you discovered DaoDao..."
+      },
+      "success": {
+        "title": "Welcome to DaoDao!",
+        "titleWithName": "{name}, Welcome to DaoDao!",
+        "primaryButton": "Set up preferences for personalized recommendations",
+        "secondaryButton": "Set up later",
+        "emailReminder": "Don't forget to check your inbox for our welcome email!"
+      }
+    },
+    "navigation": {
+      "previous": "Previous",
+      "next": "Next",
+      "complete": "Complete Registration",
+      "submitting": "Submitting..."
+    },
+    "errors": {
+      "submitFailed": "Submission failed, please try again later"
+    }
   }
 }

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -22,8 +22,13 @@
     "footer_terms_of_service": "服務條款",
     "footer_intellectual_property": "智慧財產權",
     "footer_newsletter_title": "訂閱電子報",
+    "footer_name_placeholder": "輸入您的名稱",
     "footer_email_placeholder": "輸入您的Email",
     "footer_subscribe_button": "訂閱",
+    "footer_subscribing": "訂閱中...",
+    "footer_subscribed": "訂閱成功！",
+    "footer_subscribe_confirm_hint": "請至信箱點擊確認連結完成訂閱",
+    "footer_subscribe_error": "訂閱失敗，請稍後再試",
     "footer_social_title": "追蹤島島",
     "footer_instagram_alt": "Instagram",
     "footer_facebook_alt": "Facebook",
@@ -4092,6 +4097,119 @@
     "login_dialog_terms_prefix": "註冊即代表您同意島島阿學的",
     "login_dialog_terms_link": "服務條款",
     "login_dialog_terms_and": "與",
-    "login_dialog_privacy_link": "隱私權政策"
+    "login_dialog_privacy_link": "隱私權政策",
+    "verifyEmail": {
+      "success": {
+        "verified": {
+          "title": "郵件驗證成功！",
+          "description": "歡迎加入島島阿學，開始探索你的學習之旅吧！"
+        },
+        "alreadyVerified": {
+          "title": "郵件已驗證",
+          "description": "您的郵件已經驗證過了，可以直接使用所有功能。"
+        },
+        "default": {
+          "title": "驗證成功",
+          "description": "您的郵件已成功驗證。"
+        }
+      },
+      "error": {
+        "missingToken": {
+          "title": "無效的驗證連結",
+          "description": "驗證連結缺少必要的參數，請檢查連結是否完整。"
+        },
+        "invalidToken": {
+          "title": "驗證連結已過期",
+          "description": "此驗證連結已過期或無效，請重新發送驗證郵件。"
+        },
+        "userNotFound": {
+          "title": "用戶不存在",
+          "description": "找不到此驗證連結對應的用戶帳號。"
+        },
+        "verificationFailed": {
+          "title": "驗證失敗",
+          "description": "驗證過程發生錯誤，請稍後再試。"
+        },
+        "unknown": {
+          "title": "發生錯誤",
+          "description": "發生未知錯誤，請稍後再試。"
+        }
+      },
+      "actions": {
+        "goToHome": "前往首頁",
+        "backToHome": "返回首頁"
+      },
+      "resend": {
+        "button": "重新發送驗證郵件",
+        "sending": "發送中...",
+        "success": "驗證郵件已重新發送，請檢查您的信箱",
+        "failed": "發送失敗，請稍後再試",
+        "noEmail": "無法取得郵件地址，請聯繫客服"
+      },
+      "pending": {
+        "title": "請驗證您的電子郵件",
+        "description": "我們已經發送驗證郵件到 {email}，請點擊郵件中的連結完成驗證。",
+        "descriptionNoEmail": "我們已經發送驗證郵件到您的信箱，請點擊郵件中的連結完成驗證。",
+        "checkSpam": "沒收到郵件？請檢查垃圾郵件資料夾",
+        "resendButton": "重新發送驗證郵件",
+        "resending": "發送中...",
+        "resendSuccess": "驗證郵件已重新發送",
+        "resendFailed": "發送失敗，請稍後再試",
+        "resendCooldown": "{seconds} 秒後可重新發送",
+        "logout": "使用其他帳號登入"
+      }
+    }
+  },
+  "onboarding": {
+    "steps": {
+      "profile": {
+        "title": "個人資料",
+        "email": "電子信箱",
+        "emailLinked": "此帳號已連結至 Google 帳戶",
+        "birthDate": "生日",
+        "birthDatePlaceholder": "請選擇你的生日",
+        "ageValid": "年齡符合註冊要求",
+        "ageInvalid": "島島阿學目前僅開放給年滿 16 歲的使用者註冊。歡迎符合年齡要求後再來加入我們！",
+        "name": "你的名字",
+        "namePlaceholder": "希望大家怎麼稱呼你",
+        "username": "使用者帳號",
+        "usernamePlaceholder": "設定你的專屬帳號",
+        "usernameHint": "僅可使用英文字母和數字，長度 3-15 個字元",
+        "usernameValid": "帳號名稱可以使用",
+        "usernameInvalid": "帳號名稱必須為 3-15 個字元，僅限使用英文字母和數字",
+        "usernameUnavailable": "此帳號名稱已被使用",
+        "bio": "個人標語",
+        "bioPlaceholder": "用一句話介紹自己"
+      },
+      "interests": {
+        "title": "專業與興趣領域",
+        "professionalFieldsLabel": "你的專業或正在學習的領域（選填，最多 5 個）",
+        "interestsLabel": "你有興趣探索的領域",
+        "interestsRequired": "必選",
+        "maxReached": "太棒了！我們已經有足夠資訊為你個人化學習體驗"
+      },
+      "referral": {
+        "title": "你如何得知島島阿學？",
+        "subtitle": "幫助我們了解如何讓更多人發現島島阿學",
+        "otherLabel": "請說明",
+        "otherPlaceholder": "請告訴我們你是如何得知島島阿學的..."
+      },
+      "success": {
+        "title": "歡迎加入島島阿學！",
+        "titleWithName": "{name}，歡迎加入島島阿學！",
+        "primaryButton": "前往完成偏好設定獲得個人化推薦",
+        "secondaryButton": "稍後設定",
+        "emailReminder": "記得到信箱收我們的歡迎信哦!"
+      }
+    },
+    "navigation": {
+      "previous": "上一步",
+      "next": "下一步",
+      "complete": "完成註冊",
+      "submitting": "提交中..."
+    },
+    "errors": {
+      "submitFailed": "提交失敗，請稍後再試"
+    }
   }
 }


### PR DESCRIPTION
## Why is this necessary?
- 新用戶註冊後需要完成 onboarding 流程
- 需要 email 驗證機制確保用戶身份有效性
- 帳戶設定需要支援城市/國家選擇功能

## How does it address?
- 新增多步驟 onboarding 表單（個人資料、興趣領域、推薦來源、完成頁面）
- 新增 email 驗證頁面（驗證結果頁和等待驗證頁）
- 新增城市/國家選擇 API hooks 和 UI 組件
- 新增登出確認對話框
- Footer 整合 Kit Newsletter 訂閱
- 更新 Auth Provider 支援 onboarding 和 email 驗證流程
- 新增 resendVerificationEmail 和 getAuthMe API 函數