### PR TITLE
fix(linode-cd): enhance environment file creation for branch

### DIFF
--- a/.github/workflows/linode-cd.yml
+++ b/.github/workflows/linode-cd.yml
@@ -72,7 +72,17 @@ jobs:
 
       - name: Create environment files
         run: |
-          echo "${{ secrets.ENV_DEV }}" > .env
+          BRANCH="${{ env.BRANCH_NAME }}"
+          echo "Creating environment files for branch: $BRANCH"
+
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "prod" ]; then
+            echo "Using PROD environment"
+            echo "${{ secrets.ENV_PROD }}" > .env
+          else
+            echo "Using DEV environment"
+            echo "${{ secrets.ENV_DEV }}" > .env
+          fi
+
           cp .env apps/website/.env
           cp .env apps/product/.env
 
@@ -186,7 +196,17 @@ jobs:
 
       - name: Create environment files
         run: |
-          echo "${{ secrets.ENV_DEV }}" > .env
+          BRANCH="${{ env.BRANCH_NAME }}"
+          echo "Creating environment files for branch: $BRANCH"
+
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "prod" ]; then
+            echo "Using PROD environment"
+            echo "${{ secrets.ENV_PROD }}" > .env
+          else
+            echo "Using DEV environment"
+            echo "${{ secrets.ENV_DEV }}" > .env
+          fi
+
           cp .env apps/website/.env
           cp .env apps/product/.env
 


### PR DESCRIPTION
## Why is this necessary?

environment files is not based on the branch being deployed.

## How does it address?

Updated the linode-cd.yml workflow to create environment files based on the branch being deployed. The script now checks if the branch is 'main' or 'prod' to use production environment variables, otherwise defaults to development variables. This change ensures correct environment settings during CI/CD processes.