### PR TITLE
Practice & Check-in Updates with UI Improvements

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -18,79 +18,79 @@ export default function TabLayout() {
   return (
     <View style={{ flex: 1 }}>
       <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: colors.primary.base,
-        tabBarInactiveTintColor: '#9CA3AF',
-        tabBarShowLabel: false, // Product 只顯示圖標
-        tabBarLabelStyle: {
-          fontSize: 12,
-          fontWeight: '500',
-          marginTop: 2,
-        },
-        tabBarIconStyle: {
-          marginTop: 4,
-        },
-        tabBarStyle: {
-          position: 'absolute',
-          backgroundColor: 'rgba(249, 254, 255, 0.9)',
-          borderTopWidth: 2,
-          borderTopColor: '#C1ECFF',
-          borderTopLeftRadius: 24,
-          borderTopRightRadius: 24,
-          height: Platform.OS === 'ios' ? 70 : 60,
-          paddingTop: 0,
-          paddingBottom: Platform.OS === 'ios' ? 16 : 8,
-          paddingHorizontal: 40,
-          ...Platform.select({
-            ios: {
-              shadowColor: '#000',
-              shadowOffset: { width: 0, height: -2 },
-              shadowOpacity: 0.05,
-              shadowRadius: 8,
-            },
-            android: {
-              elevation: 8,
-            },
-          }),
-        },
-        tabBarItemStyle: {
-          paddingVertical: 4,
-        },
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: '我的小島',
-          tabBarIcon: ({ color, focused }) => (
-            <HomeIcon size={32} color={color} filled={focused} />
-          ),
+        screenOptions={{
+          headerShown: false,
+          tabBarActiveTintColor: colors.primary.base,
+          tabBarInactiveTintColor: '#9CA3AF',
+          tabBarShowLabel: false, // Product 只顯示圖標
+          tabBarLabelStyle: {
+            fontSize: 12,
+            fontWeight: '500',
+            marginTop: 2,
+          },
+          tabBarIconStyle: {
+            marginTop: 4,
+          },
+          tabBarStyle: {
+            position: 'absolute',
+            backgroundColor: 'rgba(249, 254, 255, 0.9)',
+            borderTopWidth: 2,
+            borderTopColor: '#C1ECFF',
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            height: Platform.OS === 'ios' ? 70 : 60,
+            paddingTop: 0,
+            paddingBottom: Platform.OS === 'ios' ? 16 : 8,
+            paddingHorizontal: 40,
+            ...Platform.select({
+              ios: {
+                shadowColor: '#000',
+                shadowOffset: { width: 0, height: -2 },
+                shadowOpacity: 0.05,
+                shadowRadius: 8,
+              },
+              android: {
+                elevation: 8,
+              },
+            }),
+          },
+          tabBarItemStyle: {
+            paddingVertical: 4,
+          },
         }}
-      />
-      <Tabs.Screen
-        name="profile"
-        options={{
-          title: '個人資料',
-          tabBarIcon: ({ color, focused }) => (
-            <UserIcon size={32} color={color} filled={focused} />
-          ),
-        }}
-      />
-      {/* 隱藏的頁面 - 保留路由但不在 Tab 顯示 */}
-      <Tabs.Screen
-        name="explore"
-        options={{
-          href: null, // 隱藏此 Tab
-        }}
-      />
-      <Tabs.Screen
-        name="create"
-        options={{
-          href: null, // 隱藏此 Tab，改用 FAB 進入
-        }}
-      />
-    </Tabs>
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: '主頁',
+            tabBarIcon: ({ color, focused }) => (
+              <HomeIcon size={32} color={color} filled={focused} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="profile"
+          options={{
+            title: '我的小島',
+            tabBarIcon: ({ color, focused }) => (
+              <UserIcon size={32} color={color} filled={focused} />
+            ),
+          }}
+        />
+        {/* 隱藏的頁面 - 保留路由但不在 Tab 顯示 */}
+        <Tabs.Screen
+          name="explore"
+          options={{
+            href: null, // 隱藏此 Tab
+          }}
+        />
+        <Tabs.Screen
+          name="create"
+          options={{
+            href: null, // 隱藏此 Tab，改用 FAB 進入
+          }}
+        />
+      </Tabs>
 
       {/* FAB 按鈕 - 放在 Tab 層級以顯示在最上層 */}
       {showFab && (

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -5,7 +5,7 @@ import { YStack, XStack, Text, ScrollView, Spinner, } from 'tamagui'
 
 const { width: screenWidth } = Dimensions.get('window')
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { Target, MoreHorizontal } from '@tamagui/lucide-icons'
+import { Target, MoreHorizontal, SlidersHorizontal } from '@tamagui/lucide-icons'
 import { usePractices, useCheckIn } from '@/hooks/usePractices'
 import { PracticeCard, HomeBanner } from '@/components'
 import { colors } from '@/generated/design-tokens'
@@ -146,6 +146,10 @@ export default function HomeScreen() {
     router.push('/practices/create')
   }, [router])
 
+  const handleSettings = useCallback(() => {
+    router.push('/settings')
+  }, [router])
+
   if (isLoading) {
     return (
       <SafeAreaView style={{ flex: 1 }} edges={['top']}>
@@ -164,6 +168,15 @@ export default function HomeScreen() {
       {/* Fixed Banner */}
       <RNView style={styles.fixedBanner}>
         <HomeBanner />
+      </RNView>
+
+      {/* 固定頂部右上角設定按鈕 */}
+      <RNView style={styles.fixedHeader}>
+        <XStack justifyContent="flex-end" paddingHorizontal="$5" paddingVertical="$3">
+          <Pressable onPress={handleSettings} hitSlop={8}>
+            <SlidersHorizontal size={24} color={colors.text.dark} />
+          </Pressable>
+        </XStack>
       </RNView>
 
       <ScrollView
@@ -279,5 +292,13 @@ const styles = StyleSheet.create({
     right: 0,
     zIndex: 20,
     pointerEvents: 'none',
+  },
+  fixedHeader: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 30,
+    backgroundColor: 'transparent',
   },
 })

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@daodao/ui/components/dropdown-menu";
 import { toast } from "@daodao/ui/components/sonner";
-import { Archive, Ellipsis, Trash2 } from "lucide-react";
+import { Ellipsis } from "lucide-react";
 import { useMemo } from "react";
 import { CheckInButton, CheckInRecordCard, CheckInStack } from "@/components/check-in";
 import { BackgroundAnimation, PageHeader } from "@/components/layout";
@@ -220,15 +220,11 @@ export default function PracticeDetailPage() {
     }
   };
 
-  const handleBack = () => {
-    router.push("/");
-  };
-
   // Loading 狀態
   if (isLoading) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-        <PageHeader leftAction="back" title="主題實踐" onLeftAction={handleBack} rightActionTo="/" />
+        <PageHeader leftAction="back" leftLabel="" title="主題實踐" rightActionTo="/" />
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">載入中...</div>
@@ -241,7 +237,7 @@ export default function PracticeDetailPage() {
   if (error || !practice) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-        <PageHeader leftAction="back" title="主題實踐" onLeftAction={handleBack} rightActionTo="/" />
+        <PageHeader leftAction="back" leftLabel="" title="主題實踐" rightActionTo="/" />
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">
@@ -254,7 +250,7 @@ export default function PracticeDetailPage() {
 
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-      <PageHeader leftAction="back" title="主題實踐" onLeftAction={handleBack} rightActionTo="/" />
+      <PageHeader leftAction="back" leftLabel="" title="主題實踐" rightActionTo="/" />
 
       <BackgroundAnimation />
 
@@ -278,8 +274,10 @@ export default function PracticeDetailPage() {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleEdit} className="text-center">
-                編輯實踐
+              <DropdownMenuItem onClick={handleEdit}>編輯實踐</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleArchive}>封存實踐</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleDelete} className="text-destructive">
+                刪除
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -332,17 +330,6 @@ export default function PracticeDetailPage() {
         <CheckInStack practiceId={practiceId} checkInsData={checkInsData} />
       </div>
 
-      <div className="flex flex-col w-fit gap-4 mx-auto pb-40 pt-6">
-        <Button variant="white" className="px-8" onClick={handleArchive}>
-          <Archive className="size-4.5" />
-          <span>封存實踐</span>
-        </Button>
-        <Button variant="ghost" className="px-8 border border-logo-cyan" onClick={handleDelete}>
-          <Trash2 className="size-4.5" />
-          <span>刪除實踐</span>
-        </Button>
-      </div>
-
       <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-6 p-6 border-t border-light-gray bg-very-light-gray z-20">
         {/* 打卡按鈕 */}
         <CheckInButton
@@ -351,6 +338,7 @@ export default function PracticeDetailPage() {
           practiceId={practiceId}
           practiceStatus={practiceData?.data?.status}
           lastCheckInDate={checkInsData?.data?.[0]?.checkinDate || null}
+          startDate={practice.startDate}
           taskTitle={practice.name}
           progressPercentage={practice?.currentProgress ?? 0}
         />

--- a/apps/product/src/app/[locale]/practices/create/success/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/success/page.tsx
@@ -119,7 +119,7 @@ export default function PracticeSuccessPage() {
             className="inline-flex mb-px"
             animation="none"
           >
-            回到我的小島
+            回到主頁
             <ArrowRightOutlineSvg className="size-4.5" />
           </Button>
           {/* 倒數計時提示 */}

--- a/apps/product/src/app/global-provider.tsx
+++ b/apps/product/src/app/global-provider.tsx
@@ -47,7 +47,7 @@ function GlobalProvider({
                   <SheetManagerProvider>
                     <AuthProvider
                       defaultProtected
-                      publicPattern={["^/auth/login", "^/auth/callback", "^/auth/onboarding", "^/auth/verify-email(/.*)?$", "^/users/"]}
+                      publicPattern={["^/auth/login", "^/auth/callback", "^/auth/onboarding", "^/auth/verify-email(/.*)?$", "^/users/", "^/practices/[^/]+$"]}
                       onAuthRequired={(currentPath) => {
                         router.push(`/auth/login?redirect=${encodeURIComponent(currentPath)}`);
                       }}

--- a/apps/product/src/components/check-in/display/check-in-stack.tsx
+++ b/apps/product/src/components/check-in/display/check-in-stack.tsx
@@ -622,7 +622,7 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
             >
               <Emoji className="size-6" />
               <div className="text-xs text-bg-dark">
-                #{i + 1} {date}
+                #{count - i} {date}
               </div>
               <div className="max-w-40 text-bg-dark line-clamp-2">{content}</div>
             </div>

--- a/apps/product/src/components/check-in/form/check-in-sheet.tsx
+++ b/apps/product/src/components/check-in/form/check-in-sheet.tsx
@@ -2,7 +2,9 @@
 
 import { Button, type ButtonProps } from "@daodao/ui/components/button";
 import { Form } from "@daodao/ui/components/form";
+import { toast } from "@daodao/ui/components/sonner";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { isBefore, parse, startOfDay } from "date-fns";
 import { CalendarCheck, Check } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { useCheckInSheet } from "@/hooks/use-check-in-sheet";
@@ -134,6 +136,7 @@ interface ICheckInButtonProps
 export const CheckInButton = ({
   practiceStatus,
   lastCheckInDate,
+  startDate,
   practiceId,
   taskTitle,
   onComplete,
@@ -168,6 +171,19 @@ export const CheckInButton = ({
 
   const handleClick = () => {
     if (!canCheckIn) return;
+
+    // 檢查今天是否早於開始日期
+    if (startDate) {
+      const today = startOfDay(new Date());
+      const practiceStartDate = startOfDay(parse(startDate, "yyyy-MM-dd", new Date()));
+      if (isBefore(today, practiceStartDate)) {
+        toast.warning("實踐尚未開始", {
+          description: "今天的日期早於實踐的開始日期，請在開始日期後再進行打卡。",
+        });
+        return;
+      }
+    }
+
     openCheckInSheet();
   };
 

--- a/apps/product/src/components/check-in/share/share-check-in-content.tsx
+++ b/apps/product/src/components/check-in/share/share-check-in-content.tsx
@@ -44,7 +44,9 @@ export const ShareCheckInSheetContent = ({
     if (!imageUrl) return;
 
     try {
-      const response = await fetch(imageUrl);
+      // 添加時間戳參數繞過 Cloudflare 快取，確保獲取帶有 CORS headers 的回應
+      const urlWithCacheBust = `${imageUrl}${imageUrl.includes("?") ? "&" : "?"}_t=${Date.now()}`;
+      const response = await fetch(urlWithCacheBust);
       const blob = await response.blob();
       const blobUrl = URL.createObjectURL(blob);
 

--- a/apps/product/src/components/check-in/types.ts
+++ b/apps/product/src/components/check-in/types.ts
@@ -50,6 +50,11 @@ export interface ICheckInStatusOptions {
    * 如果沒有打卡記錄，應傳入 null
    */
   lastCheckInDate: string | null;
+  /**
+   * 實踐開始日期 (ISO 格式字串，例如 "2026-01-01")
+   * 用於檢查打卡日期是否早於開始日期
+   */
+  startDate?: string | null;
 }
 
 /**

--- a/apps/product/src/components/dashboard/banner.tsx
+++ b/apps/product/src/components/dashboard/banner.tsx
@@ -111,7 +111,7 @@ export function Banner() {
             "md:top-[calc(3/13*100%)] md:-translate-y-full md:text-[1.75rem]"
           )}
         >
-          我的小島
+          主頁
         </h1>
         <h2
           className={cn(

--- a/apps/product/src/components/layout/sidebar/constant.tsx
+++ b/apps/product/src/components/layout/sidebar/constant.tsx
@@ -7,6 +7,8 @@ import {
   MedalSolidSvg,
   SearchOutlineSvg,
   SearchSolidSvg,
+  SettingOutlineSvg,
+  SettingSolidSvg,
   UserOutlineSvg,
   UserSolidSvg,
 } from "@daodao/assets";
@@ -15,7 +17,7 @@ export const menuItems = [
   {
     activeIcon: HomeSolidSvg,
     icon: HomeOutlineSvg,
-    label: "我的小島",
+    label: "主頁",
     href: "/",
     isMatch: (pathname: string) => pathname === "/",
   },
@@ -46,8 +48,15 @@ export const menuItems = [
   {
     activeIcon: UserSolidSvg,
     icon: UserOutlineSvg,
-    label: "個人資料",
+    label: "我的小島",
     href: (identifier: string) => `/users/${identifier}`,
     isMatch: (pathname: string, identifier: string) => pathname.startsWith(`/users/${identifier}`),
+  },
+  {
+    activeIcon: SettingSolidSvg,
+    icon: SettingOutlineSvg,
+    label: "設定",
+    href: "/settings",
+    isMatch: (pathname: string) => pathname.startsWith("/settings"),
   },
 ];

--- a/apps/product/src/components/practice/list/practice-section.tsx
+++ b/apps/product/src/components/practice/list/practice-section.tsx
@@ -236,9 +236,10 @@ export function PracticeSection({ userId }: PracticeSectionProps) {
           )
         ) : (
           filteredPractices.map((practice) => (
-            <div
+            <CustomLink
               key={practice.id}
-              className="flex items-start gap-4 p-4 rounded-lg border-b border-bg-gray hover:shadow-sm transition-shadow bg-white"
+              href={`/practices/${practice.id}`}
+              className="block p-4 rounded-lg border-b border-bg-gray hover:shadow-sm transition-shadow bg-white"
             >
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between gap-2 mb-2">
@@ -264,15 +265,11 @@ export function PracticeSection({ userId }: PracticeSectionProps) {
                     <p className="text-xs text-text-dark line-clamp-1">{practice.description}</p>
                   </div>
                   <div className="shrink-0">
-                    <Button variant="ghost" size="icon" asChild>
-                      <CustomLink href={`/practices/${practice.id}`}>
-                        <ArrowRightOutlineSvg className="size-5 text-light-gray" />
-                      </CustomLink>
-                    </Button>
+                    <ArrowRightOutlineSvg className="size-5 text-light-gray" />
                   </div>
                 </div>
               </div>
-            </div>
+            </CustomLink>
           ))
         )}
       </div>

--- a/apps/product/src/components/user/island-header.tsx
+++ b/apps/product/src/components/user/island-header.tsx
@@ -93,7 +93,7 @@ export function IslandHeader({ resultType, userId }: IslandHeaderProps) {
   };
 
   const handleGoToQuizDetail = () => {
-    router.push(`${getEnv("NEXT_PUBLIC_WEBSITE_URL")}/quiz/${resultType}`);
+    router.push(`${getEnv("NEXT_PUBLIC_WEBSITE_URL")}/quiz/result/${resultType}`);
   };
 
   const pageHeaderProps = useMemo<PageHeaderProps>(() => {
@@ -179,7 +179,7 @@ export function IslandHeader({ resultType, userId }: IslandHeaderProps) {
         />
         <PageHeader {...pageHeaderProps} />
         {isEmptyResult && isOwnProfile && (
-          <div className="absolute left-0 right-0 top-[256px] w-[600px] mx-auto overflow-hidden mask-marquee">
+          <div className="absolute left-0 right-0 top-[150px] w-[600px] mx-auto overflow-hidden mask-marquee">
             <div className="animate-marquee flex w-max gap-3 will-change-transform">
               {/* 第一份內容 */}
               {Array.from(resultTypeToLottiePathMap.keys()).map((key) => {

--- a/packages/shared/src/lib/capture-element-as-image.ts
+++ b/packages/shared/src/lib/capture-element-as-image.ts
@@ -113,6 +113,8 @@ export const captureElementAsImage = async (
     const dataUrl = await toJpeg(element, {
       quality: 0.95,
       pixelRatio: devicePixelRatio,
+      // 添加 cacheBust 繞過 Cloudflare 快取，確保獲取帶有 CORS headers 的回應
+      cacheBust: true,
     });
 
     const imageData: CapturedImageData = {

--- a/packages/ui/src/components/date-picker.tsx
+++ b/packages/ui/src/components/date-picker.tsx
@@ -9,33 +9,11 @@ import { Calendar } from "./calendar";
 import { Input } from "./input";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
-function getRangeErrorMessage(
-  date: Date,
-  minDate: Date | undefined,
-  maxDate: Date | undefined
-): string | undefined {
-  const dateStartOfDay = startOfDay(date);
-  if (minDate && isBefore(dateStartOfDay, startOfDay(minDate))) {
-    return `日期不能早於 ${format(minDate, "yyyy/MM/dd")}`;
-  }
-  if (maxDate && isAfter(dateStartOfDay, startOfDay(maxDate))) {
-    return `日期不能晚於 ${format(maxDate, "yyyy/MM/dd")}`;
-  }
-  return undefined;
-}
-
 function formatDate(date: Date | undefined) {
   if (date && isValid(date)) {
     return format(date, "yyyy/MM/dd");
   }
   return "";
-}
-
-function isValidDate(date: Date | undefined) {
-  if (!date) {
-    return false;
-  }
-  return !Number.isNaN(date.getTime());
 }
 
 function isDateInRange(
@@ -66,7 +44,7 @@ interface DatePickerProps {
   disabled?: boolean;
   onChange?: (date: Date | undefined) => void;
   onBlur?: () => void;
-  onError?: (message: string) => void;
+  onError?: (errorMessage: string) => void;
 }
 
 const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
@@ -81,7 +59,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       disabled = false,
       onChange,
       onBlur,
-      onError,
+      onError: _onError,
     },
     ref
   ) => {
@@ -111,63 +89,42 @@ const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       }
     };
 
-    const handleRangeError = (inputDate: Date) => {
-      setIsRangeError(true);
-      const errorMessage = getRangeErrorMessage(inputDate, minDate, maxDate);
-      if (errorMessage) {
-        onError?.(errorMessage);
-      }
-    };
-
     return (
-      <div className="relative flex gap-2">
-        <Input
-          ref={ref}
-          value={inputValue}
-          placeholder={placeholder}
-          disabled={disabled}
-          className={cn("pr-10", className, (invalid || isRangeError) && "border-red")}
-          onChange={(e) => {
-            if (disabled) return;
-            const inputDate = new Date(e.target.value);
-            setInputValue(e.target.value);
-            if (isValidDate(inputDate)) {
-              if (isDateInRange(inputDate, minDate, maxDate)) {
-                handleDateChange(inputDate);
-              } else {
-                onChange?.(undefined);
-                setDate(undefined);
-                setMonth(undefined);
-                handleRangeError(inputDate);
-              }
-            } else {
-              setIsRangeError(false);
-              onChange?.(undefined);
-              setDate(undefined);
-              setMonth(undefined);
-            }
-          }}
-          onBlur={onBlur}
-          onKeyDown={(e) => {
-            if (disabled) return;
-            if (e.key === "ArrowDown") {
-              e.preventDefault();
-              setOpen(true);
-            }
-          }}
-        />
-        <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
-          <PopoverTrigger asChild>
+      <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
+        <PopoverTrigger asChild>
+          <div className="relative flex gap-2">
+            <Input
+              ref={ref}
+              value={inputValue}
+              placeholder={placeholder}
+              disabled={disabled}
+              readOnly
+              className={cn(
+                "pr-10 cursor-pointer",
+                className,
+                (invalid || isRangeError) && "border-red"
+              )}
+              onBlur={onBlur}
+              onKeyDown={(e) => {
+                if (disabled) return;
+                if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setOpen(true);
+                }
+              }}
+            />
             <Button
               id="date-picker"
               variant="ghost"
               disabled={disabled}
-              className="absolute top-1/2 right-2 size-6 -translate-y-1/2"
+              type="button"
+              className="absolute top-1/2 right-2 size-6 -translate-y-1/2 pointer-events-none"
             >
               <CalendarIcon className="size-3.5" />
               <span className="sr-only">Select date</span>
             </Button>
-          </PopoverTrigger>
+          </div>
+        </PopoverTrigger>
           <PopoverContent
             className="w-auto overflow-hidden p-0"
             align="end"
@@ -196,8 +153,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
               }}
             />
           </PopoverContent>
-        </Popover>
-      </div>
+      </Popover>
     );
   }
 );


### PR DESCRIPTION
## Why is this necessary?

- 導航命名需要統一調整，讓「主頁」與「我的小島」（個人資料）的概念更清晰
- 打卡功能需要驗證開始日期，避免用戶在實踐開始前就打卡
- 實踐詳情頁面需要簡化 UI，將封存/刪除按鈕整合到選單中
- 分享圖片功能在 Cloudflare 快取下有 CORS 問題需要修復
- 實踐詳情頁應該對未登入用戶開放，方便分享

---

## How does it address?

### 1. 導航與命名調整

| 原名稱 | 新名稱 | 說明 |
|--------|--------|------|
| 我的小島 (首頁) | 主頁 | 統一為「主頁」更直觀 |
| 個人資料 | 我的小島 | 個人頁面改稱「我的小島」|
| - | 設定 | 新增設定入口 |

**變更位置：**
- Mobile App: `_layout.tsx`, `index.tsx`
- Product App: `banner.tsx`, `sidebar/constant.tsx`, `success/page.tsx`

### 2. 打卡功能增強

**開始日期驗證：**
- 新增 `startDate` prop 到打卡按鈕
- 若今天早於開始日期，顯示 toast 警告並阻止打卡

**修正打卡序號顯示：**
- CheckInStack 序號從 `#{i + 1}` 改為 `#{count - i}`，正確顯示打卡順序

**修正 CORS 問題：**
- `share-check-in-content.tsx`: 加入時間戳參數繞過快取
- `capture-element-as-image.ts`: 加入 `cacheBust: true` 選項

### 3. 實踐詳情頁面簡化

**UI 調整：**
- 移除頁面底部的封存/刪除按鈕
- 將封存和刪除選項整合到右上角的 dropdown menu
- 簡化 PageHeader，移除 `onLeftAction` 改用 `leftLabel=""`

**公開路由：**
- 新增 `^/practices/[^/]+$` 到公開路由 pattern
- 未登入用戶可以查看實踐詳情（方便分享）

### 4. 其他 UI 修復

| 項目 | 變更 |
|------|------|
| 實踐列表 | 整個區塊可點擊，不只是箭頭按鈕 |
| DatePicker | 改為只讀模式，點擊輸入框打開日曆 |
| Island Header | 跑馬燈位置從 `top-[256px]` 調整為 `top-[150px]` | | 測驗結果 URL | 修正為 `/quiz/result/${resultType}` |
| Mobile 設定 | 首頁右上角新增設定按鈕 |