### PR TITLE
Feat/fix user issue

### DIFF
--- a/apps/mobile/components/check-in/display/check-in-stack.tsx
+++ b/apps/mobile/components/check-in/display/check-in-stack.tsx
@@ -96,7 +96,7 @@ export const CheckInStack = ({ checkInsData, onCheckInPress }: ICheckInStackProp
 
             {/* Date */}
             <Text fontSize={12} color={colors.text.dark} fontWeight="500">
-              #{index + 1} {item.date}
+              {item.date}
             </Text>
 
             {/* Content preview */}

--- a/apps/mobile/components/check-in/form/hooks/use-check-in-status.ts
+++ b/apps/mobile/components/check-in/form/hooks/use-check-in-status.ts
@@ -2,61 +2,18 @@ import { useMemo } from "react";
 import { CheckInStatus, type CheckInStatusType } from "@/constants/check-in-status";
 import type { ICheckInStatusOptions } from "../../types";
 
-const CHECK_IN_COOLDOWN_MS = 24 * 60 * 60 * 1000;
-
-/**
- * 檢查距離上次打卡是否未滿 24 小時
- * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 和日期字串 (e.g., "2024-01-20")
- * - ISO 時間戳：精確計算是否未滿 24 小時
- * - 日期字串：退回使用「是否為同一天」的判斷
- */
-const isWithinCooldown = (dateString: string | null | undefined): boolean => {
-  if (!dateString) return false;
-
-  try {
-    // ISO 8601 時間戳（包含 "T"）：精確計算 24 小時
-    if (dateString.includes("T")) {
-      const checkInTime = new Date(dateString);
-      if (Number.isNaN(checkInTime.getTime())) return false;
-
-      const now = new Date();
-      const diffMs = now.getTime() - checkInTime.getTime();
-      return diffMs < CHECK_IN_COOLDOWN_MS;
-    }
-
-    // 日期字串 (yyyy-MM-dd)：退回使用同一天判斷
-    const [year, month, day] = dateString.split("-").map(Number);
-    if (!year || !month || !day) return false;
-
-    const checkInDate = new Date(year, month - 1, day);
-    if (Number.isNaN(checkInDate.getTime())) return false;
-
-    // 驗證日期沒有溢出（例如 "2024-02-30" 會變成 3 月 1 日）
-    if (checkInDate.getDate() !== day) return false;
-
-    const today = new Date();
-    return (
-      checkInDate.getFullYear() === today.getFullYear() &&
-      checkInDate.getMonth() === today.getMonth() &&
-      checkInDate.getDate() === today.getDate()
-    );
-  } catch {
-    return false;
-  }
-};
-
 /**
  * Hook 用於檢查打卡狀態 (Mobile)
  */
 export const useCheckInStatus = (options: ICheckInStatusOptions) => {
-  const { practiceStatus, lastCheckInDate } = options;
+  const { practiceStatus } = options;
 
   return useMemo(() => {
     // 檢查實踐是否已完成
     const isPracticeCompleted = practiceStatus === "completed" || practiceStatus === "archived";
 
-    // 檢查距離上次打卡是否未滿 24 小時
-    const isCheckInLocked = isWithinCooldown(lastCheckInDate);
+    // 不限制打卡冷卻時間
+    const isCheckInLocked = false;
 
     // 決定最終狀態（優先級：已完成 > 冷卻中 > 可打卡）
     const getStatus = (): CheckInStatusType => {
@@ -90,5 +47,5 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
       canCheckIn,
       getButtonLabel,
     };
-  }, [practiceStatus, lastCheckInDate]);
+  }, [practiceStatus]);
 };

--- a/apps/mobile/components/check-in/types.ts
+++ b/apps/mobile/components/check-in/types.ts
@@ -44,12 +44,10 @@ export interface ICheckInStatusOptions {
    */
   practiceStatus?: string;
   /**
-   * 最後打卡時間
-   * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 或日期字串 (e.g., "2024-01-20")
-   * 傳入時間戳時可精確判斷 24 小時冷卻；僅傳入日期時退回使用同一天判斷
-   * 如果沒有打卡記錄，應傳入 null
+   * 最後打卡時間（已停用，不再限制打卡冷卻時間）
+   * @deprecated 已移除 24 小時打卡限制
    */
-  lastCheckInDate: string | null;
+  lastCheckInDate?: string | null;
 }
 
 /**

--- a/apps/mobile/components/practice/create/manual/schema.ts
+++ b/apps/mobile/components/practice/create/manual/schema.ts
@@ -122,7 +122,7 @@ export const manualPracticeFormSchema = z.object({
 
   // Step 3
   durationMinutes: z.number(),
-  executionTiming: z.array(z.nativeEnum(ExecutionTiming)).min(1, "請至少選擇一個執行時機"),
+  executionTiming: z.array(z.nativeEnum(ExecutionTiming)),
   customTiming: z.string(),
 
   // Step 4
@@ -143,6 +143,12 @@ export const manualPracticeFormSchema = z.object({
       })
     )
     .optional(),
-});
+}).refine(
+  (data) => data.executionTiming.length > 0 || data.customTiming.trim().length > 0,
+  {
+    message: "請至少選擇一個執行時機或填寫其他時段",
+    path: ["executionTiming"],
+  }
+);
 
 export type ManualPracticeFormValues = z.infer<typeof manualPracticeFormSchema>;

--- a/apps/mobile/components/practice/shared/circular-progress.tsx
+++ b/apps/mobile/components/practice/shared/circular-progress.tsx
@@ -26,19 +26,20 @@ export const CircularProgress = ({
   progressColor = colors.primary.base,
   backgroundColor = colors.basic["200"],
 }: CircularProgressProps) => {
-  const { radius, circumference, offset } = useMemo(() => {
+  const { radius, circumference, offset, clampedValue } = useMemo(() => {
     const r = (size - strokeWidth) / 2;
     const c = r * 2 * Math.PI;
-    const o = c - (value / 100) * c;
-    return { radius: r, circumference: c, offset: o };
+    const clamped = Math.min(100, Math.max(0, value));
+    const o = c - (clamped / 100) * c;
+    return { radius: r, circumference: c, offset: o, clampedValue: clamped };
   }, [size, strokeWidth, value]);
 
   return (
     <View
       style={[styles.container, { width: size, height: size }]}
-      accessibilityLabel={`進度 ${Math.round(value)}%`}
+      accessibilityLabel={`進度 ${Math.round(clampedValue)}%`}
       accessibilityRole="progressbar"
-      accessibilityValue={{ min: 0, max: 100, now: value }}
+      accessibilityValue={{ min: 0, max: 100, now: clampedValue }}
     >
       <Svg width={size} height={size} style={styles.svg}>
         {/* Background circle */}
