### PR TITLE
Refactor check-in cooldown to use precise 24-hour calculation

### DIFF
--- a/apps/mobile/components/check-in/form/hooks/use-check-in-status.ts
+++ b/apps/mobile/components/check-in/form/hooks/use-check-in-status.ts
@@ -2,14 +2,29 @@ import { useMemo } from "react";
 import { CheckInStatus, type CheckInStatusType } from "@/constants/check-in-status";
 import type { ICheckInStatusOptions } from "../../types";
 
+const CHECK_IN_COOLDOWN_HOURS = 24;
+
 /**
- * 檢查指定日期是否為今天
+ * 檢查距離上次打卡是否未滿 24 小時
+ * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 和日期字串 (e.g., "2024-01-20")
+ * - ISO 時間戳：精確計算是否未滿 24 小時
+ * - 日期字串：退回使用「是否為同一天」的判斷
  */
-const isDateToday = (dateString: string | null | undefined): boolean => {
+const isWithinCooldown = (dateString: string | null | undefined): boolean => {
   if (!dateString) return false;
 
   try {
-    // 解析 "yyyy-MM-dd" 格式的日期
+    // ISO 8601 時間戳（包含 "T"）：精確計算 24 小時
+    if (dateString.includes("T")) {
+      const checkInTime = new Date(dateString);
+      if (Number.isNaN(checkInTime.getTime())) return false;
+
+      const now = new Date();
+      const diffMs = now.getTime() - checkInTime.getTime();
+      return diffMs < CHECK_IN_COOLDOWN_HOURS * 60 * 60 * 1000;
+    }
+
+    // 日期字串 (yyyy-MM-dd)：退回使用同一天判斷
     const [year, month, day] = dateString.split("-").map(Number);
     if (!year || !month || !day) return false;
 
@@ -37,8 +52,8 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
     // 檢查實踐是否已完成
     const isPracticeCompleted = practiceStatus === "completed" || practiceStatus === "archived";
 
-    // 檢查今天是否已打卡
-    const isTodayCheckedIn = isDateToday(lastCheckInDate);
+    // 檢查距離上次打卡是否未滿 24 小時
+    const isTodayCheckedIn = isWithinCooldown(lastCheckInDate);
 
     // 決定最終狀態（優先級：已完成 > 今天已打卡 > 可打卡）
     const getStatus = (): CheckInStatusType => {

--- a/apps/mobile/components/check-in/form/hooks/use-check-in-status.ts
+++ b/apps/mobile/components/check-in/form/hooks/use-check-in-status.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { CheckInStatus, type CheckInStatusType } from "@/constants/check-in-status";
 import type { ICheckInStatusOptions } from "../../types";
 
-const CHECK_IN_COOLDOWN_HOURS = 24;
+const CHECK_IN_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 /**
  * 檢查距離上次打卡是否未滿 24 小時
@@ -21,7 +21,7 @@ const isWithinCooldown = (dateString: string | null | undefined): boolean => {
 
       const now = new Date();
       const diffMs = now.getTime() - checkInTime.getTime();
-      return diffMs < CHECK_IN_COOLDOWN_HOURS * 60 * 60 * 1000;
+      return diffMs < CHECK_IN_COOLDOWN_MS;
     }
 
     // 日期字串 (yyyy-MM-dd)：退回使用同一天判斷
@@ -30,6 +30,9 @@ const isWithinCooldown = (dateString: string | null | undefined): boolean => {
 
     const checkInDate = new Date(year, month - 1, day);
     if (Number.isNaN(checkInDate.getTime())) return false;
+
+    // 驗證日期沒有溢出（例如 "2024-02-30" 會變成 3 月 1 日）
+    if (checkInDate.getDate() !== day) return false;
 
     const today = new Date();
     return (
@@ -53,12 +56,12 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
     const isPracticeCompleted = practiceStatus === "completed" || practiceStatus === "archived";
 
     // 檢查距離上次打卡是否未滿 24 小時
-    const isTodayCheckedIn = isWithinCooldown(lastCheckInDate);
+    const isCheckInLocked = isWithinCooldown(lastCheckInDate);
 
-    // 決定最終狀態（優先級：已完成 > 今天已打卡 > 可打卡）
+    // 決定最終狀態（優先級：已完成 > 冷卻中 > 可打卡）
     const getStatus = (): CheckInStatusType => {
       if (isPracticeCompleted) return CheckInStatus.practiceCompleted;
-      if (isTodayCheckedIn) return CheckInStatus.alreadyCheckedIn;
+      if (isCheckInLocked) return CheckInStatus.alreadyCheckedIn;
       return CheckInStatus.available;
     };
     const status = getStatus();
@@ -69,7 +72,7 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
         case CheckInStatus.practiceCompleted:
           return "實踐已完成";
         case CheckInStatus.alreadyCheckedIn:
-          return "今天已打過卡囉！";
+          return "24 小時內已打過卡囉！";
         case CheckInStatus.available:
           return "打卡";
         default:
@@ -83,7 +86,7 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
     return {
       status,
       isPracticeCompleted,
-      isTodayCheckedIn,
+      isCheckInLocked,
       canCheckIn,
       getButtonLabel,
     };

--- a/apps/mobile/components/check-in/types.ts
+++ b/apps/mobile/components/check-in/types.ts
@@ -44,7 +44,9 @@ export interface ICheckInStatusOptions {
    */
   practiceStatus?: string;
   /**
-   * 最後打卡日期 (ISO 格式字串，例如 "2026-01-01")
+   * 最後打卡時間
+   * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 或日期字串 (e.g., "2024-01-20")
+   * 傳入時間戳時可精確判斷 24 小時冷卻；僅傳入日期時退回使用同一天判斷
    * 如果沒有打卡記錄，應傳入 null
    */
   lastCheckInDate: string | null;

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -3,7 +3,7 @@
 import { useMyPracticeStats, useMyPractices } from "@daodao/api";
 import { MessagesSvg } from "@daodao/assets";
 import { useRouter } from "@daodao/i18n/navigation";
-import { format, parseISO } from "date-fns";
+
 import { CheckCircle2 } from "lucide-react";
 import { useMemo } from "react";
 import {
@@ -43,11 +43,8 @@ export default function HomePage() {
         practice.status === PracticeStatus.draft ||
         practice.status === PracticeStatus.notStarted;
 
-      // 將 ISO timestamp 轉換為 yyyy-MM-dd 格式
-      // API 回傳 lastCheckinAt 為 ISO 8601 格式 (e.g., "2024-01-20T09:00:00.000Z")
-      const lastCheckInDate = practice.lastCheckinAt
-        ? format(parseISO(practice.lastCheckinAt), "yyyy-MM-dd")
-        : null;
+      // 直接使用 ISO 8601 時間戳，以支援精確的 24 小時冷卻判斷
+      const lastCheckInDate = practice.lastCheckinAt ?? null;
 
       if (isInProgress) {
         inProgressTasksData.push({

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -115,7 +115,7 @@ export default function CheckInDetailPage() {
     return map;
   }, [checkInsData]);
 
-  // 建立 check-in ID 到原始日期的映射（用於 lastCheckInDate）
+  // 建立 check-in ID 到時間戳的映射（用於 lastCheckInDate 的 24 小時冷卻判斷）
   const checkInIdToDateMap = useMemo(() => {
     const map = new Map<string, string>();
 
@@ -124,7 +124,7 @@ export default function CheckInDetailPage() {
     }
 
     checkInsData.data.forEach((checkIn) => {
-      map.set(String(checkIn.id), checkIn.checkinDate);
+      map.set(String(checkIn.id), checkIn.createdAt);
     });
 
     return map;

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -345,7 +345,7 @@ export default function PracticeDetailPage() {
             className="w-full sm:max-w-[288px]"
             practiceId={practiceId}
             practiceStatus={practiceData?.data?.status}
-            lastCheckInDate={checkInsData?.data?.[0]?.checkinDate || null}
+            lastCheckInDate={checkInsData?.data?.[0]?.createdAt || null}
             startDate={practice.startDate}
             taskTitle={practice.name}
             progressPercentage={practice?.currentProgress ?? 0}

--- a/apps/product/src/components/check-in/form/hooks/use-check-in-status.ts
+++ b/apps/product/src/components/check-in/form/hooks/use-check-in-status.ts
@@ -1,9 +1,9 @@
-import { differenceInHours, isSameDay, isValid, parse, parseISO } from "date-fns";
+import { isSameDay, isValid, parse, parseISO } from "date-fns";
 import { useMemo } from "react";
 import { CheckInStatus, type CheckInStatusType } from "@/constants/check-in-status";
 import type { ICheckInStatusOptions } from "../../types";
 
-const CHECK_IN_COOLDOWN_HOURS = 24;
+const CHECK_IN_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 /**
  * 檢查距離上次打卡是否未滿 24 小時
@@ -21,7 +21,8 @@ const isWithinCooldown = (dateString: string | null | undefined): boolean => {
       if (!isValid(checkInTime)) return false;
 
       const now = new Date();
-      return differenceInHours(now, checkInTime) < CHECK_IN_COOLDOWN_HOURS;
+      const diffMs = now.getTime() - checkInTime.getTime();
+      return diffMs < CHECK_IN_COOLDOWN_MS;
     }
 
     // 日期字串 (yyyy-MM-dd)：退回使用同一天判斷
@@ -46,12 +47,12 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
     const isPracticeCompleted = practiceStatus === "completed" || practiceStatus === "archived";
 
     // 檢查距離上次打卡是否未滿 24 小時
-    const isTodayCheckedIn = isWithinCooldown(lastCheckInDate);
+    const isCheckInLocked = isWithinCooldown(lastCheckInDate);
 
-    // 決定最終狀態（優先級：已完成 > 今天已打卡 > 可打卡）
+    // 決定最終狀態（優先級：已完成 > 冷卻中 > 可打卡）
     const getStatus = (): CheckInStatusType => {
       if (isPracticeCompleted) return CheckInStatus.practiceCompleted;
-      if (isTodayCheckedIn) return CheckInStatus.alreadyCheckedIn;
+      if (isCheckInLocked) return CheckInStatus.alreadyCheckedIn;
       return CheckInStatus.available;
     };
     const status = getStatus();
@@ -62,7 +63,7 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
         case CheckInStatus.practiceCompleted:
           return "實踐已完成";
         case CheckInStatus.alreadyCheckedIn:
-          return "今天已打過卡囉！";
+          return "24 小時內已打過卡囉！";
         case CheckInStatus.available:
           return "打卡";
         default:
@@ -76,7 +77,7 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
     return {
       status,
       isPracticeCompleted,
-      isTodayCheckedIn,
+      isCheckInLocked,
       canCheckIn,
       getButtonLabel,
     };

--- a/apps/product/src/components/check-in/form/hooks/use-check-in-status.ts
+++ b/apps/product/src/components/check-in/form/hooks/use-check-in-status.ts
@@ -1,17 +1,31 @@
-import { isSameDay, isValid, parse } from "date-fns";
+import { differenceInHours, isSameDay, isValid, parse, parseISO } from "date-fns";
 import { useMemo } from "react";
 import { CheckInStatus, type CheckInStatusType } from "@/constants/check-in-status";
 import type { ICheckInStatusOptions } from "../../types";
 
+const CHECK_IN_COOLDOWN_HOURS = 24;
+
 /**
- * 檢查指定日期是否為今天
+ * 檢查距離上次打卡是否未滿 24 小時
+ * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 和日期字串 (e.g., "2024-01-20")
+ * - ISO 時間戳：精確計算是否未滿 24 小時
+ * - 日期字串：退回使用「是否為同一天」的判斷
  */
-const isDateToday = (dateString: string | null | undefined): boolean => {
+const isWithinCooldown = (dateString: string | null | undefined): boolean => {
   if (!dateString) return false;
 
   try {
-    const checkInDate = parse(dateString, "yyyy-MM-dd", new Date());
+    // ISO 8601 時間戳（包含 "T"）：精確計算 24 小時
+    if (dateString.includes("T")) {
+      const checkInTime = parseISO(dateString);
+      if (!isValid(checkInTime)) return false;
 
+      const now = new Date();
+      return differenceInHours(now, checkInTime) < CHECK_IN_COOLDOWN_HOURS;
+    }
+
+    // 日期字串 (yyyy-MM-dd)：退回使用同一天判斷
+    const checkInDate = parse(dateString, "yyyy-MM-dd", new Date());
     if (!isValid(checkInDate)) return false;
 
     const today = new Date();
@@ -31,8 +45,8 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
     // 檢查實踐是否已完成
     const isPracticeCompleted = practiceStatus === "completed" || practiceStatus === "archived";
 
-    // 檢查今天是否已打卡
-    const isTodayCheckedIn = isDateToday(lastCheckInDate);
+    // 檢查距離上次打卡是否未滿 24 小時
+    const isTodayCheckedIn = isWithinCooldown(lastCheckInDate);
 
     // 決定最終狀態（優先級：已完成 > 今天已打卡 > 可打卡）
     const getStatus = (): CheckInStatusType => {

--- a/apps/product/src/components/check-in/types.ts
+++ b/apps/product/src/components/check-in/types.ts
@@ -46,7 +46,9 @@ export interface ICheckInStatusOptions {
    */
   practiceStatus?: string;
   /**
-   * 最後打卡日期 (ISO 格式字串，例如 "2026-01-01")
+   * 最後打卡時間
+   * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 或日期字串 (e.g., "2024-01-20")
+   * 傳入時間戳時可精確判斷 24 小時冷卻；僅傳入日期時退回使用同一天判斷
    * 如果沒有打卡記錄，應傳入 null
    */
   lastCheckInDate: string | null;


### PR DESCRIPTION
## Why is this necessary?

The previous implementation only checked if the last check-in was on the same day, which doesn't accurately represent a 24-hour cooldown period. This could allow users to check in multiple times within a 24-hour window if they check in near the end of one day and again near the start of the next day.

This change implements a precise 24-hour cooldown mechanism that:
- Calculates the exact time difference between now and the last check-in
- Prevents check-ins within 24 hours of the previous one
- Maintains backward compatibility with date-only strings (falls back to same-day logic)

## How does it address?

### Main Changes:

1. **Renamed function**: `isDateToday` → `isWithinCooldown` to better reflect the actual behavior

2. **Enhanced cooldown logic** (both mobile and product apps):
   - Added support for ISO 8601 timestamps (e.g., `"2024-01-20T09:00:00.000Z"`)
   - Implements precise 24-hour calculation using `differenceInHours` (product) or manual millisecond calculation (mobile)
   - Falls back to same-day comparison for date-only strings (e.g., `"2024-01-20"`)

3. **Updated data flow**:
   - Changed from converting `lastCheckinAt` to `yyyy-MM-dd` format to passing the raw ISO 8601 timestamp
   - Updated check-in detail page to use `createdAt` instead of `checkinDate` for accurate timestamp
   - Removed unnecessary `date-fns` imports from product homepage

4. **Updated documentation**:
   - Enhanced JSDoc comments explaining the dual format support
   - Updated type definitions to clarify timestamp vs date string handling

### Files Modified:
- `apps/mobile/components/check-in/form/hooks/use-check-in-status.ts`
- `apps/mobile/components/check-in/types.ts`
- `apps/product/src/components/check-in/form/hooks/use-check-in-status.ts`
- `apps/product/src/components/check-in/types.ts`
- `apps/product/src/app/[locale]/(with-layout)/page.tsx`
- `apps/product/src/app/[locale]/practices/[id]/page.tsx`
- `apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx`

### Impact:
- **Backward compatible**: Still supports date-only strings
- **More accurate**: Precise 24-hour cooldown enforcement
- **Consistent**: Applied to both mobile and product applications

https://claude.ai/code/session_01YA7brKqCesJpYkRkSb1wfs