### PR TITLE
fix: implement check-in update API to persist edited content

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -9,7 +9,7 @@ import { useMemo } from "react";
 import { CheckInButton, CheckInDateSelector, CheckInDetail } from "@/components/check-in";
 import type { ICheckInDisplayData, ICheckInFormData } from "@/components/check-in/types";
 import { PageHeader } from "@/components/layout";
-import { mapApiMoodToMoodType } from "@/constants/mood";
+import { mapApiMoodToMoodType, mapMoodTypeToApiMood } from "@/constants/mood";
 
 /**
  * 將 API 的 checkinDate 格式轉換為顯示格式
@@ -202,7 +202,13 @@ export default function CheckInDetailPage() {
 
   const handleEditComplete = async (data: ICheckInFormData) => {
     try {
-      await updateCheckIn(data);
+      const apiMood = mapMoodTypeToApiMood(data.mood);
+      await updateCheckIn({
+        mood: apiMood,
+        tags: data.tags,
+        description: data.description,
+        media: data.media,
+      });
       toast.success("打卡已更新");
     } catch (error) {
       console.error("更新打卡失敗:", error);

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePracticeById, usePracticeCheckIns } from "@daodao/api";
+import { usePracticeById, usePracticeCheckIns, useUpdatePracticeCheckIn } from "@daodao/api";
 import { Deco4Svg } from "@daodao/assets";
 import { useParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
@@ -60,6 +60,9 @@ export default function CheckInDetailPage() {
 
   // 獲取 practice 資料
   const { data: practiceData, isLoading: isLoadingPractice } = usePracticeById(practiceId);
+
+  // 更新打卡記錄
+  const { updateCheckIn } = useUpdatePracticeCheckIn(practiceId, checkInId);
 
   // 獲取所有 check-ins
   const { data: checkInsData, isLoading: isLoadingCheckIns } = usePracticeCheckIns(practiceId, {
@@ -199,13 +202,12 @@ export default function CheckInDetailPage() {
 
   const handleEditComplete = async (data: ICheckInFormData) => {
     try {
-      // TODO: 實現更新打卡 API 調用（等待後端 API）
-      // await updateCheckIn(checkInId, data);
-      console.log("編輯打卡資料:", data);
+      await updateCheckIn(data);
       toast.success("打卡已更新");
     } catch (error) {
       console.error("更新打卡失敗:", error);
       toast.error("更新打卡失敗，請稍後再試");
+      throw error;
     }
   };
 

--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -312,6 +312,56 @@ export const createPracticeCheckInWithFormData = async (
 };
 
 /**
+ * 更新實踐打卡記錄（使用 FormData 統一提交）
+ * @param practiceId 實踐 ID
+ * @param checkInId 打卡記錄 ID
+ * @param data 表單資料（包含圖片檔案）
+ * @returns 更新結果
+ */
+export const updatePracticeCheckInWithFormData = async (
+  practiceId: string,
+  checkInId: string,
+  data: ICheckInFormData
+): Promise<CreateCheckInResponse> => {
+  const formData = new FormData();
+
+  // 基本欄位
+  if (data.mood) formData.append("mood", data.mood);
+  if (data.description) formData.append("note", data.description);
+
+  // 陣列欄位需轉成 JSON 字串
+  if (data.tags && data.tags.length > 0) {
+    formData.append("tags", JSON.stringify(data.tags));
+  }
+
+  // 圖片檔案（多張）
+  if (data.media && data.media.length > 0) {
+    data.media.forEach((file) => {
+      formData.append("images", file);
+    });
+  }
+
+  const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
+  const response = await unauthorizedHandler.wrapFetch(
+    `${baseUrl}/api/v1/practices/${practiceId}/checkins/${checkInId}`,
+    {
+      method: "PUT",
+      body: formData,
+      credentials: "include",
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({
+      error: { message: "更新打卡失敗" },
+    }));
+    throw new Error(error.error?.message || "更新打卡失敗");
+  }
+
+  return response.json();
+};
+
+/**
  * 刷新實踐相關的 cache（共用函數）
  * @param mutate mutate 函數
  * @param practiceId 實踐 ID
@@ -395,6 +445,39 @@ export const useCreatePracticeCheckIn = (practiceId: string) => {
   };
 
   return { createCheckIn };
+};
+
+/**
+ * Hook 用於更新實踐打卡記錄（自動處理 cache 刷新）
+ * @param practiceId 實踐 ID
+ * @param checkInId 打卡記錄 ID
+ * @returns 更新打卡記錄的函數
+ */
+export const useUpdatePracticeCheckIn = (practiceId: string, checkInId: string) => {
+  const mutate = useMutate();
+
+  const updateCheckIn = async (formData: ICheckInFormData) => {
+    const response = await updatePracticeCheckInWithFormData(practiceId, checkInId, formData);
+
+    // 刷新打卡列表的 cache
+    await mutate([
+      "/api/v1/practices/{id}/checkins",
+      {
+        params: {
+          path: {
+            id: practiceId,
+          },
+        },
+      },
+    ] as const);
+
+    // 刷新實踐相關的 cache
+    await refreshPracticeCaches(mutate, practiceId);
+
+    return response;
+  };
+
+  return { updateCheckIn };
 };
 
 /**


### PR DESCRIPTION
The edit check-in UI showed a fake success toast without actually
saving data to the backend. Wire up the existing PUT endpoint
(/api/v1/practices/{id}/checkins/{checkInId}) with a new
useUpdatePracticeCheckIn hook and proper cache invalidation.

https://claude.ai/code/session_01DtK1XMXbfnWTsb7d6prsCr