@@ -66,7 +67,7 @@ export const CircularProgress = ({
       {showText && (
         <View style={styles.textContainer}>
           <Text fontSize={size > 50 ? 16 : 12} fontWeight="600" color={textColor}>
-            {Math.round(value)}%
+            {Math.round(clampedValue)}%
           </Text>
         </View>
       )}

--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -280,7 +280,7 @@ export default function EditPracticePage() {
   if (isLoading) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-        <PageHeader leftAction="back" title="編輯實踐" rightActionTo="/" />
+        <PageHeader leftAction="back" leftLabel="" title="編輯實踐" rightActionTo="/" />
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">載入中...</div>
@@ -293,7 +293,7 @@ export default function EditPracticePage() {
   if (error || !practiceData?.data) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
-        <PageHeader leftAction="back" title="編輯實踐" rightActionTo="/" />
+        <PageHeader leftAction="back" leftLabel="" title="編輯實踐" rightActionTo="/" />
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -333,7 +333,7 @@ export default function PracticeDetailPage() {
       </main>
 
       {/* CheckIn Stack */}
-      <div className="max-w-[448px] mx-auto">
+      <div className="max-w-[448px] mx-auto pb-24">
         <CheckInStack practiceId={practiceId} checkInsData={checkInsData} />
       </div>
 

--- a/apps/product/src/app/[locale]/practices/create/template/[templateId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/template/[templateId]/page.tsx
@@ -289,9 +289,6 @@ export default function TemplateDetailPage() {
         <PageHeader leftAction="back" leftLabel="" rightActionTo="/" variant="light" />
         <div className="flex flex-col items-center justify-center min-h-[60vh] px-5">
           <p className="text-white mb-4">載入模板時發生錯誤</p>
-          <Button variant="white" onClick={() => router.back()}>
-            返回
-          </Button>
         </div>
       </div>
     );

--- a/apps/product/src/app/[locale]/settings/account/page.tsx
+++ b/apps/product/src/app/[locale]/settings/account/page.tsx
@@ -6,7 +6,7 @@ import { AccountForm } from "@/components/settings/account";
 export default function AccountSettingsPage() {
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
-      <PageHeader leftAction="back" title="帳號設定" />
+      <PageHeader leftAction="back" leftLabel="" title="帳號設定" />
 
       <BackgroundAnimation />
 

--- a/apps/product/src/app/[locale]/settings/archived/page.tsx
+++ b/apps/product/src/app/[locale]/settings/archived/page.tsx
@@ -6,7 +6,7 @@ import { ArchivedContentList } from "@/components/settings/archived-content-list
 export default function ArchivedContentPage() {
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
-      <PageHeader leftAction="back" title="已封存的內容" />
+      <PageHeader leftAction="back" leftLabel="" title="已封存的內容" />
 
       <BackgroundAnimation />
 

--- a/apps/product/src/app/[locale]/settings/preferences/page.tsx
+++ b/apps/product/src/app/[locale]/settings/preferences/page.tsx
@@ -6,7 +6,7 @@ import { PreferencesForm } from "@/components/settings/preferences";
 export default function PreferencesSettingsPage() {
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
-      <PageHeader leftAction="back" title="領域偏好設定" />
+      <PageHeader leftAction="back" leftLabel="" title="領域偏好設定" />
 
       <BackgroundAnimation />
 

--- a/apps/product/src/app/[locale]/settings/public-info/page.tsx
+++ b/apps/product/src/app/[locale]/settings/public-info/page.tsx
@@ -6,7 +6,7 @@ import { PublicInfoForm } from "@/components/settings/public-info";
 export default function PublicInfoSettingsPage() {
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
-      <PageHeader leftAction="back" title="公開資訊設定" />
+      <PageHeader leftAction="back" leftLabel="" title="公開資訊設定" />
 
       <BackgroundAnimation />
 

--- a/apps/product/src/components/check-in/display/check-in-stack.tsx
+++ b/apps/product/src/components/check-in/display/check-in-stack.tsx
@@ -316,13 +316,29 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
   const getSvgConfig = useCallback((index: number) => SVG_CONFIGS[index % SVG_CONFIGS.length], []);
 
   const getSvgRef = useCallback(
-    (index: number) => svgRefsRef.current[index % svgRefsRef.current.length],
+    (index: number) => svgRefsRef.current[index % SVG_CONFIGS.length],
     []
   );
 
   // 從實際渲染的 SVG 元素中提取幾何數據
   useEffect(() => {
-    const frameId = requestAnimationFrame(() => {
+    if (count === 0) return;
+
+    let currentFrameId: number | undefined;
+    let isCancelled = false;
+
+    // 檢查所有 SVG refs 是否已準備好
+    const checkAndExtractGeometries = () => {
+      if (isCancelled) return;
+
+      // 確保所有需要的 SVG refs 都已經存在
+      const allRefsReady = SVG_CONFIGS.every((_, i) => svgRefsRef.current[i] != null);
+      if (!allRefsReady) {
+        // 如果還沒準備好，稍後再試
+        currentFrameId = requestAnimationFrame(checkAndExtractGeometries);
+        return;
+      }
+
       const geometries: (ISvgGeometry | null)[] = [];
 
       for (let i = 0; i < count; i++) {
@@ -333,12 +349,17 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
 
       // 只有在所有幾何數據都準備好時才更新
       const allReady = geometries.every((g) => g !== null);
-      if (allReady) {
+      if (allReady && !isCancelled) {
         setSvgGeometries(geometries);
       }
-    });
+    };
 
-    return () => cancelAnimationFrame(frameId);
+    currentFrameId = requestAnimationFrame(checkAndExtractGeometries);
+
+    return () => {
+      isCancelled = true;
+      if (currentFrameId) cancelAnimationFrame(currentFrameId);
+    };
   }, [count, getSvgRef]);
 
   useEffect(() => {
@@ -621,9 +642,7 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
               )}
             >
               <Emoji className="size-6" />
-              <div className="text-xs text-bg-dark">
-                #{count - i} {date}
-              </div>
+              <div className="text-xs text-bg-dark">{date}</div>
               <div className="max-w-40 text-bg-dark line-clamp-2">{content}</div>
             </div>
           </Link>

--- a/apps/product/src/components/check-in/form/hooks/use-check-in-status.ts
+++ b/apps/product/src/components/check-in/form/hooks/use-check-in-status.ts
@@ -1,53 +1,19 @@
-import { isSameDay, isValid, parse, parseISO } from "date-fns";
 import { useMemo } from "react";
 import { CheckInStatus, type CheckInStatusType } from "@/constants/check-in-status";
 import type { ICheckInStatusOptions } from "../../types";
-
-const CHECK_IN_COOLDOWN_MS = 24 * 60 * 60 * 1000;
-
-/**
- * 檢查距離上次打卡是否未滿 24 小時
- * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 和日期字串 (e.g., "2024-01-20")
- * - ISO 時間戳：精確計算是否未滿 24 小時
- * - 日期字串：退回使用「是否為同一天」的判斷
- */
-const isWithinCooldown = (dateString: string | null | undefined): boolean => {
-  if (!dateString) return false;
-
-  try {
-    // ISO 8601 時間戳（包含 "T"）：精確計算 24 小時
-    if (dateString.includes("T")) {
-      const checkInTime = parseISO(dateString);
-      if (!isValid(checkInTime)) return false;
-
-      const now = new Date();
-      const diffMs = now.getTime() - checkInTime.getTime();
-      return diffMs < CHECK_IN_COOLDOWN_MS;
-    }
-
-    // 日期字串 (yyyy-MM-dd)：退回使用同一天判斷
-    const checkInDate = parse(dateString, "yyyy-MM-dd", new Date());
-    if (!isValid(checkInDate)) return false;
-
-    const today = new Date();
-    return isSameDay(checkInDate, today);
-  } catch {
-    return false;
-  }
-};
 
 /**
  * Hook 用於檢查打卡狀態
  */
 export const useCheckInStatus = (options: ICheckInStatusOptions) => {
-  const { practiceStatus, lastCheckInDate } = options;
+  const { practiceStatus } = options;
 
   return useMemo(() => {
     // 檢查實踐是否已完成
     const isPracticeCompleted = practiceStatus === "completed" || practiceStatus === "archived";
 
-    // 檢查距離上次打卡是否未滿 24 小時
-    const isCheckInLocked = isWithinCooldown(lastCheckInDate);
+    // 不限制打卡冷卻時間
+    const isCheckInLocked = false;
 
     // 決定最終狀態（優先級：已完成 > 冷卻中 > 可打卡）
     const getStatus = (): CheckInStatusType => {
@@ -81,5 +47,5 @@ export const useCheckInStatus = (options: ICheckInStatusOptions) => {
       canCheckIn,
       getButtonLabel,
     };
-  }, [practiceStatus, lastCheckInDate]);
+  }, [practiceStatus]);
 };

--- a/apps/product/src/components/check-in/types.ts
+++ b/apps/product/src/components/check-in/types.ts
@@ -46,12 +46,10 @@ export interface ICheckInStatusOptions {
    */
   practiceStatus?: string;
   /**
-   * 最後打卡時間
-   * 支援 ISO 8601 時間戳 (e.g., "2024-01-20T09:00:00.000Z") 或日期字串 (e.g., "2024-01-20")
-   * 傳入時間戳時可精確判斷 24 小時冷卻；僅傳入日期時退回使用同一天判斷
-   * 如果沒有打卡記錄，應傳入 null
+   * 最後打卡時間（已停用，不再限制打卡冷卻時間）
+   * @deprecated 已移除 24 小時打卡限制
    */
-  lastCheckInDate: string | null;
+  lastCheckInDate?: string | null;
   /**
    * 實踐開始日期 (ISO 格式字串，例如 "2026-01-01")
    * 用於檢查打卡日期是否早於開始日期

--- a/apps/product/src/components/dashboard/in-progress-task-card.tsx
+++ b/apps/product/src/components/dashboard/in-progress-task-card.tsx
@@ -81,11 +81,9 @@ export const InProgressTaskCard = ({
               </div>
             </div>
             <div className="shrink-0 self-center">
-              <Button variant="ghost" size="icon" asChild onClick={(e) => e.stopPropagation()}>
-                <CustomLink href={`/practices/${id}`}>
-                  <ArrowRightOutlineSvg className="size-6 text-light-gray" />
-                </CustomLink>
-              </Button>
+              <span className="inline-flex items-center justify-center size-10">
+                <ArrowRightOutlineSvg className="size-6 text-light-gray" />
+              </span>
             </div>
           </div>
         </div>

--- a/apps/product/src/components/practice/create/manual/schema.ts
+++ b/apps/product/src/components/practice/create/manual/schema.ts
@@ -123,7 +123,7 @@ export const createManualPracticeFormSchema = (options?: ManualPracticeSchemaOpt
 
     // Step 3
     durationMinutes: z.number(),
-    executionTiming: z.array(z.nativeEnum(ExecutionTiming)).min(1, "請至少選擇一個執行時機"),
+    executionTiming: z.array(z.nativeEnum(ExecutionTiming)),
     customTiming: z.string(),
 
     // Step 4
@@ -144,7 +144,13 @@ export const createManualPracticeFormSchema = (options?: ManualPracticeSchemaOpt
         })
       )
       .optional(),
-  });
+  }).refine(
+    (data) => data.executionTiming.length > 0 || data.customTiming.trim().length > 0,
+    {
+      message: "請至少選擇一個執行時機或填寫其他時段",
+      path: ["executionTiming"],
+    }
+  );
 };
 
 // 預設 schema（用於創建模式）

--- a/apps/product/src/components/practice/create/manual/steps/step-3.tsx
+++ b/apps/product/src/components/practice/create/manual/steps/step-3.tsx
@@ -79,7 +79,7 @@ export const Step3 = ({ form }: Step3Props) => {
         render={({ field }) => (
           <FormItem>
             <div className="flex items-center justify-between mb-3">
-              <FormLabel required className="text-base font-medium text-text-dark">
+              <FormLabel className="text-base font-medium text-text-dark">
                 執行時機
               </FormLabel>
               <FormDescription className="text-sm text-light-gray">多選</FormDescription>

--- a/apps/product/src/components/practice/shared/circular-progress.tsx
+++ b/apps/product/src/components/practice/shared/circular-progress.tsx
@@ -21,7 +21,8 @@ export const CircularProgress = ({
 }: CircularProgressProps) => {
   const radius = (size - strokeWidth) / 2;
   const circumference = radius * 2 * Math.PI;
-  const offset = circumference - (value / 100) * circumference;
+  const clampedValue = Math.min(100, Math.max(0, value));
+  const offset = circumference - (clampedValue / 100) * circumference;
 
   return (
     <div className={cn("relative inline-flex items-center justify-center", className)}>
@@ -30,7 +31,7 @@ export const CircularProgress = ({
         height={size}
         className="transform -rotate-90"
         role="img"
-        aria-label={`進度 ${value}%`}
+        aria-label={`進度 ${clampedValue}%`}
       >
         {/* Background circle */}
         <circle
@@ -63,7 +64,7 @@ export const CircularProgress = ({
             textClassName
           )}
         >
-          {Math.round(value)}%
+          {Math.round(clampedValue)}%
         </div>
       )}
     </div>

--- a/apps/product/src/components/settings/account/account-form.tsx
+++ b/apps/product/src/components/settings/account/account-form.tsx
@@ -27,8 +27,10 @@ export const AccountForm = () => {
   const { updateCurrentUser } = useUserMutations();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // 獲取城市列表以找到用戶 location 對應的 countryCode（傳入 locale 以支援多語系）
+  // 使用 search 參數精確搜尋用戶的城市，以獲取 countryCode
+  const userLocation = userData?.data?.location;
   const { data: citiesData } = useCities({
+    search: userLocation || undefined,
     locale: locale === "en" ? "en" : "zh-TW",
   });
 

--- a/apps/product/src/components/settings/public-info/basic-info-section.tsx
+++ b/apps/product/src/components/settings/public-info/basic-info-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { checkCustomIdAvailability } from "@daodao/api";
-import { useLocale, useTranslations } from "@daodao/i18n";
+import { checkCustomIdAvailability, useCities, useCountries } from "@daodao/api";
+import { useLocale } from "@daodao/i18n";
 import {
   FormControl,
   FormDescription,
@@ -11,10 +11,16 @@ import {
   FormMessage,
 } from "@daodao/ui/components/form";
 import { Input } from "@daodao/ui/components/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@daodao/ui/components/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@daodao/ui/components/select";
 import { cn } from "@daodao/ui/lib/utils";
-import { CheckCircleIcon, ChevronDownIcon, LoaderIcon, XCircleIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CheckCircleIcon, LoaderIcon, MapPin, XCircleIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import type { PublicInfoFormValues } from "./schema";
 
@@ -25,7 +31,7 @@ interface IBasicInfoSectionProps {
 
 export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionProps) => {
   const locale = useLocale();
-  const t = useTranslations();
+  const selectedCountry = form.watch("country");
 
   // customId 即時檢查狀態
   const [customIdStatus, setCustomIdStatus] = useState<
@@ -33,16 +39,23 @@ export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionPro
   >("idle");
   const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // 取得城市選項
-  const cityOptions = useMemo(() => {
-    const cities: Record<string, string> = t.raw("cities") as Record<string, string>;
-    return Object.entries(cities)
-      .map(([key, value]) => ({
-        value: key,
-        label: value,
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label, locale === "en" ? "en" : "zh-TW"));
-  }, [t, locale]);
+  // 獲取國家列表
+  const { data: countriesData, isLoading: isLoadingCountries } = useCountries();
+
+  // 根據選擇的國家獲取城市列表（傳入 locale 以支援多語系）
+  const { data: citiesData, isLoading: isLoadingCities } = useCities({
+    country: selectedCountry || undefined,
+    locale: locale === "en" ? "en" : "zh-TW",
+  });
+
+  const countries = (countriesData?.data ?? []).filter((c) => c.code);
+  const cities = (citiesData?.data ?? []).filter((c) => c.code);
+
+  // 當國家變更時，清空城市選擇
+  const handleCountryChange = (value: string) => {
+    form.setValue("country", value);
+    form.setValue("location", "");
+  };
 
   // customId 即時檢查函數（debounced）
   const checkCustomId = useCallback(
@@ -185,205 +198,101 @@ export const BasicInfoSection = ({ form, initialCustomId }: IBasicInfoSectionPro
         )}
       />
 
-      {/* 居住地 */}
+      {/* 居住地 - 國家 */}
+      <FormField
+        control={form.control}
+        name="country"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="block font-medium text-text-dark mb-3">居住地</FormLabel>
+            <FormControl>
+              <div className="relative">
+                <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-light-gray z-10" />
+                <Select
+                  value={field.value || ""}
+                  onValueChange={handleCountryChange}
+                  disabled={field.disabled || isLoadingCountries}
+                >
+                  <SelectTrigger
+                    className={cn(
+                      "w-full h-10 pl-11 pr-4 py-2 text-left font-normal text-sm",
+                      "border border-bg-gray hover:border-logo-cyan bg-background rounded-lg",
+                      "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
+                      form.formState.errors.country && "border-red",
+                      "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray",
+                      "data-placeholder:text-light-gray"
+                    )}
+                    aria-invalid={!!form.formState.errors.country}
+                  >
+                    <SelectValue placeholder={isLoadingCountries ? "載入中..." : "請選擇國家"} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {countries.map((country) => (
+                      <SelectItem key={country.code} value={country.code}>
+                        {locale === "en" ? country.nameEn || country.name : country.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* 居住地 - 城市 */}
       <FormField
         control={form.control}
         name="location"
         render={({ field }) => (
           <FormItem>
-            <FormLabel className="block font-medium text-text-dark mb-3">居住地</FormLabel>
             <FormControl>
-              <CityCombobox
-                value={field.value || ""}
-                options={cityOptions}
-                onChange={(value) => {
-                  field.onChange(value || undefined);
-                  field.onBlur();
-                }}
-                invalid={!!form.formState.errors.location}
-              />
+              <div className="relative">
+                <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-light-gray z-10" />
+                <Select
+                  value={field.value || ""}
+                  onValueChange={(value) => {
+                    field.onChange(value);
+                    field.onBlur();
+                  }}
+                  disabled={field.disabled || !selectedCountry || isLoadingCities}
+                >
+                  <SelectTrigger
+                    className={cn(
+                      "w-full h-10 pl-11 pr-4 py-2 text-left font-normal text-sm",
+                      "border border-bg-gray hover:border-logo-cyan bg-background rounded-lg",
+                      "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
+                      form.formState.errors.location && "border-red",
+                      "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray",
+                      "data-placeholder:text-light-gray"
+                    )}
+                    aria-invalid={!!form.formState.errors.location}
+                  >
+                    <SelectValue
+                      placeholder={
+                        !selectedCountry
+                          ? "請先選擇國家"
+                          : isLoadingCities
+                            ? "載入中..."
+                            : "請選擇城市"
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {cities.map((city) => (
+                      <SelectItem key={city.code} value={city.code}>
+                        {city.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </FormControl>
             <FormMessage />
           </FormItem>
         )}
       />
     </div>
-  );
-};
-
-interface ICityOption {
-  value: string;
-  label: string;
-}
-
-interface ICityComboboxProps {
-  value: string;
-  options: ICityOption[];
-  onChange: (value: string) => void;
-  invalid?: boolean;
-}
-
-const CityCombobox = ({ value, options, onChange, invalid }: ICityComboboxProps) => {
-  const [open, setOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
-  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
-
-  // 取得選中的選項標籤
-  const selectedOption = useMemo(() => {
-    return options.find((option) => option.value === value);
-  }, [options, value]);
-
-  // 過濾選項
-  const filteredOptions = useMemo(() => {
-    if (!searchQuery.trim()) {
-      return options;
-    }
-    const query = searchQuery.toLowerCase();
-    return options.filter(
-      (option) =>
-        option.label.toLowerCase().includes(query) || option.value.toLowerCase().includes(query)
-    );
-  }, [options, searchQuery]);
-
-  // 當 Popover 打開時，聚焦到輸入框
-  useEffect(() => {
-    if (open && inputRef.current) {
-      // 延遲一下確保 Popover 已經完全打開
-      setTimeout(() => {
-        inputRef.current?.focus();
-      }, 100);
-    } else if (!open) {
-      // 關閉時清空搜尋並重置高亮
-      setSearchQuery("");
-      setHighlightedIndex(0);
-    }
-  }, [open]);
-
-  // 處理選項點擊
-  const handleSelectOption = (optionValue: string) => {
-    onChange(optionValue);
-    setOpen(false);
-    setSearchQuery("");
-    setHighlightedIndex(0);
-  };
-
-  // 處理鍵盤導航
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Escape") {
-      setOpen(false);
-      setSearchQuery("");
-      setHighlightedIndex(0);
-    } else if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setHighlightedIndex((prev) => {
-        const nextIndex = prev < filteredOptions.length - 1 ? prev + 1 : 0;
-        // 滾動到可見區域
-        optionRefs.current[nextIndex]?.scrollIntoView({
-          block: "nearest",
-          behavior: "smooth",
-        });
-        return nextIndex;
-      });
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setHighlightedIndex((prev) => {
-        const nextIndex = prev > 0 ? prev - 1 : filteredOptions.length - 1;
-        // 滾動到可見區域
-        optionRefs.current[nextIndex]?.scrollIntoView({
-          block: "nearest",
-          behavior: "smooth",
-        });
-        return nextIndex;
-      });
-    } else if (e.key === "Enter" && filteredOptions.length > 0) {
-      e.preventDefault();
-      const selectedValue = filteredOptions[highlightedIndex]?.value;
-      if (selectedValue) {
-        handleSelectOption(selectedValue);
-      }
-    }
-  };
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-bg-gray hover:border-logo-cyan bg-background text-sm",
-            "px-4 py-2 focus-visible:px-[15px] focus-visible:py-[9px]",
-            "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
-            "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray disabled:text-light-gray",
-            invalid && "border-red",
-            !selectedOption && "text-light-gray"
-          )}
-          aria-invalid={invalid}
-        >
-          <span className="flex-1 text-left truncate">
-            {selectedOption ? selectedOption.label : "請選擇"}
-          </span>
-          <ChevronDownIcon className="size-4 opacity-50 shrink-0" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-(--radix-popover-trigger-width) p-0"
-        align="start"
-        sideOffset={4}
-      >
-        <div className="flex flex-col">
-          {/* 搜尋輸入框 */}
-          <div className="p-2 border-b border-bg-gray">
-            <Input
-              ref={inputRef}
-              value={searchQuery}
-              onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setHighlightedIndex(0);
-              }}
-              onKeyDown={handleKeyDown}
-              placeholder="搜尋城市..."
-              className="h-9"
-            />
-          </div>
-
-          {/* 選項列表 */}
-          <div ref={listRef} className="max-h-[300px] overflow-y-auto p-1">
-            {filteredOptions.length === 0 ? (
-              <div className="py-6 text-center text-sm text-light-gray">沒有找到符合的城市</div>
-            ) : (
-              filteredOptions.map((option, index) => (
-                <button
-                  key={option.value}
-                  ref={(el) => {
-                    optionRefs.current[index] = el;
-                  }}
-                  type="button"
-                  onClick={() => handleSelectOption(option.value)}
-                  className={cn(
-                    "w-full flex items-center rounded-sm py-1.5 px-2 text-sm text-left",
-                    "hover:bg-accent hover:text-accent-foreground",
-                    "focus:bg-accent focus:text-accent-foreground outline-hidden",
-                    "transition-colors",
-                    "city-option-item",
-                    highlightedIndex === index && "bg-accent text-accent-foreground"
-                  )}
-                  style={{
-                    contentVisibility: "auto",
-                    containIntrinsicSize: "0 36px",
-                  }}
-                >
-                  <span className={cn("flex-1", value === option.value && "font-medium")}>
-                    {option.label}
-                  </span>
-                </button>
-              ))
-            )}
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
   );
 };

--- a/apps/product/src/components/settings/public-info/public-info-form.tsx
+++ b/apps/product/src/components/settings/public-info/public-info-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCurrentUser, useMutate, useUserMutations } from "@daodao/api";
+import { useCities, useCurrentUser, useMutate, useUserMutations } from "@daodao/api";
+import { useLocale } from "@daodao/i18n";
 import { Button } from "@daodao/ui/components/button";
 import { Form } from "@daodao/ui/components/form";
 import { toast } from "@daodao/ui/components/sonner";
@@ -15,11 +16,19 @@ import { type PublicInfoFormValues, publicInfoFormSchema } from "./schema";
 import { SocialLinksSection } from "./social-links-section";
 
 export const PublicInfoForm = () => {
+  const locale = useLocale();
   const { data: userData, isLoading, error: userError } = useCurrentUser();
   const { updateCurrentUserWithFormData } = useUserMutations();
   const mutate = useMutate();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
+
+  // 使用 search 參數精確搜尋用戶的城市，以獲取 countryCode
+  const userLocation = userData?.data?.location;
+  const { data: citiesData } = useCities({
+    search: userLocation || undefined,
+    locale: locale === "en" ? "en" : "zh-TW",
+  });
 
   const form = useForm<PublicInfoFormValues>({
     resolver: zodResolver(publicInfoFormSchema),
@@ -27,6 +36,7 @@ export const PublicInfoForm = () => {
       photoURL: "",
       name: "",
       customId: "",
+      country: "",
       location: "",
       personalSlogan: "",
       selfIntroduction: "",
@@ -47,10 +57,20 @@ export const PublicInfoForm = () => {
       const user = userData.data;
       const contactList = user.contactList;
 
+      // 根據 location 找到對應的 countryCode
+      let countryCode = "";
+      if (user.location && citiesData?.data) {
+        const city = citiesData.data.find((c) => c.code === user.location);
+        if (city?.countryCode) {
+          countryCode = city.countryCode;
+        }
+      }
+
       form.reset({
         photoURL: user.photoURL || "",
         name: user.name || "",
         customId: user.customId || "",
+        country: countryCode,
         location: user.location || "",
         personalSlogan: user.personalSlogan || "",
         selfIntroduction: user.selfIntroduction || "",
@@ -64,7 +84,7 @@ export const PublicInfoForm = () => {
         threads: contactList?.threads || "",
       });
     }
-  }, [userData, form.reset]);
+  }, [userData, citiesData, form.reset]);
 
   const handleSubmit = async (values: PublicInfoFormValues) => {
     setIsSubmitting(true);

--- a/apps/product/src/components/settings/public-info/schema.ts
+++ b/apps/product/src/components/settings/public-info/schema.ts
@@ -21,6 +21,7 @@ export const publicInfoFormSchema = z.object({
     .min(3, "ID 最少需要 3 個字符")
     .max(50, "ID 最多 50 個字符")
     .refine((val) => customIdRegex.test(val), "請依照 ID 的格式規則輸入"),
+  country: z.string().optional(),
   location: z.string().optional(),
   personalSlogan: z.string().min(1, "此為必填欄位").max(150, "個人標語最多 150 字"),
   selfIntroduction: z.string().max(350, "關於我最多 350 字").optional(),

--- a/apps/website/src/components/landing-page/learning-foundation-section.tsx
+++ b/apps/website/src/components/landing-page/learning-foundation-section.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "@daodao/i18n";
 import { Image } from "@daodao/ui/components/image";
 import Stack from "@daodao/ui/components/stack";
 import { ChevronRight, Loader2 } from "lucide-react";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 
 // 主題 SVG 背景組件映射（參考 product/src/constants/practice-theme.ts）
 const themeSvgMap = {
@@ -43,9 +43,6 @@ const convertTemplateToCard = (template: PracticeTemplateType, index: number) =>
   templateId: template.id,
 });
 
-// 滑動檢測閾值（像素）
-const SWIPE_THRESHOLD = 10;
-
 function PracticeCard({
   tag,
   title,
@@ -56,6 +53,7 @@ function PracticeCard({
   durationUnit,
   theme,
   templateId,
+  isActive = false,
   onClick,
 }: {
   tag: string;
@@ -67,44 +65,18 @@ function PracticeCard({
   durationUnit: string;
   theme: PracticeTheme;
   templateId: string;
+  isActive?: boolean;
   onClick?: (templateId: string) => void;
 }) {
   const ThemeSvg = themeSvgMap[theme];
-  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
-  const isDraggingRef = useRef(false);
 
-  const handlePointerDown = (e: React.PointerEvent) => {
-    pointerStartRef.current = { x: e.clientX, y: e.clientY };
-    isDraggingRef.current = false;
-  };
-
-  const handlePointerMove = (e: React.PointerEvent) => {
-    if (!pointerStartRef.current) return;
-    const dx = Math.abs(e.clientX - pointerStartRef.current.x);
-    const dy = Math.abs(e.clientY - pointerStartRef.current.y);
-    // 如果移動超過閾值，視為滑動
-    if (dx > SWIPE_THRESHOLD || dy > SWIPE_THRESHOLD) {
-      isDraggingRef.current = true;
-    }
-  };
-
-  const handleClick = () => {
-    // 如果是滑動，不執行點擊
-    if (isDraggingRef.current) {
-      isDraggingRef.current = false;
-      return;
-    }
+  const handleIconClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     onClick?.(templateId);
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      className="relative h-full w-full overflow-hidden rounded-2xl text-left cursor-pointer transition-transform hover:scale-[1.02] active:scale-[0.98]"
-    >
+    <div className="relative h-full w-full overflow-hidden rounded-2xl text-left">
       {/* SVG 背景 */}
       <ThemeSvg className="absolute inset-0 size-full" preserveAspectRatio="xMidYMid slice" />
 
@@ -118,15 +90,17 @@ function PracticeCard({
           <p className="mt-2 text-sm text-basic-400">{description}</p>
         </div>
 
-        {/* Speech bubble */}
-        <div className="mt-4 flex justify-end">
-          <div className="relative">
-            <div className="rounded-lg bg-basic-500 px-4 py-2 text-sm text-white">
-              喜歡嗎？馬上開始！
+        {/* Speech bubble - 只有當前顯示的卡片顯示 */}
+        {isActive && (
+          <div className="mt-4 flex justify-end">
+            <div className="relative">
+              <div className="rounded-lg bg-basic-500 px-4 py-2 text-sm text-white">
+                喜歡嗎？馬上開始！
+              </div>
+              <div className="absolute -bottom-2 right-8 size-0 border-x-8 border-t-8 border-x-transparent border-t-basic-500" />
             </div>
-            <div className="absolute -bottom-2 right-8 size-0 border-x-8 border-t-8 border-x-transparent border-t-basic-500" />
           </div>
-        </div>
+        )}
 
         {/* Stats + next button */}
         <div className="mt-4 flex items-end justify-between">
@@ -141,13 +115,17 @@ function PracticeCard({
             </div>
           </div>
 
-          {/* Next button */}
-          <div className="flex size-12 items-center justify-center rounded-full bg-white/80 shadow-sm group-hover:bg-white transition-colors">
+          {/* Next button - 只有這裡可以點擊跳轉 */}
+          <button
+            type="button"
+            onClick={handleIconClick}
+            className="flex size-12 items-center justify-center rounded-full bg-white/80 shadow-sm hover:bg-white active:scale-95 transition-all cursor-pointer"
+          >
             <ChevronRight className="size-5 text-basic-400" />
-          </div>
+          </button>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -220,8 +198,7 @@ export function LearningFoundationSection() {
           ) : cards.length > 0 ? (
             <Stack
               cards={cards}
-              sendToBackOnClick={false}
-              mobileClickOnly
+              sendToBackOnClick
               autoplay
               autoplayDelay={4000}
               pauseOnHover

--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -325,12 +325,12 @@ export const updatePracticeCheckInWithFormData = async (
 ): Promise<CreateCheckInResponse> => {
   const formData = new FormData();
 
-  // 基本欄位
-  if (data.mood) formData.append("mood", data.mood);
-  if (data.description) formData.append("note", data.description);
+  // 基本欄位 - 使用 !== undefined 確保空字串也能被發送
+  if (data.mood !== undefined) formData.append("mood", data.mood);
+  if (data.description !== undefined) formData.append("note", data.description);
 
-  // 陣列欄位需轉成 JSON 字串
-  if (data.tags && data.tags.length > 0) {
+  // 陣列欄位需轉成 JSON 字串 - 空陣列也要發送以便清除標籤
+  if (data.tags !== undefined) {
     formData.append("tags", JSON.stringify(data.tags));
   }
 
@@ -426,7 +426,7 @@ export const useCreatePracticeCheckIn = (practiceId: string) => {
     // 創建打卡記錄（函數會直接拋出錯誤）
     const response = await createPracticeCheckInWithFormData(practiceId, formData);
 
-    // 刷新打卡列表的 cache
+    // 刷新打卡列表的 cache（使用空 query 對象來匹配所有 query 參數組合）
     await mutate([
       "/api/v1/practices/{id}/checkins",
       {
@@ -434,6 +434,7 @@ export const useCreatePracticeCheckIn = (practiceId: string) => {
           path: {
             id: practiceId,
           },
+          query: {},
         },
       },
     ] as const);
@@ -459,7 +460,7 @@ export const useUpdatePracticeCheckIn = (practiceId: string, checkInId: string) 
   const updateCheckIn = async (formData: ICheckInFormData) => {
     const response = await updatePracticeCheckInWithFormData(practiceId, checkInId, formData);
 
-    // 刷新打卡列表的 cache
+    // 刷新打卡列表的 cache（使用空 query 對象來匹配所有 query 參數組合）
     await mutate([
       "/api/v1/practices/{id}/checkins",
       {
@@ -467,6 +468,7 @@ export const useUpdatePracticeCheckIn = (practiceId: string, checkInId: string) 
           path: {
             id: practiceId,
           },
+          query: {},
         },
       },
     ] as const);

--- a/packages/ui/src/components/progress.tsx
+++ b/packages/ui/src/components/progress.tsx
@@ -17,7 +17,7 @@ const Progress = React.forwardRef<
   >
     <ProgressPrimitive.Indicator
       className="size-full flex-1 bg-(--active-color) transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${100 - Math.min(100, Math.max(0, value || 0))}%)` }}
     />
   </ProgressPrimitive.Root>
 ));

--- a/packages/ui/src/components/stack.tsx
+++ b/packages/ui/src/components/stack.tsx
@@ -1,5 +1,5 @@
 import { motion, type PanInfo, useMotionValue, useTransform } from "motion/react";
-import { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 interface CardRotateProps {
   children: React.ReactNode;
@@ -163,7 +163,9 @@ export default function Stack({
                 damping: animationConfig.damping,
               }}
             >
-              {card.content}
+              {React.isValidElement(card.content)
+                ? React.cloneElement(card.content, { isActive: index === stack.length - 1 } as Record<string, unknown>)
+                : card.content}
             </motion.div>
           </CardRotate>
         );


### PR DESCRIPTION
## Why is this necessary?

- 進度條顯示數值可能超過 100%（來自後端數據），導致 UI 顯示異常
- 打卡堆疊沒有顯示所有卡片，且卡片上的 `#number` 前綴不必要
- 24 小時打卡冷卻限制過於嚴格，影響用戶體驗
- 打卡卡片可能被固定底部遮擋，需要增加底部間距
- 設定頁面 PageHeader 的「返回」文字不必要
- 自訂時間的實踐不應強制選擇執行時機
- Dashboard 任務卡片需要更簡潔的 UI
- 公開資訊表單的國家/城市選擇需要更好的互動體驗
- Landing Page 練習卡片需要支援滑動導航



## How does it address?

### 1. 進度條數值限制 (Progress Bar Clamping)

**問題：** 當後端返回的 `progressPercentage` 超過 100% 時，進度條和圓形進度組件顯示異常。

**解決方案：** 對進度數值進行 0-100 範圍的 clamp 處理。

**變更位置：**
- `apps/mobile/components/practice/shared/circular-progress.tsx`
- `apps/product/src/components/practice/shared/circular-progress.tsx`
- `packages/ui/src/components/progress.tsx`

### 2. 打卡顯示改進

**功能說明：**
- 使用固定的 `SVG_CONFIGS.length` 確保打卡堆疊顯示所有卡片
- 移除打卡卡片上的 `#number` 前綴（product 和 mobile 兩端）
- 移除 24 小時打卡冷卻限制，允許用戶隨時打卡
- 為 CheckInStack 容器增加底部間距，避免卡片被固定底部遮擋

**變更位置：**
- `apps/product/src/app/[locale]/practices/[id]/page.tsx`
- `apps/product/src/components/check-in/display/check-in-stack.tsx`
- `apps/product/src/components/check-in/form/hooks/use-check-in-status.ts`
- `apps/product/src/components/check-in/types.ts`
- `apps/mobile/components/check-in/display/check-in-stack.tsx`
- `apps/mobile/components/check-in/form/hooks/use-check-in-status.ts`
- `apps/mobile/components/check-in/types.ts`

### 3. PageHeader 優化

**功能說明：** 移除設定相關頁面 PageHeader 的「返回」文字標籤。

**變更位置：**
- `apps/product/src/app/[locale]/settings/account/page.tsx`
- `apps/product/src/app/[locale]/settings/archived/page.tsx`
- `apps/product/src/app/[locale]/settings/preferences/page.tsx`
- `apps/product/src/app/[locale]/settings/public-info/page.tsx`
- `apps/product/src/app/[locale]/practices/[id]/edit/page.tsx`

### 4. 實踐建立表單改進

**功能說明：** 允許自訂時間的實踐不強制選擇執行時機（executionTiming）。

**變更位置：**
- `apps/product/src/components/practice/create/manual/schema.ts`
- `apps/product/src/components/practice/create/manual/steps/step-3.tsx`
- `apps/mobile/components/practice/create/manual/schema.ts`
- `packages/api/src/services/practice-hooks.ts`

### 5. Dashboard 任務卡片 UI 改進

**功能說明：** 將 InProgressTaskCard 的按鈕替換為圖示，讓 UI 更簡潔。

**變更位置：**
- `apps/product/src/components/dashboard/in-progress-task-card.tsx`

### 6. 公開資訊表單增強

**功能說明：**
- 增強 AccountForm 和 PublicInfoForm 對城市和國家數據的處理
- 新增國家選擇機制，用戶選擇國家後動態載入對應城市
- Schema 新增 `country` 作為可選欄位

**變更位置：**
- `apps/product/src/components/settings/account/account-form.tsx`
- `apps/product/src/components/settings/public-info/basic-info-section.tsx`
- `apps/product/src/components/settings/public-info/public-info-form.tsx`
- `apps/product/src/components/settings/public-info/schema.ts`

### 7. Landing Page 練習卡片滑動導航

**功能說明：**
- 啟用滑動/拖曳方式切換練習卡片
- 將點擊切換區域限制為箭頭圖示，避免誤觸
- 對話氣泡只顯示在當前活躍的卡片上
- Stack 組件新增 `isActive` prop 注入

**變更位置：**
- `apps/product/src/components/landing-page/learning-foundation-section.tsx`
- `packages/ui/src/components/stack.tsx`