### PR TITLE
Feat/admin feature

### DIFF
--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -42,6 +42,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-hook-form": "catalog:",
+    "recharts": "catalog:",
     "swr": "^2.2.5",
     "zod": "catalog:"
   },

--- a/apps/product/src/app/[locale]/admin/email/page.tsx
+++ b/apps/product/src/app/[locale]/admin/email/page.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { sendBulkEmail, sendCustomEmail, useEmailHealth, useEmailStats } from "@daodao/api";
+import { cn } from "@daodao/ui/lib/utils";
+import { AlertTriangle, CheckCircle, Send, XCircle } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { StatCard } from "../../../../components/admin/stat-card";
+
+type TabId = "stats" | "health" | "send";
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: "stats", label: "郵件統計" },
+  { id: "health", label: "服務健康" },
+  { id: "send", label: "發送郵件" },
+];
+
+export default function EmailPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("stats");
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-text-dark">郵件管理</h1>
+
+      <div className="flex gap-1 overflow-x-auto border-b border-border">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "shrink-0 whitespace-nowrap px-4 py-2.5 text-sm font-medium transition-colors border-b-2 border-transparent",
+              activeTab === tab.id
+                ? "border-b-primary-base text-primary-base"
+                : "text-basic-400 hover:text-text-dark"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "stats" && <EmailStatsTab />}
+      {activeTab === "health" && <EmailHealthTab />}
+      {activeTab === "send" && <EmailSendTab />}
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 1: Email Stats
+// ============================================================================
+
+function EmailStatsTab() {
+  const { data, isLoading } = useEmailStats();
+  const emailStats = data?.data as
+    | {
+        totalSent?: number;
+        totalFailed?: number;
+        successRate?: number;
+        byTemplate?: Array<{
+          template?: string;
+          count?: number;
+        }>;
+      }
+    | undefined;
+
+  const chartData = useMemo(
+    () =>
+      (emailStats?.byTemplate ?? []).map((item) => ({
+        name: item.template ?? "Unknown",
+        count: item.count ?? 0,
+      })),
+    [emailStats]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatCard title="總發送數" value={emailStats?.totalSent ?? 0} />
+        <StatCard title="總失敗數" value={emailStats?.totalFailed ?? 0} />
+        <StatCard
+          title="成功率"
+          value={emailStats?.successRate !== undefined ? `${emailStats.successRate}%` : "N/A"}
+        />
+      </div>
+
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold">按模板分類</h3>
+        {chartData.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無資料</div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" fontSize={12} />
+              <YAxis fontSize={12} />
+              <Tooltip />
+              <Bar dataKey="count" fill="#16B9B3" radius={[4, 4, 0, 0]} name="發送數" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 2: Email Health
+// ============================================================================
+
+function EmailHealthTab() {
+  const { data, isLoading } = useEmailHealth();
+  const health = data?.data as
+    | {
+        status?: string;
+        smtp?: { connected?: boolean; host?: string; port?: number };
+        queue?: { size?: number };
+        lastError?: string;
+        uptime?: number;
+      }
+    | undefined;
+
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+      </div>
+    );
+  }
+
+  const status = health?.status ?? "unknown";
+  const StatusIcon =
+    status === "healthy" ? CheckCircle : status === "degraded" ? AlertTriangle : XCircle;
+  const statusColor =
+    status === "healthy"
+      ? "text-green-500"
+      : status === "degraded"
+        ? "text-yellow-500"
+        : "text-red-500";
+  const statusBg =
+    status === "healthy"
+      ? "bg-green-50 border-green-200"
+      : status === "degraded"
+        ? "bg-yellow-50 border-yellow-200"
+        : "bg-red-50 border-red-200";
+
+  return (
+    <div className="space-y-4">
+      {/* Status Banner */}
+      <div className={cn("flex items-center gap-3 rounded-xl border p-5", statusBg)}>
+        <StatusIcon className={cn("size-8", statusColor)} />
+        <div>
+          <p className={cn("text-lg font-semibold capitalize", statusColor)}>{status}</p>
+          <p className="text-sm text-basic-400">郵件服務狀態</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {/* SMTP */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h3 className="mb-3 font-semibold">SMTP 連線</h3>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-basic-400">狀態</span>
+              <span
+                className={cn(
+                  "font-medium",
+                  health?.smtp?.connected ? "text-green-600" : "text-red-600"
+                )}
+              >
+                {health?.smtp?.connected ? "已連線" : "未連線"}
+              </span>
+            </div>
+            {health?.smtp?.host && (
+              <div className="flex justify-between">
+                <span className="text-basic-400">主機</span>
+                <span>{health.smtp.host}</span>
+              </div>
+            )}
+            {health?.smtp?.port && (
+              <div className="flex justify-between">
+                <span className="text-basic-400">埠號</span>
+                <span>{health.smtp.port}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Queue */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h3 className="mb-3 font-semibold">佇列狀態</h3>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-basic-400">待發送</span>
+              <span className="font-medium">{health?.queue?.size ?? 0} 封</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Error */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h3 className="mb-3 font-semibold">最後錯誤</h3>
+          <p className="text-sm text-basic-400">{health?.lastError ?? "無"}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 3: Send Email
+// ============================================================================
+
+function EmailSendTab() {
+  const [emailType, setEmailType] = useState<"custom" | "bulk">("custom");
+  const [recipient, setRecipient] = useState("");
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [bulkRecipients, setBulkRecipients] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [result, setResult] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
+
+  const handleSendCustom = async () => {
+    if (!recipient || !subject || !body) return;
+
+    setIsSending(true);
+    setResult(null);
+    try {
+      await sendCustomEmail({
+        to: recipient,
+        subject,
+        htmlContent: body,
+        template: "custom",
+      });
+      setResult({ type: "success", message: "郵件已發送" });
+      setRecipient("");
+      setSubject("");
+      setBody("");
+    } catch (_err) {
+      setResult({ type: "error", message: "發送失敗，請重試" });
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleSendBulk = async () => {
+    const recipientEmails = bulkRecipients
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (recipientEmails.length === 0 || !subject || !body) return;
+    if (recipientEmails.length > 100) {
+      setResult({ type: "error", message: "最多 100 位收件人" });
+      return;
+    }
+
+    setIsSending(true);
+    setResult(null);
+    try {
+      await sendBulkEmail({
+        template: "custom",
+        subject,
+        recipients: recipientEmails.map((email) => ({ email, data: {} })),
+      });
+      setResult({
+        type: "success",
+        message: `已發送給 ${recipientEmails.length} 位收件人`,
+      });
+    } catch (_err) {
+      setResult({ type: "error", message: "批量發送失敗，請重試" });
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Email Type Toggle */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setEmailType("custom")}
+          className={cn(
+            "rounded-lg px-4 py-2 text-sm font-medium",
+            emailType === "custom"
+              ? "bg-primary-base text-white"
+              : "border border-border bg-white hover:bg-basic-50"
+          )}
+        >
+          單封郵件
+        </button>
+        <button
+          type="button"
+          onClick={() => setEmailType("bulk")}
+          className={cn(
+            "rounded-lg px-4 py-2 text-sm font-medium",
+            emailType === "bulk"
+              ? "bg-primary-base text-white"
+              : "border border-border bg-white hover:bg-basic-50"
+          )}
+        >
+          批量發送
+        </button>
+      </div>
+
+      {/* Form */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm space-y-4">
+        {emailType === "custom" ? (
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              收件人
+              <input
+                type="email"
+                value={recipient}
+                onChange={(e) => setRecipient(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+                placeholder="user@example.com"
+              />
+            </label>
+          </div>
+        ) : (
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              收件人列表（每行一個，最多 100 位）
+              <textarea
+                value={bulkRecipients}
+                onChange={(e) => setBulkRecipients(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm h-24 resize-y font-normal"
+                placeholder={"user1@example.com\nuser2@example.com"}
+              />
+            </label>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            主旨
+            <input
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+              placeholder="郵件主旨"
+            />
+          </label>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            內容（HTML）
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm h-40 resize-y font-mono font-normal"
+              placeholder="<p>郵件內容...</p>"
+            />
+          </label>
+        </div>
+
+        {result && (
+          <div
+            className={cn(
+              "rounded-lg p-3 text-sm",
+              result.type === "success" ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"
+            )}
+          >
+            {result.message}
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={emailType === "custom" ? handleSendCustom : handleSendBulk}
+          disabled={isSending}
+          className="flex items-center gap-2 rounded-lg bg-primary-base px-4 py-2 text-sm font-medium text-white hover:bg-primary-base/90 disabled:opacity-50"
+        >
+          <Send className="size-4" />
+          {isSending ? "發送中..." : "發送"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/email/page.tsx
+++ b/apps/product/src/app/[locale]/admin/email/page.tsx
@@ -319,54 +319,58 @@ function EmailSendTab() {
       <div className="rounded-xl border border-border bg-white p-5 shadow-sm space-y-4">
         {emailType === "custom" ? (
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="email-recipient" className="block text-sm font-medium mb-1">
               收件人
-              <input
-                type="email"
-                value={recipient}
-                onChange={(e) => setRecipient(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
-                placeholder="user@example.com"
-              />
             </label>
+            <input
+              id="email-recipient"
+              type="email"
+              value={recipient}
+              onChange={(e) => setRecipient(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+              placeholder="user@example.com"
+            />
           </div>
         ) : (
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="email-bulk-recipients" className="block text-sm font-medium mb-1">
               收件人列表（每行一個，最多 100 位）
-              <textarea
-                value={bulkRecipients}
-                onChange={(e) => setBulkRecipients(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm h-24 resize-y font-normal"
-                placeholder={"user1@example.com\nuser2@example.com"}
-              />
             </label>
+            <textarea
+              id="email-bulk-recipients"
+              value={bulkRecipients}
+              onChange={(e) => setBulkRecipients(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm h-24 resize-y font-normal"
+              placeholder={"user1@example.com\nuser2@example.com"}
+            />
           </div>
         )}
 
         <div>
-          <label className="block text-sm font-medium mb-1">
+          <label htmlFor="email-subject" className="block text-sm font-medium mb-1">
             主旨
-            <input
-              type="text"
-              value={subject}
-              onChange={(e) => setSubject(e.target.value)}
-              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
-              placeholder="郵件主旨"
-            />
           </label>
+          <input
+            id="email-subject"
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+            placeholder="郵件主旨"
+          />
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">
+          <label htmlFor="email-body" className="block text-sm font-medium mb-1">
             內容（HTML）
-            <textarea
-              value={body}
-              onChange={(e) => setBody(e.target.value)}
-              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm h-40 resize-y font-mono font-normal"
-              placeholder="<p>郵件內容...</p>"
-            />
           </label>
+          <textarea
+            id="email-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm h-40 resize-y font-mono font-normal"
+            placeholder="<p>郵件內容...</p>"
+          />
         </div>
 
         {result && (

--- a/apps/product/src/app/[locale]/admin/layout.tsx
+++ b/apps/product/src/app/[locale]/admin/layout.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useAuth } from "@daodao/auth";
+import { useRouter } from "@daodao/i18n/navigation";
+import { useEffect } from "react";
+import { AdminMobileHeader, AdminSidebar } from "../../../components/admin/admin-sidebar";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { isAdmin, isLoading, isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!isAuthenticated || !isAdmin) {
+      router.replace("/");
+    }
+  }, [isLoading, isAuthenticated, isAdmin, router]);
+
+  // 載入中顯示骨架
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="size-8 animate-spin rounded-full border-4 border-primary-base border-t-transparent" />
+      </div>
+    );
+  }
+
+  // 無權限時不渲染內容（useEffect 會處理導向）
+  if (!isAuthenticated || !isAdmin) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-screen bg-basic-50">
+      <AdminSidebar />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <AdminMobileHeader />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/page.tsx
+++ b/apps/product/src/app/[locale]/admin/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useAdminActiveUsers, useAdminOverview, useEmailHealth, useEmailStats } from "@daodao/api";
+import { Link } from "@daodao/i18n/navigation";
+import { cn } from "@daodao/ui/lib/utils";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle,
+  Mail,
+  Monitor,
+  Shield,
+  Target,
+  Users,
+  XCircle,
+} from "lucide-react";
+import { StatCard } from "../../../components/admin/stat-card";
+
+export default function AdminDashboardPage() {
+  const { data: overviewData, isLoading: overviewLoading } = useAdminOverview();
+  const { data: activeUsersData, isLoading: activeUsersLoading } = useAdminActiveUsers();
+  const { data: emailStatsData, isLoading: emailStatsLoading } = useEmailStats();
+  const { data: emailHealthData, isLoading: emailHealthLoading } = useEmailHealth();
+
+  const overview = overviewData?.data;
+  const activeUsers = activeUsersData?.data;
+  const emailStats = emailStatsData?.data;
+  const emailHealth = emailHealthData?.data;
+
+  const isLoading =
+    overviewLoading || activeUsersLoading || emailStatsLoading || emailHealthLoading;
+
+  if (isLoading) {
+    return <DashboardSkeleton />;
+  }
+
+  const healthStatus = emailHealth?.status ?? "unknown";
+  const HealthIcon =
+    healthStatus === "healthy"
+      ? CheckCircle
+      : healthStatus === "degraded"
+        ? AlertTriangle
+        : XCircle;
+  const healthColor =
+    healthStatus === "healthy"
+      ? "text-green-500"
+      : healthStatus === "degraded"
+        ? "text-yellow-500"
+        : "text-red-500";
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-text-dark">總覽儀表板</h1>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          title="總使用者數"
+          value={overview?.totalUsers ?? 0}
+          change={overview?.growthRate}
+          changeLabel="vs 上月"
+        />
+        <StatCard
+          title="本月新增"
+          value={overview?.newUsersThisMonth ?? 0}
+          change={overview?.growthRate}
+          changeLabel="vs 上月"
+        />
+        <StatCard
+          title="活躍使用者"
+          value={overview?.activeUsers ?? 0}
+          changeLabel={`活躍率 ${overview?.activeRate ? `${overview.activeRate}%` : "N/A"}`}
+        />
+        <StatCard
+          title="郵件成功率"
+          value={emailStats?.successRate !== undefined ? `${emailStats.successRate}%` : "N/A"}
+        />
+      </div>
+
+      {/* DAU / WAU / MAU */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold">DAU / WAU / MAU</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <DauCard
+            label="DAU (日活躍數)"
+            value={activeUsers?.dau}
+            change={activeUsers?.trend?.dauTrend}
+          />
+          <DauCard
+            label="WAU (週活躍數)"
+            value={activeUsers?.wau}
+            change={activeUsers?.trend?.wauTrend}
+          />
+          <DauCard
+            label="MAU (月活躍數)"
+            value={activeUsers?.mau}
+            change={activeUsers?.trend?.mauTrend}
+          />
+        </div>
+      </div>
+
+      {/* Bottom row */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* Email Health */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold">郵件服務狀態</h2>
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <HealthIcon className={cn("size-5", healthColor)} />
+              <span className="font-medium capitalize">{healthStatus}</span>
+            </div>
+            <div className="text-sm text-basic-400">
+              <p>SMTP: {emailHealth?.smtpConnection ? "已連線" : "未連線"}</p>
+              <p>佇列: {emailHealth?.queueSize ?? 0} 封待發送</p>
+              {emailHealth?.lastError && (
+                <p className="text-red-500">錯誤: {emailHealth.lastError}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Quick Links */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold">快速連結</h2>
+          <div className="space-y-2">
+            {[
+              { href: "/admin/users", label: "使用者統計", icon: Users },
+              { href: "/admin/practices", label: "主題實踐管理", icon: Target },
+              { href: "/admin/email", label: "郵件管理", icon: Mail },
+              { href: "/admin/roles", label: "角色權限管理", icon: Shield },
+              { href: "/admin/system", label: "系統監控", icon: Monitor },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="flex items-center justify-between rounded-lg px-3 py-2.5 text-sm hover:bg-basic-50 transition-colors"
+              >
+                <div className="flex items-center gap-2">
+                  <link.icon className="size-4 text-basic-400" />
+                  <span>{link.label}</span>
+                </div>
+                <ArrowRight className="size-4 text-basic-300" />
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DauCard({ label, value, change }: { label: string; value?: number; change?: number }) {
+  const isPositive = change !== undefined && change >= 0;
+  return (
+    <div className="rounded-lg bg-basic-50 p-4 text-center">
+      <p className="text-sm text-basic-400">{label}</p>
+      <p className="mt-1 text-2xl font-bold">
+        {value !== undefined ? value.toLocaleString() : "—"}
+      </p>
+      {change !== undefined && (
+        <p
+          className={cn("mt-1 text-sm font-medium", isPositive ? "text-green-600" : "text-red-600")}
+        >
+          {isPositive ? "↑" : "↓"} {Math.abs(change).toFixed(1)}%
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="h-8 w-48 animate-pulse rounded-lg bg-basic-100" />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders have no unique identifiers
+          <div key={`kpi-${i}`} className="h-28 animate-pulse rounded-xl bg-basic-100" />
+        ))}
+      </div>
+      <div className="h-40 animate-pulse rounded-xl bg-basic-100" />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="h-40 animate-pulse rounded-xl bg-basic-100" />
+        <div className="h-40 animate-pulse rounded-xl bg-basic-100" />
+      </div>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/practices/page.tsx
+++ b/apps/product/src/app/[locale]/admin/practices/page.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useAdminPractices, useAdminPracticesStats } from "@daodao/api";
+import { cn } from "@daodao/ui/lib/utils";
+import { useState } from "react";
+import { StatCard } from "../../../../components/admin/stat-card";
+
+type PracticeStatus = "all" | "draft" | "not_started" | "active" | "completed" | "archived";
+
+export default function PracticesPage() {
+  const [status, setStatus] = useState<PracticeStatus>("all");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState("createdAt");
+  const limit = 20;
+
+  const { data: statsData } = useAdminPracticesStats();
+
+  const stats = statsData?.data as
+    | {
+        total?: number;
+        active?: number;
+        completed?: number;
+        totalCheckIns?: number;
+      }
+    | undefined;
+
+  const { data: listData, isLoading: listLoading } = useAdminPractices({
+    page,
+    limit,
+    status,
+    query: search || undefined,
+    sort: sortBy as "createdAt" | "updatedAt" | "likeCount",
+  });
+
+  const practices = listData?.data ?? [];
+  const total = listData?.pagination?.totalItems ?? 0;
+  const totalPages = listData?.pagination?.totalPages ?? Math.ceil(total / limit);
+
+  const statusLabels: Record<string, string> = {
+    draft: "草稿",
+    not_started: "未開始",
+    active: "進行中",
+    completed: "已完成",
+    archived: "已封存",
+  };
+
+  const statusColors: Record<string, string> = {
+    draft: "bg-basic-100 text-basic-400",
+    not_started: "bg-yellow-100 text-yellow-700",
+    active: "bg-green-100 text-green-700",
+    completed: "bg-blue-100 text-blue-700",
+    archived: "bg-basic-100 text-basic-300",
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-text-dark">主題實踐管理</h1>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard title="總實踐數" value={stats?.total ?? 0} />
+        <StatCard title="活躍實踐" value={stats?.active ?? 0} />
+        <StatCard title="已完成" value={stats?.completed ?? 0} />
+        <StatCard title="總簽到數" value={stats?.totalCheckIns ?? 0} />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          placeholder="搜尋實踐..."
+          className="rounded-lg border border-border px-3 py-2 text-sm w-60"
+        />
+        <select
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value as PracticeStatus);
+            setPage(1);
+          }}
+          className="rounded-lg border border-border px-3 py-2 text-sm"
+        >
+          <option value="all">全部狀態</option>
+          <option value="draft">草稿</option>
+          <option value="not_started">未開始</option>
+          <option value="active">進行中</option>
+          <option value="completed">已完成</option>
+          <option value="archived">已封存</option>
+        </select>
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value)}
+          className="rounded-lg border border-border px-3 py-2 text-sm"
+        >
+          <option value="createdAt">建立時間</option>
+          <option value="updatedAt">更新時間</option>
+          <option value="likeCount">按讚數</option>
+        </select>
+      </div>
+
+      {/* Practices Table */}
+      <div className="rounded-xl border border-border bg-white shadow-sm overflow-x-auto">
+        {listLoading ? (
+          <div className="flex h-48 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : practices.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無資料</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-basic-400">
+                <th className="px-4 py-3">標題</th>
+                <th className="px-4 py-3">創建者</th>
+                <th className="px-4 py-3">狀態</th>
+                <th className="px-4 py-3">開始日期</th>
+                <th className="px-4 py-3">天數</th>
+                <th className="px-4 py-3">簽到</th>
+                <th className="px-4 py-3">按讚</th>
+              </tr>
+            </thead>
+            <tbody>
+              {practices.map(
+                (
+                  practice: {
+                    id?: string;
+                    title?: string;
+                    user?: { name?: string };
+                    status?: string;
+                    startDate?: string;
+                    durationDays?: number;
+                    checkInCount?: number;
+                    stats?: { likeCount?: number };
+                  },
+                  i: number
+                ) => (
+                  <tr
+                    key={practice.id ?? i}
+                    className="border-b border-border/50 hover:bg-basic-50"
+                  >
+                    <td className="px-4 py-3 font-medium max-w-xs truncate">
+                      {practice.title ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-basic-400">{practice.user?.name ?? "—"}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={cn(
+                          "rounded-full px-2 py-0.5 text-xs font-medium",
+                          statusColors[practice.status ?? ""] ?? "bg-basic-100 text-basic-400"
+                        )}
+                      >
+                        {statusLabels[practice.status ?? ""] ?? practice.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-basic-400 whitespace-nowrap">
+                      {practice.startDate ? new Date(practice.startDate).toLocaleDateString() : "—"}
+                    </td>
+                    <td className="px-4 py-3">{practice.durationDays ?? "—"}</td>
+                    <td className="px-4 py-3">{practice.checkInCount ?? 0}</td>
+                    <td className="px-4 py-3">{practice.stats?.likeCount ?? 0}</td>
+                  </tr>
+                )
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setPage(page - 1)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            上一頁
+          </button>
+          <span className="text-sm text-basic-400">
+            {page} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages}
+            onClick={() => setPage(page + 1)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            下一頁
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/roles/page.tsx
+++ b/apps/product/src/app/[locale]/admin/roles/page.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { useAdminMutations, useAdminPermissions, useAdminRole, useAdminRoles } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { cn } from "@daodao/ui/lib/utils";
+import { ChevronDown, ChevronRight, Plus, Trash2, X } from "lucide-react";
+import { useState } from "react";
+
+type TabId = "roles" | "permissions";
+
+const tabsList: { id: TabId; label: string }[] = [
+  { id: "roles", label: "角色管理" },
+  { id: "permissions", label: "權限管理" },
+];
+
+export default function RolesPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("roles");
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-text-dark">角色權限管理</h1>
+
+      <div className="flex gap-1 overflow-x-auto border-b border-border">
+        {tabsList.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "shrink-0 whitespace-nowrap px-4 py-2.5 text-sm font-medium transition-colors border-b-2 border-transparent",
+              activeTab === tab.id
+                ? "border-b-primary-base text-primary-base"
+                : "text-basic-400 hover:text-text-dark"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "roles" && <RolesTab />}
+      {activeTab === "permissions" && <PermissionsTab />}
+    </div>
+  );
+}
+
+// ============================================================================
+// Roles Tab
+// ============================================================================
+
+function RolesTab() {
+  const { data, isLoading, mutate } = useAdminRoles();
+  const mutations = useAdminMutations();
+  const { hasPermission } = useAuth();
+  const canManage = hasPermission("role:manage");
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [expandedRoleId, setExpandedRoleId] = useState<string | null>(null);
+
+  const roles = (data?.data ?? []) as Array<{
+    id?: number;
+    name?: string;
+    description?: string;
+    permissionCount?: number;
+    createdAt?: string;
+  }>;
+
+  const handleCreateRole = async (name: string, description: string) => {
+    await mutations.createRole({ name, description });
+    mutate();
+    setShowCreateDialog(false);
+  };
+
+  const handleDeleteRole = async (id: string) => {
+    if (!confirm("確定要刪除此角色？")) return;
+    await mutations.deleteRole(id);
+    mutate();
+  };
+
+  return (
+    <div className="space-y-4">
+      {canManage && (
+        <button
+          type="button"
+          onClick={() => setShowCreateDialog(true)}
+          className="flex items-center gap-2 rounded-lg bg-primary-base px-4 py-2 text-sm font-medium text-white hover:bg-primary-base/90"
+        >
+          <Plus className="size-4" />
+          新增角色
+        </button>
+      )}
+
+      {/* Create Dialog */}
+      {showCreateDialog && (
+        <CreateDialog
+          title="新增角色"
+          onClose={() => setShowCreateDialog(false)}
+          onSubmit={handleCreateRole}
+        />
+      )}
+
+      {/* Roles Table */}
+      <div className="rounded-xl border border-border bg-white shadow-sm">
+        {isLoading ? (
+          <div className="flex h-48 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : roles.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無角色</div>
+        ) : (
+          <div>
+            {roles.map((role) => (
+              <div key={role.id} className="border-b border-border/50 last:border-0">
+                <div className="flex items-center justify-between px-4 py-3 hover:bg-basic-50">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setExpandedRoleId(expandedRoleId === String(role.id) ? null : String(role.id))
+                    }
+                    className="flex flex-1 items-center gap-3 text-left"
+                  >
+                    {expandedRoleId === String(role.id) ? (
+                      <ChevronDown className="size-4 text-basic-400" />
+                    ) : (
+                      <ChevronRight className="size-4 text-basic-400" />
+                    )}
+                    <div>
+                      <p className="font-medium">{role.name}</p>
+                      <p className="text-xs text-basic-400">
+                        {role.description ?? "無描述"} · {role.permissionCount ?? 0} 項權限
+                      </p>
+                    </div>
+                  </button>
+                  {canManage && (
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteRole(String(role.id))}
+                      className="rounded p-1 text-basic-300 hover:bg-red-50 hover:text-red-500"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  )}
+                </div>
+                {expandedRoleId === String(role.id) && (
+                  <RolePermissionsDetail roleId={String(role.id)} canManage={canManage} />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RolePermissionsDetail({ roleId, canManage }: { roleId: string; canManage: boolean }) {
+  const { data, isLoading, mutate } = useAdminRole(roleId);
+  const { data: allPermsData } = useAdminPermissions();
+  const mutations = useAdminMutations();
+
+  const roleDetail = data?.data as
+    | {
+        permissions?: Array<{
+          id?: number;
+          name?: string;
+          description?: string;
+        }>;
+      }
+    | undefined;
+
+  const allPerms = (allPermsData?.data ?? []) as Array<{
+    id?: number;
+    name?: string;
+  }>;
+
+  const currentPermIds = new Set(roleDetail?.permissions?.map((p) => p.id) ?? []);
+
+  const handleAddPerm = async (permId: number) => {
+    await mutations.addPermissionToRole(roleId, permId);
+    mutate();
+  };
+
+  const handleRemovePerm = async (permId: string) => {
+    await mutations.removePermissionFromRole(roleId, permId);
+    mutate();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-20 items-center justify-center border-t border-border/50 bg-basic-50">
+        <div className="size-4 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border/50 bg-basic-50 px-4 py-3">
+      <p className="mb-2 text-sm font-medium">已指派權限:</p>
+      <div className="flex flex-wrap gap-2 mb-3">
+        {roleDetail?.permissions?.map((perm) => (
+          <span
+            key={perm.id}
+            className="flex items-center gap-1 rounded-full bg-primary-base/10 px-3 py-1 text-xs font-medium text-primary-base"
+          >
+            {perm.name}
+            {canManage && (
+              <button
+                type="button"
+                onClick={() => handleRemovePerm(String(perm.id))}
+                className="ml-1 rounded-full hover:bg-primary-base/20"
+              >
+                <X className="size-3" />
+              </button>
+            )}
+          </span>
+        ))}
+        {(!roleDetail?.permissions || roleDetail.permissions.length === 0) && (
+          <span className="text-xs text-basic-300">無權限</span>
+        )}
+      </div>
+      {canManage && (
+        <div>
+          <p className="mb-1 text-xs text-basic-400">新增權限:</p>
+          <div className="flex flex-wrap gap-1">
+            {allPerms
+              .filter((p) => !currentPermIds.has(p.id))
+              .map((perm) => (
+                <button
+                  key={perm.id}
+                  type="button"
+                  onClick={() => handleAddPerm(perm.id ?? 0)}
+                  className="rounded-full border border-border bg-white px-2 py-0.5 text-xs hover:bg-primary-base/10 hover:border-primary-base"
+                >
+                  + {perm.name}
+                </button>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Permissions Tab
+// ============================================================================
+
+function PermissionsTab() {
+  const { data, isLoading, mutate } = useAdminPermissions();
+  const mutations = useAdminMutations();
+  const { hasPermission } = useAuth();
+  const canManage = hasPermission("role:manage");
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  const permissions = (data?.data ?? []) as Array<{
+    id?: number;
+    name?: string;
+    description?: string;
+    createdAt?: string;
+  }>;
+
+  const handleCreate = async (name: string, description: string) => {
+    await mutations.createPermission({ name, description });
+    mutate();
+    setShowCreateDialog(false);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("確定要刪除此權限？")) return;
+    await mutations.deletePermission(id);
+    mutate();
+  };
+
+  return (
+    <div className="space-y-4">
+      {canManage && (
+        <button
+          type="button"
+          onClick={() => setShowCreateDialog(true)}
+          className="flex items-center gap-2 rounded-lg bg-primary-base px-4 py-2 text-sm font-medium text-white hover:bg-primary-base/90"
+        >
+          <Plus className="size-4" />
+          新增權限
+        </button>
+      )}
+
+      {showCreateDialog && (
+        <CreateDialog
+          title="新增權限"
+          namePlaceholder="resource:action (例如 user:read)"
+          onClose={() => setShowCreateDialog(false)}
+          onSubmit={handleCreate}
+        />
+      )}
+
+      <div className="rounded-xl border border-border bg-white shadow-sm overflow-x-auto">
+        {isLoading ? (
+          <div className="flex h-48 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : permissions.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無權限</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-basic-400">
+                <th className="px-4 py-3">名稱</th>
+                <th className="px-4 py-3">描述</th>
+                <th className="px-4 py-3">建立時間</th>
+                {canManage && <th className="px-4 py-3 w-16" />}
+              </tr>
+            </thead>
+            <tbody>
+              {permissions.map((perm) => (
+                <tr key={perm.id} className="border-b border-border/50 hover:bg-basic-50">
+                  <td className="px-4 py-3 font-mono text-sm">{perm.name}</td>
+                  <td className="px-4 py-3 text-basic-400">{perm.description ?? "—"}</td>
+                  <td className="px-4 py-3 text-basic-400 whitespace-nowrap">
+                    {perm.createdAt ? new Date(perm.createdAt).toLocaleDateString() : "—"}
+                  </td>
+                  {canManage && (
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(String(perm.id))}
+                        className="rounded p-1 text-basic-300 hover:bg-red-50 hover:text-red-500"
+                      >
+                        <Trash2 className="size-4" />
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Create Dialog
+// ============================================================================
+
+function CreateDialog({
+  title,
+  namePlaceholder = "名稱",
+  onClose,
+  onSubmit,
+}: {
+  title: string;
+  namePlaceholder?: string;
+  onClose: () => void;
+  onSubmit: (name: string, description: string) => Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(name.trim(), description.trim());
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop click to close dialog */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: overlay backdrop click to close dialog */}
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-lg">
+        <h3 className="mb-4 text-lg font-semibold">{title}</h3>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              名稱
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+                placeholder={namePlaceholder}
+              />
+            </label>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              描述
+              <input
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+                placeholder="描述（選填）"
+              />
+            </label>
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-border px-4 py-2 text-sm hover:bg-basic-50"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!name.trim() || isSubmitting}
+            className="rounded-lg bg-primary-base px-4 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {isSubmitting ? "建立中..." : "建立"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/roles/page.tsx
+++ b/apps/product/src/app/[locale]/admin/roles/page.tsx
@@ -4,7 +4,7 @@ import { useAdminMutations, useAdminPermissions, useAdminRole, useAdminRoles } f
 import { useAuth } from "@daodao/auth";
 import { cn } from "@daodao/ui/lib/utils";
 import { ChevronDown, ChevronRight, Plus, Trash2, X } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 type TabId = "roles" | "permissions";
 
@@ -56,6 +56,8 @@ function RolesTab() {
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [expandedRoleId, setExpandedRoleId] = useState<string | null>(null);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const roles = (data?.data ?? []) as Array<{
     id?: number;
@@ -66,19 +68,34 @@ function RolesTab() {
   }>;
 
   const handleCreateRole = async (name: string, description: string) => {
-    await mutations.createRole({ name, description });
-    mutate();
-    setShowCreateDialog(false);
+    setError(null);
+    try {
+      await mutations.createRole({ name, description });
+      mutate();
+      setShowCreateDialog(false);
+    } catch (_err) {
+      setError("建立角色失敗，請重試");
+    }
   };
 
   const handleDeleteRole = async (id: string) => {
-    if (!confirm("確定要刪除此角色？")) return;
-    await mutations.deleteRole(id);
-    mutate();
+    setError(null);
+    try {
+      await mutations.deleteRole(id);
+      mutate();
+    } catch (_err) {
+      setError("刪除角色失敗，請重試");
+    } finally {
+      setDeleteConfirmId(null);
+    }
   };
 
   return (
     <div className="space-y-4">
+      {error && (
+        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+      )}
+
       {canManage && (
         <button
           type="button"
@@ -96,6 +113,15 @@ function RolesTab() {
           title="新增角色"
           onClose={() => setShowCreateDialog(false)}
           onSubmit={handleCreateRole}
+        />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {deleteConfirmId && (
+        <ConfirmDialog
+          message="確定要刪除此角色？"
+          onConfirm={() => handleDeleteRole(deleteConfirmId)}
+          onCancel={() => setDeleteConfirmId(null)}
         />
       )}
 
@@ -134,7 +160,7 @@ function RolesTab() {
                   {canManage && (
                     <button
                       type="button"
-                      onClick={() => handleDeleteRole(String(role.id))}
+                      onClick={() => setDeleteConfirmId(String(role.id))}
                       className="rounded p-1 text-basic-300 hover:bg-red-50 hover:text-red-500"
                     >
                       <Trash2 className="size-4" />
@@ -252,6 +278,8 @@ function PermissionsTab() {
   const canManage = hasPermission("role:manage");
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const permissions = (data?.data ?? []) as Array<{
     id?: number;
@@ -261,19 +289,34 @@ function PermissionsTab() {
   }>;
 
   const handleCreate = async (name: string, description: string) => {
-    await mutations.createPermission({ name, description });
-    mutate();
-    setShowCreateDialog(false);
+    setError(null);
+    try {
+      await mutations.createPermission({ name, description });
+      mutate();
+      setShowCreateDialog(false);
+    } catch (_err) {
+      setError("建立權限失敗，請重試");
+    }
   };
 
   const handleDelete = async (id: string) => {
-    if (!confirm("確定要刪除此權限？")) return;
-    await mutations.deletePermission(id);
-    mutate();
+    setError(null);
+    try {
+      await mutations.deletePermission(id);
+      mutate();
+    } catch (_err) {
+      setError("刪除權限失敗，請重試");
+    } finally {
+      setDeleteConfirmId(null);
+    }
   };
 
   return (
     <div className="space-y-4">
+      {error && (
+        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+      )}
+
       {canManage && (
         <button
           type="button"
@@ -291,6 +334,15 @@ function PermissionsTab() {
           namePlaceholder="resource:action (例如 user:read)"
           onClose={() => setShowCreateDialog(false)}
           onSubmit={handleCreate}
+        />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {deleteConfirmId && (
+        <ConfirmDialog
+          message="確定要刪除此權限？"
+          onConfirm={() => handleDelete(deleteConfirmId)}
+          onCancel={() => setDeleteConfirmId(null)}
         />
       )}
 
@@ -323,7 +375,7 @@ function PermissionsTab() {
                     <td className="px-4 py-3">
                       <button
                         type="button"
-                        onClick={() => handleDelete(String(perm.id))}
+                        onClick={() => setDeleteConfirmId(String(perm.id))}
                         className="rounded p-1 text-basic-300 hover:bg-red-50 hover:text-red-500"
                       >
                         <Trash2 className="size-4" />
@@ -369,37 +421,49 @@ function CreateDialog({
     }
   };
 
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop click to close dialog */}
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: overlay backdrop click to close dialog */}
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+    <div className="fixed inset-0 z-50 flex items-center justify-center" role="dialog" aria-modal="true" aria-label={title}>
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
       <div className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-lg">
         <h3 className="mb-4 text-lg font-semibold">{title}</h3>
         <div className="space-y-3">
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="create-dialog-name" className="block text-sm font-medium mb-1">
               名稱
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
-                placeholder={namePlaceholder}
-              />
             </label>
+            <input
+              id="create-dialog-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+              placeholder={namePlaceholder}
+            />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="create-dialog-description" className="block text-sm font-medium mb-1">
               描述
-              <input
-                type="text"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
-                placeholder="描述（選填）"
-              />
             </label>
+            <input
+              id="create-dialog-description"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border px-3 py-2 text-sm font-normal"
+              placeholder="描述（選填）"
+            />
           </div>
         </div>
         <div className="mt-4 flex justify-end gap-2">
@@ -417,6 +481,53 @@ function CreateDialog({
             className="rounded-lg bg-primary-base px-4 py-2 text-sm text-white disabled:opacity-50"
           >
             {isSubmitting ? "建立中..." : "建立"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmDialog({
+  message,
+  onConfirm,
+  onCancel,
+}: {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    },
+    [onCancel]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" role="alertdialog" aria-modal="true" aria-label="確認操作">
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
+      <div className="relative w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
+        <p className="mb-4 text-sm">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-border px-4 py-2 text-sm hover:bg-basic-50"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-lg bg-red-500 px-4 py-2 text-sm text-white hover:bg-red-600"
+          >
+            確定刪除
           </button>
         </div>
       </div>

--- a/apps/product/src/app/[locale]/admin/system/page.tsx
+++ b/apps/product/src/app/[locale]/admin/system/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useDbInfo, useHealthCheck, useSystemMonitor } from "@daodao/api";
+import { cn } from "@daodao/ui/lib/utils";
+import { CheckCircle, Database, HardDrive, Server, XCircle } from "lucide-react";
+
+export default function SystemPage() {
+  const { data: monitorData, isLoading: monitorLoading } = useSystemMonitor();
+  const { data: dbData, isLoading: dbLoading } = useDbInfo();
+  const { data: healthData, isLoading: healthLoading } = useHealthCheck();
+
+  // /api/v1/monitor returns { system, postgres, disk }
+  const systemInfo = monitorData?.system;
+  const monitorPostgres = monitorData?.postgres;
+  const monitorDisk = monitorData?.disk;
+
+  // /api/v1/db-info returns { postgres, redis }
+  const dbRedis = dbData?.redis;
+
+  // /api/v1/health returns { status, uptime, timestamp }
+  const health = healthData;
+
+  const isLoading = monitorLoading || dbLoading || healthLoading;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded bg-basic-100" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders have no unique identifiers
+          <div key={`skel-${i}`} className="h-40 animate-pulse rounded-xl bg-basic-100" />
+        ))}
+      </div>
+    );
+  }
+
+  const formatUptime = (seconds?: number) => {
+    if (!seconds) return "—";
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return `${d}天 ${h}時 ${m}分`;
+  };
+
+  const formatBytes = (bytes?: number) => {
+    if (!bytes) return "—";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1073741824) return `${(bytes / 1048576).toFixed(1)} MB`;
+    return `${(bytes / 1073741824).toFixed(1)} GB`;
+  };
+
+  const totalMem = systemInfo?.totalMemory ?? 0;
+  const freeMem = systemInfo?.freeMemory ?? 0;
+  const usedMem = totalMem - freeMem;
+  const memoryPercent = totalMem > 0 ? Math.round((usedMem / totalMem) * 100) : 0;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-text-dark">系統監控</h1>
+
+      {/* Health Status */}
+      <div
+        className={cn(
+          "flex items-center gap-3 rounded-xl border p-4",
+          health?.status === "ok" ? "border-green-200 bg-green-50" : "border-red-200 bg-red-50"
+        )}
+      >
+        {health?.status === "ok" ? (
+          <CheckCircle className="size-6 text-green-500" />
+        ) : (
+          <XCircle className="size-6 text-red-500" />
+        )}
+        <div>
+          <p className="font-medium">API 健康狀態: {health?.status ?? "unknown"}</p>
+          {health?.timestamp && (
+            <p className="text-xs text-basic-400">{new Date(health.timestamp).toLocaleString()}</p>
+          )}
+        </div>
+      </div>
+
+      {/* System Info */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <InfoCard
+          icon={<Server className="size-5" />}
+          label="主機名"
+          value={systemInfo?.hostname ?? "—"}
+        />
+        <InfoCard
+          icon={<Server className="size-5" />}
+          label="平台/架構"
+          value={`${systemInfo?.platform ?? "—"} / ${systemInfo?.arch ?? "—"}`}
+        />
+        <InfoCard
+          icon={<Server className="size-5" />}
+          label="Uptime"
+          value={formatUptime(systemInfo?.uptime)}
+        />
+        <InfoCard
+          icon={<Server className="size-5" />}
+          label="CPU 負載"
+          value={
+            systemInfo?.loadAverage
+              ? systemInfo.loadAverage.map((l) => l.toFixed(2)).join(" / ")
+              : "—"
+          }
+        />
+      </div>
+
+      {/* Memory */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+        <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
+          <HardDrive className="size-5" />
+          記憶體使用量
+        </h2>
+        <div className="mb-2 flex justify-between text-sm">
+          <span>
+            {formatBytes(usedMem)} / {formatBytes(totalMem)}
+          </span>
+          <span className="font-medium">{memoryPercent}%</span>
+        </div>
+        <div className="h-4 w-full overflow-hidden rounded-full bg-basic-100">
+          <div
+            className={cn(
+              "h-full rounded-full transition-all",
+              memoryPercent > 90
+                ? "bg-red-500"
+                : memoryPercent > 70
+                  ? "bg-yellow-500"
+                  : "bg-primary-base"
+            )}
+            style={{ width: `${memoryPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Disk */}
+      {monitorDisk && monitorDisk.length > 0 && (
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
+            <HardDrive className="size-5" />
+            磁碟使用量
+          </h2>
+          <div className="space-y-4">
+            {monitorDisk.map((d) => {
+              const percent = d.use ?? 0;
+              return (
+                <div key={`disk-${d.mount ?? d.filesystem}`}>
+                  <div className="mb-1 flex justify-between text-sm">
+                    <span>
+                      {d.mount} ({d.filesystem})
+                    </span>
+                    <span>
+                      {formatBytes(d.used)} / {formatBytes(d.size)} ({percent}%)
+                    </span>
+                  </div>
+                  <div className="h-3 w-full overflow-hidden rounded-full bg-basic-100">
+                    <div
+                      className={cn(
+                        "h-full rounded-full",
+                        percent > 90
+                          ? "bg-red-500"
+                          : percent > 70
+                            ? "bg-yellow-500"
+                            : "bg-primary-base"
+                      )}
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* PostgreSQL */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+        <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
+          <Database className="size-5" />
+          PostgreSQL
+        </h2>
+        <div className="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <p className="text-sm text-basic-400">版本</p>
+            <p className="font-medium">{monitorPostgres?.version ?? "—"}</p>
+          </div>
+          <div>
+            <p className="text-sm text-basic-400">連線數</p>
+            <p className="font-medium">
+              {monitorPostgres?.current_connections ?? "—"} /{" "}
+              {monitorPostgres?.max_connections ?? "—"}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-basic-400">DB 大小</p>
+            <p className="font-medium">{monitorPostgres?.database_size ?? "—"}</p>
+          </div>
+        </div>
+        {monitorPostgres?.tables && monitorPostgres.tables.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-basic-400">
+                  <th className="pb-2 pr-4">表格</th>
+                  <th className="pb-2 pr-4">行數</th>
+                  <th className="pb-2">大小</th>
+                </tr>
+              </thead>
+              <tbody>
+                {monitorPostgres.tables.map((table) => (
+                  <tr key={table.table_name} className="border-b border-border/50">
+                    <td className="py-1.5 pr-4 font-mono text-xs">{table.table_name}</td>
+                    <td className="py-1.5 pr-4">{table.row_count?.toLocaleString()}</td>
+                    <td className="py-1.5">{table.size}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Redis */}
+      {dbRedis && !("error" in dbRedis) && (
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
+            <Database className="size-5" />
+            Redis
+          </h2>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
+            <div>
+              <p className="text-sm text-basic-400">版本</p>
+              <p className="font-medium">{dbRedis.version ?? "—"}</p>
+            </div>
+            <div>
+              <p className="text-sm text-basic-400">Uptime</p>
+              <p className="font-medium">{formatUptime(dbRedis.uptime_in_seconds)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-basic-400">連線數</p>
+              <p className="font-medium">{dbRedis.connected_clients ?? "—"}</p>
+            </div>
+            <div>
+              <p className="text-sm text-basic-400">記憶體</p>
+              <p className="font-medium">{dbRedis.used_memory_human ?? "—"}</p>
+            </div>
+            <div>
+              <p className="text-sm text-basic-400">命令處理</p>
+              <p className="font-medium">
+                {dbRedis.total_commands_processed?.toLocaleString() ?? "—"}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InfoCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-white p-4 shadow-sm">
+      <div className="flex items-center gap-2 text-basic-400">
+        {icon}
+        <span className="text-sm">{label}</span>
+      </div>
+      <p className="mt-1 font-medium text-text-dark">{value}</p>
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/users/[userId]/page.tsx
+++ b/apps/product/src/app/[locale]/admin/users/[userId]/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import {
+  useAdminMutations,
+  useAdminRoles,
+  useAdminUserActivityStats,
+  useAdminUserDetail,
+  useAdminUserLoginHistory,
+  useUserRole,
+} from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { useRouter } from "@daodao/i18n/navigation";
+import { cn } from "@daodao/ui/lib/utils";
+import { ArrowLeft } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { StatCard } from "../../../../../components/admin/stat-card";
+
+export default function UserDetailPage() {
+  const params = useParams();
+  const userId = params.userId as string;
+  const router = useRouter();
+  const { hasPermission } = useAuth();
+
+  const { data: userData, isLoading: userLoading } = useAdminUserDetail(userId);
+  const { data: roleData, mutate: mutateRole } = useUserRole(userId);
+  const { data: activityData } = useAdminUserActivityStats(userId);
+  const { data: loginHistoryData } = useAdminUserLoginHistory(userId, {
+    limit: 10,
+  });
+  const { data: rolesListData } = useAdminRoles();
+  const mutations = useAdminMutations();
+
+  const [selectedRoleId, setSelectedRoleId] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const user = userData?.data as
+    | {
+        id?: string;
+        name?: string;
+        email?: string;
+        photoUrl?: string;
+        createdAt?: string;
+        lastLoginAt?: string;
+        loginCount?: number;
+        profileViews?: number;
+        isActive?: boolean;
+      }
+    | undefined;
+
+  const currentRole = roleData?.data as { role?: { id?: number; name?: string } } | undefined;
+
+  const activity = activityData?.data as
+    | {
+        totalPractices?: number;
+        activePractices?: number;
+        completedPractices?: number;
+        totalCheckIns?: number;
+        avgStreak?: number;
+        maxStreak?: number;
+      }
+    | undefined;
+
+  const loginHistory = loginHistoryData?.data as
+    | {
+        records?: Array<{
+          loginAt?: string;
+          ipAddress?: string;
+          userAgent?: string;
+        }>;
+      }
+    | undefined;
+
+  const rolesList = rolesListData?.data as Array<{ id?: number; name?: string }> | undefined;
+
+  const canManageRoles = hasPermission("role:manage");
+
+  const handleSaveRole = async () => {
+    if (!selectedRoleId) return;
+    setIsSaving(true);
+    try {
+      await mutations.updateUserRole(userId, Number(selectedRoleId));
+      mutateRole();
+    } catch (err) {
+      console.error("Failed to update role:", err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (userLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded bg-basic-100" />
+        <div className="h-48 animate-pulse rounded-xl bg-basic-100" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back Button */}
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="flex items-center gap-1 text-sm text-basic-400 hover:text-text-dark"
+      >
+        <ArrowLeft className="size-4" />
+        返回使用者列表
+      </button>
+
+      {/* User Info Card */}
+      <div className="rounded-xl border border-border bg-white p-6 shadow-sm">
+        <div className="flex items-start gap-4">
+          {user?.photoUrl ? (
+            <img src={user.photoUrl} alt="" className="size-16 rounded-full object-cover" />
+          ) : (
+            <div className="flex size-16 items-center justify-center rounded-full bg-primary-base/10 text-xl font-bold text-primary-base">
+              {user?.name?.[0] ?? "?"}
+            </div>
+          )}
+          <div className="flex-1">
+            <h2 className="text-xl font-bold">{user?.name ?? "—"}</h2>
+            <p className="text-sm text-basic-400">{user?.email ?? "—"}</p>
+            <div className="mt-2 flex flex-wrap gap-4 text-sm text-basic-400">
+              <span>
+                註冊時間: {user?.createdAt ? new Date(user.createdAt).toLocaleDateString() : "—"}
+              </span>
+              <span>
+                最後登入:{" "}
+                {user?.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : "—"}
+              </span>
+              <span>登入次數: {user?.loginCount?.toLocaleString() ?? "—"}</span>
+            </div>
+          </div>
+          <div
+            className={cn(
+              "rounded-full px-3 py-1 text-xs font-medium",
+              user?.isActive ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
+            )}
+          >
+            {user?.isActive ? "啟用" : "停用"}
+          </div>
+        </div>
+
+        {/* Role Management */}
+        {canManageRoles && (
+          <div className="mt-4 flex items-center gap-3 border-t border-border pt-4">
+            <span className="text-sm font-medium">角色:</span>
+            <select
+              value={selectedRoleId || String(currentRole?.role?.id ?? "")}
+              onChange={(e) => setSelectedRoleId(e.target.value)}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm"
+            >
+              <option value="">{currentRole?.role?.name ?? "未指定"}</option>
+              {rolesList?.map((role) => (
+                <option key={role.id} value={String(role.id)}>
+                  {role.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handleSaveRole}
+              disabled={!selectedRoleId || isSaving}
+              className="rounded-lg bg-primary-base px-4 py-1.5 text-sm text-white disabled:opacity-50"
+            >
+              {isSaving ? "儲存中..." : "儲存變更"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Activity Stats */}
+      {activity && (
+        <div>
+          <h3 className="mb-3 text-lg font-semibold">實踐統計</h3>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+            <StatCard title="總實踐數" value={activity.totalPractices ?? 0} />
+            <StatCard title="活躍數" value={activity.activePractices ?? 0} />
+            <StatCard title="完成數" value={activity.completedPractices ?? 0} />
+            <StatCard title="總簽到" value={activity.totalCheckIns ?? 0} />
+            <StatCard title="平均連續" value={`${activity.avgStreak ?? 0} 天`} />
+            <StatCard title="最大連續" value={`${activity.maxStreak ?? 0} 天`} />
+          </div>
+        </div>
+      )}
+
+      {/* Login History */}
+      {loginHistory?.records && loginHistory.records.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-lg font-semibold">登入歷史</h3>
+          <div className="rounded-xl border border-border bg-white shadow-sm overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-basic-400">
+                  <th className="px-4 py-3">時間</th>
+                  <th className="px-4 py-3">IP</th>
+                  <th className="px-4 py-3">User Agent</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loginHistory.records.map((record) => (
+                  <tr
+                    key={`login-${record.loginAt ?? record.ipAddress}`}
+                    className="border-b border-border/50"
+                  >
+                    <td className="px-4 py-2 whitespace-nowrap">
+                      {record.loginAt ? new Date(record.loginAt).toLocaleString() : "—"}
+                    </td>
+                    <td className="px-4 py-2">{record.ipAddress ?? "—"}</td>
+                    <td className="px-4 py-2 max-w-xs truncate text-basic-400">
+                      {record.userAgent ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/users/[userId]/page.tsx
+++ b/apps/product/src/app/[locale]/admin/users/[userId]/page.tsx
@@ -33,6 +33,7 @@ export default function UserDetailPage() {
 
   const [selectedRoleId, setSelectedRoleId] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const user = userData?.data as
     | {
@@ -78,11 +79,13 @@ export default function UserDetailPage() {
   const handleSaveRole = async () => {
     if (!selectedRoleId) return;
     setIsSaving(true);
+    setSaveError(null);
     try {
       await mutations.updateUserRole(userId, Number(selectedRoleId));
       mutateRole();
     } catch (err) {
       console.error("Failed to update role:", err);
+      setSaveError("角色更新失敗，請重試");
     } finally {
       setIsSaving(false);
     }
@@ -113,7 +116,7 @@ export default function UserDetailPage() {
       <div className="rounded-xl border border-border bg-white p-6 shadow-sm">
         <div className="flex items-start gap-4">
           {user?.photoUrl ? (
-            <img src={user.photoUrl} alt="" className="size-16 rounded-full object-cover" />
+            <img src={user.photoUrl} alt={user.name ?? "使用者頭像"} className="size-16 rounded-full object-cover" />
           ) : (
             <div className="flex size-16 items-center justify-center rounded-full bg-primary-base/10 text-xl font-bold text-primary-base">
               {user?.name?.[0] ?? "?"}
@@ -167,6 +170,9 @@ export default function UserDetailPage() {
             >
               {isSaving ? "儲存中..." : "儲存變更"}
             </button>
+            {saveError && (
+              <span className="text-sm text-red-600">{saveError}</span>
+            )}
           </div>
         )}
       </div>
@@ -200,9 +206,9 @@ export default function UserDetailPage() {
                 </tr>
               </thead>
               <tbody>
-                {loginHistory.records.map((record) => (
+                {loginHistory.records.map((record, index) => (
                   <tr
-                    key={`login-${record.loginAt ?? record.ipAddress}`}
+                    key={`login-${index}-${record.loginAt ?? record.ipAddress}`}
                     className="border-b border-border/50"
                   >
                     <td className="px-4 py-2 whitespace-nowrap">

--- a/apps/product/src/app/[locale]/admin/users/page.tsx
+++ b/apps/product/src/app/[locale]/admin/users/page.tsx
@@ -1,0 +1,864 @@
+"use client";
+
+import {
+  getAdminExportUrl,
+  useAdminActivity,
+  useAdminDeviceAnalytics,
+  useAdminPopularProfiles,
+  useAdminRegistrations,
+  useAdminRetention,
+  useAdminSegmentation,
+} from "@daodao/api";
+import { Link } from "@daodao/i18n/navigation";
+import { cn } from "@daodao/ui/lib/utils";
+import { Download } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type TabId = "registrations" | "activity" | "retention" | "devices" | "segmentation" | "popular";
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: "registrations", label: "註冊統計" },
+  { id: "activity", label: "活躍度" },
+  { id: "retention", label: "留存率" },
+  { id: "devices", label: "裝置" },
+  { id: "segmentation", label: "分群" },
+  { id: "popular", label: "熱門排行" },
+];
+
+export default function UsersStatsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("registrations");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-text-dark">使用者統計</h1>
+        <ExportButton />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 overflow-x-auto border-b border-border">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "shrink-0 whitespace-nowrap px-4 py-2.5 text-sm font-medium transition-colors border-b-2 border-transparent",
+              activeTab === tab.id
+                ? "border-b-primary-base text-primary-base"
+                : "text-basic-400 hover:text-text-dark"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === "registrations" && <RegistrationsTab />}
+      {activeTab === "activity" && <ActivityTab />}
+      {activeTab === "retention" && <RetentionTab />}
+      {activeTab === "devices" && <DevicesTab />}
+      {activeTab === "segmentation" && <SegmentationTab />}
+      {activeTab === "popular" && <PopularTab />}
+    </div>
+  );
+}
+
+// ============================================================================
+// Export Button
+// ============================================================================
+
+function ExportButton() {
+  const [format, setFormat] = useState<"csv" | "excel">("csv");
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleExport = (type: "registrations" | "activity" | "full") => {
+    const url = getAdminExportUrl({ format, type });
+    window.open(url, "_blank");
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 rounded-lg border border-border bg-white px-3 py-2 text-sm hover:bg-basic-50 transition-colors"
+      >
+        <Download className="size-4" />
+        匯出
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 top-full z-10 mt-1 w-48 rounded-lg border border-border bg-white py-1 shadow-lg">
+          <div className="border-b border-border px-3 py-2">
+            <select
+              value={format}
+              onChange={(e) => setFormat(e.target.value as "csv" | "excel")}
+              className="w-full text-sm bg-transparent"
+            >
+              <option value="csv">CSV</option>
+              <option value="excel">Excel</option>
+            </select>
+          </div>
+          {(["registrations", "activity", "full"] as const).map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => handleExport(type)}
+              className="w-full px-3 py-2 text-left text-sm hover:bg-basic-50"
+            >
+              {type === "registrations"
+                ? "註冊統計"
+                : type === "activity"
+                  ? "活躍度統計"
+                  : "完整資料"}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 1: Registrations
+// ============================================================================
+
+function RegistrationsTab() {
+  const [groupBy, setGroupBy] = useState<
+    "day" | "week" | "month" | "year" | "location" | "role" | "education_stage"
+  >("month");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const { data, isLoading } = useAdminRegistrations({
+    groupBy,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+  });
+
+  const chartData = useMemo(() => {
+    if (!data?.data) return [];
+    const items = data.data as Array<{ label?: string; group?: string; count?: number }>;
+    return items.map((item) => ({
+      name: item.label || item.group || "N/A",
+      count: item.count ?? 0,
+    }));
+  }, [data]);
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="rounded-lg border border-border px-3 py-2 text-sm"
+          placeholder="開始日期"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="rounded-lg border border-border px-3 py-2 text-sm"
+          placeholder="結束日期"
+        />
+        <select
+          value={groupBy}
+          onChange={(e) => setGroupBy(e.target.value as typeof groupBy)}
+          className="rounded-lg border border-border px-3 py-2 text-sm"
+        >
+          <option value="day">按日</option>
+          <option value="week">按週</option>
+          <option value="month">按月</option>
+          <option value="year">按年</option>
+          <option value="location">按地區</option>
+          <option value="role">按角色</option>
+          <option value="education_stage">按教育階段</option>
+        </select>
+      </div>
+
+      {/* Chart */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold">註冊趨勢圖</h3>
+        {isLoading ? (
+          <div className="flex h-64 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : chartData.length === 0 ? (
+          <div className="flex h-64 items-center justify-center text-basic-300">暫無資料</div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" fontSize={12} />
+              <YAxis fontSize={12} />
+              <Tooltip />
+              <Bar dataKey="count" fill="#16B9B3" radius={[4, 4, 0, 0]} name="註冊數" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 2: Activity
+// ============================================================================
+
+const ACTIVITY_COLORS = ["#16B9B3", "#E5E7EB"];
+
+function ActivityTab() {
+  const [groupBy, setGroupBy] = useState<"role" | "location" | "education_stage" | undefined>(
+    undefined
+  );
+  const { data, isLoading } = useAdminActivity({ groupBy });
+
+  const activityData = data?.data as
+    | {
+        activeUsers?: number;
+        inactiveUsers?: number;
+        activeRate?: number;
+        groups?: Array<{
+          group?: string;
+          activeUsers?: number;
+          inactiveUsers?: number;
+        }>;
+      }
+    | undefined;
+
+  const pieData = useMemo(() => {
+    if (!activityData) return [];
+    return [
+      { name: "活躍", value: activityData.activeUsers ?? 0 },
+      { name: "不活躍", value: activityData.inactiveUsers ?? 0 },
+    ];
+  }, [activityData]);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* Pie Chart */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <h3 className="mb-4 text-lg font-semibold">活躍度比例</h3>
+          {isLoading ? (
+            <div className="flex h-64 items-center justify-center">
+              <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+            </div>
+          ) : (
+            <>
+              <ResponsiveContainer width="100%" height={250}>
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={60}
+                    outerRadius={100}
+                    dataKey="value"
+                    label={({ name, percent }: { name: string; percent: number }) =>
+                      `${name} ${(percent * 100).toFixed(1)}%`
+                    }
+                  >
+                    {pieData.map((entry, index) => (
+                      <Cell
+                        key={entry.name}
+                        fill={ACTIVITY_COLORS[index % ACTIVITY_COLORS.length]}
+                      />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="mt-2 text-center text-sm text-basic-400">
+                活躍: {activityData?.activeUsers?.toLocaleString()} / 不活躍:{" "}
+                {activityData?.inactiveUsers?.toLocaleString()}
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Group Analysis */}
+        <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className="text-lg font-semibold">分組分析</h3>
+            <select
+              value={groupBy ?? ""}
+              onChange={(e) => setGroupBy((e.target.value || undefined) as typeof groupBy)}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm"
+            >
+              <option value="">不分組</option>
+              <option value="role">按角色</option>
+              <option value="location">按地區</option>
+              <option value="education_stage">按教育階段</option>
+            </select>
+          </div>
+          {isLoading ? (
+            <div className="flex h-48 items-center justify-center">
+              <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+            </div>
+          ) : activityData?.groups && activityData.groups.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border text-left text-basic-400">
+                    <th className="pb-2 pr-4">分組</th>
+                    <th className="pb-2 pr-4">活躍</th>
+                    <th className="pb-2">不活躍</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {activityData.groups.map((group) => (
+                    <tr key={group.group} className="border-b border-border/50">
+                      <td className="py-2 pr-4">{group.group}</td>
+                      <td className="py-2 pr-4 font-medium text-green-600">
+                        {group.activeUsers?.toLocaleString()}
+                      </td>
+                      <td className="py-2 text-basic-400">
+                        {group.inactiveUsers?.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="flex h-48 items-center justify-center text-basic-300">
+              請選擇分組方式
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 3: Retention
+// ============================================================================
+
+function RetentionTab() {
+  const [cohorts, setCohorts] = useState(12);
+  const [trackDays, setTrackDays] = useState(30);
+  const [granularity, setGranularity] = useState<"day" | "week">("week");
+
+  const { data, isLoading } = useAdminRetention({
+    cohorts,
+    trackDays,
+    granularity,
+  });
+
+  const retentionData = data?.data as
+    | {
+        averageRetention?: Record<string, number>;
+        cohorts?: Array<{
+          cohortDate?: string;
+          size?: number;
+          retention?: Record<string, number>;
+        }>;
+      }
+    | undefined;
+
+  const avgRetention = retentionData?.averageRetention ?? {};
+
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          群組數
+          <select
+            value={cohorts}
+            onChange={(e) => setCohorts(Number(e.target.value))}
+            className="rounded-lg border border-border px-2 py-1.5 text-sm"
+          >
+            {[6, 8, 10, 12, 16, 20].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          追蹤天數
+          <select
+            value={trackDays}
+            onChange={(e) => setTrackDays(Number(e.target.value))}
+            className="rounded-lg border border-border px-2 py-1.5 text-sm"
+          >
+            {[7, 14, 30, 60].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          粒度
+          <select
+            value={granularity}
+            onChange={(e) => setGranularity(e.target.value as "day" | "week")}
+            className="rounded-lg border border-border px-2 py-1.5 text-sm"
+          >
+            <option value="day">日</option>
+            <option value="week">週</option>
+          </select>
+        </label>
+      </div>
+
+      {/* Average Retention Cards */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {["day1", "day7", "day14", "day30"].map((key) => (
+          <div
+            key={key}
+            className="rounded-xl border border-border bg-white p-4 text-center shadow-sm"
+          >
+            <p className="text-sm text-basic-400">{key.replace("day", "Day ")}</p>
+            <p className="mt-1 text-2xl font-bold">
+              {avgRetention[key] !== undefined ? `${avgRetention[key]}%` : "—"}
+            </p>
+            <p className="text-xs text-basic-300">平均留存</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Cohort Table */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm overflow-x-auto">
+        <h3 className="mb-4 text-lg font-semibold">Cohort 留存率熱力圖</h3>
+        {isLoading ? (
+          <div className="flex h-48 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : retentionData?.cohorts && retentionData.cohorts.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-basic-400">
+                <th className="pb-2 pr-4">群組</th>
+                <th className="pb-2 pr-4">人數</th>
+                <th className="pb-2 pr-4">D1</th>
+                <th className="pb-2 pr-4">D7</th>
+                <th className="pb-2 pr-4">D14</th>
+                <th className="pb-2">D30</th>
+              </tr>
+            </thead>
+            <tbody>
+              {retentionData.cohorts.map((cohort) => (
+                <tr key={cohort.cohortDate} className="border-b border-border/50">
+                  <td className="py-2 pr-4 whitespace-nowrap">{cohort.cohortDate}</td>
+                  <td className="py-2 pr-4">{cohort.size}</td>
+                  {["day1", "day7", "day14", "day30"].map((key) => {
+                    const val = cohort.retention?.[key];
+                    return (
+                      <td key={key} className="py-2 pr-4">
+                        {val !== undefined ? (
+                          <span
+                            className="inline-block rounded px-2 py-0.5 text-xs font-medium"
+                            style={{
+                              backgroundColor: `rgba(22,185,179,${(val / 100) * 0.7 + 0.1})`,
+                              color: val > 50 ? "white" : "#333",
+                            }}
+                          >
+                            {val}%
+                          </span>
+                        ) : (
+                          <span className="text-basic-200">—</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無資料</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 4: Devices
+// ============================================================================
+
+const DEVICE_COLORS = ["#16B9B3", "#FF9F1C", "#6366F1", "#EC4899", "#94A3B8"];
+
+function DevicesTab() {
+  const { data, isLoading } = useAdminDeviceAnalytics({ days: 30 });
+
+  const deviceData = data?.data as
+    | {
+        totalLogins?: number;
+        devices?: Array<{ deviceType?: string; count?: number; percentage?: number }>;
+        browsers?: Array<{ browser?: string; count?: number; percentage?: number }>;
+        operatingSystems?: Array<{ os?: string; count?: number; percentage?: number }>;
+      }
+    | undefined;
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-basic-400">
+        總登入次數: {deviceData?.totalLogins?.toLocaleString() ?? "—"}
+      </p>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <DeviceChart
+          title="裝置類型"
+          items={deviceData?.devices?.map((d) => ({
+            name: d.deviceType,
+            count: d.count,
+            percentage: d.percentage,
+          }))}
+        />
+        <DeviceChart
+          title="瀏覽器"
+          items={deviceData?.browsers?.map((b) => ({
+            name: b.browser,
+            count: b.count,
+            percentage: b.percentage,
+          }))}
+        />
+        <DeviceChart
+          title="作業系統"
+          items={deviceData?.operatingSystems?.map((o) => ({
+            name: o.os,
+            count: o.count,
+            percentage: o.percentage,
+          }))}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DeviceChart({
+  title,
+  items,
+}: {
+  title: string;
+  items?: Array<{ name?: string; count?: number; percentage?: number }>;
+}) {
+  const chartData = useMemo(
+    () =>
+      (items ?? []).map((item) => ({
+        name: item.name ?? "Unknown",
+        value: item.count ?? 0,
+        percentage: item.percentage ?? 0,
+      })),
+    [items]
+  );
+
+  return (
+    <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+      <h3 className="mb-4 text-lg font-semibold">{title}</h3>
+      {chartData.length === 0 ? (
+        <div className="flex h-48 items-center justify-center text-basic-300">暫無資料</div>
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                outerRadius={65}
+                dataKey="value"
+                label={({ name, percent }: { name: string; percent: number }) =>
+                  `${name} ${(percent * 100).toFixed(0)}%`
+                }
+                labelLine
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={entry.name} fill={DEVICE_COLORS[index % DEVICE_COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className="mt-2 space-y-1">
+            {chartData.map((item, index) => (
+              <div key={item.name} className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="size-3 rounded-full"
+                    style={{
+                      backgroundColor: DEVICE_COLORS[index % DEVICE_COLORS.length],
+                    }}
+                  />
+                  <span>{item.name}</span>
+                </div>
+                <span className="text-basic-400">{item.percentage}%</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 5: Segmentation
+// ============================================================================
+
+const SEGMENT_COLORS: Record<string, string> = {
+  highly_active: "#059669",
+  active: "#16B9B3",
+  moderate: "#F59E0B",
+  inactive: "#F97316",
+  dormant: "#EF4444",
+};
+
+function SegmentationTab() {
+  const { data, isLoading } = useAdminSegmentation();
+
+  const segmentData = data?.data as
+    | {
+        totalUsers?: number;
+        segments?: Array<{
+          label?: string;
+          displayName?: string;
+          description?: string;
+          criteria?: string;
+          userCount?: number;
+          percentage?: number;
+        }>;
+      }
+    | undefined;
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+      </div>
+    );
+  }
+
+  const segments = segmentData?.segments ?? [];
+
+  return (
+    <div className="space-y-4">
+      {/* Visual Chart */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-semibold">用戶活躍度分群</h3>
+          <span className="text-sm text-basic-400">
+            總計: {segmentData?.totalUsers?.toLocaleString()}
+          </span>
+        </div>
+        <div className="space-y-3">
+          {segments.map((seg) => (
+            <div key={seg.label} className="flex items-center gap-3">
+              <div className="w-24 text-sm font-medium">{seg.displayName}</div>
+              <div className="flex-1">
+                <div className="h-8 w-full overflow-hidden rounded-lg bg-basic-50">
+                  <div
+                    className="h-full rounded-lg transition-all"
+                    style={{
+                      width: `${seg.percentage ?? 0}%`,
+                      backgroundColor: SEGMENT_COLORS[seg.label ?? ""] ?? "#94A3B8",
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="w-24 text-right text-sm text-basic-400">
+                {seg.percentage}% ({seg.userCount?.toLocaleString()})
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Description Table */}
+      <div className="rounded-xl border border-border bg-white p-5 shadow-sm overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-basic-400">
+              <th className="pb-2 pr-4">分群</th>
+              <th className="pb-2 pr-4">說明</th>
+              <th className="pb-2">條件</th>
+            </tr>
+          </thead>
+          <tbody>
+            {segments.map((seg) => (
+              <tr key={seg.label} className="border-b border-border/50">
+                <td className="py-2 pr-4 font-medium">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className="size-3 rounded-full"
+                      style={{
+                        backgroundColor: SEGMENT_COLORS[seg.label ?? ""] ?? "#94A3B8",
+                      }}
+                    />
+                    {seg.displayName}
+                  </div>
+                </td>
+                <td className="py-2 pr-4 text-basic-400">{seg.description}</td>
+                <td className="py-2 text-basic-400">{seg.criteria}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Tab 6: Popular Profiles
+// ============================================================================
+
+function PopularTab() {
+  const [minViews, setMinViews] = useState<number | undefined>(undefined);
+  const [page, setPage] = useState(0);
+  const limit = 10;
+
+  const { data, isLoading } = useAdminPopularProfiles({
+    minViews,
+    limit,
+    offset: page * limit,
+  });
+
+  const profilesData = data?.data as
+    | {
+        profiles?: Array<{
+          userId?: number;
+          externalId?: string;
+          nickname?: string | null;
+          photoUrl?: string | null;
+          profileViews?: number;
+          lastActiveAt?: string | null;
+        }>;
+        totalCount?: number;
+      }
+    | undefined;
+
+  const profiles = profilesData?.profiles ?? [];
+  const total = profilesData?.totalCount ?? 0;
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <div className="space-y-4">
+      {/* Filter */}
+      <div className="flex items-center gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          最低瀏覽次數:
+          <input
+            type="number"
+            value={minViews ?? ""}
+            onChange={(e) => setMinViews(e.target.value ? Number(e.target.value) : undefined)}
+            className="w-24 rounded-lg border border-border px-3 py-1.5 text-sm"
+            placeholder="不限"
+          />
+        </label>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border border-border bg-white shadow-sm overflow-x-auto">
+        {isLoading ? (
+          <div className="flex h-48 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : profiles.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無資料</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-basic-400">
+                <th className="px-4 py-3">#</th>
+                <th className="px-4 py-3">頭像</th>
+                <th className="px-4 py-3">暱稱</th>
+                <th className="px-4 py-3">瀏覽次數</th>
+                <th className="px-4 py-3">最後活躍</th>
+              </tr>
+            </thead>
+            <tbody>
+              {profiles.map((profile, i) => (
+                <tr key={profile.userId} className="border-b border-border/50 hover:bg-basic-50">
+                  <td className="px-4 py-3 text-basic-400">{page * limit + i + 1}</td>
+                  <td className="px-4 py-3">
+                    {profile.photoUrl ? (
+                      <img
+                        src={profile.photoUrl}
+                        alt=""
+                        className="size-8 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex size-8 items-center justify-center rounded-full bg-basic-100 text-xs text-basic-400">
+                        {profile.nickname?.[0] ?? "?"}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/admin/users/${profile.userId}`}
+                      className="text-primary-base hover:underline"
+                    >
+                      {profile.nickname ?? "—"}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 font-medium">
+                    {profile.profileViews?.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 text-basic-400">
+                    {profile.lastActiveAt
+                      ? new Date(profile.lastActiveAt).toLocaleDateString()
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button
+            type="button"
+            disabled={page === 0}
+            onClick={() => setPage(page - 1)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            上一頁
+          </button>
+          <span className="text-sm text-basic-400">
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages - 1}
+            onClick={() => setPage(page + 1)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            下一頁
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/product/src/app/[locale]/admin/users/page.tsx
+++ b/apps/product/src/app/[locale]/admin/users/page.tsx
@@ -85,10 +85,10 @@ function ExportButton() {
   const [format, setFormat] = useState<"csv" | "excel">("csv");
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleExport = (type: "registrations" | "activity" | "full") => {
-    const url = getAdminExportUrl({ format, type });
-    window.open(url, "_blank");
-    setIsOpen(false);
+  const getExportLabel = (type: "registrations" | "activity" | "full") => {
+    if (type === "registrations") return "註冊統計";
+    if (type === "activity") return "活躍度統計";
+    return "完整資料";
   };
 
   return (
@@ -114,18 +114,16 @@ function ExportButton() {
             </select>
           </div>
           {(["registrations", "activity", "full"] as const).map((type) => (
-            <button
+            <a
               key={type}
-              type="button"
-              onClick={() => handleExport(type)}
-              className="w-full px-3 py-2 text-left text-sm hover:bg-basic-50"
+              href={getAdminExportUrl({ format, type })}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setIsOpen(false)}
+              className="block w-full px-3 py-2 text-left text-sm hover:bg-basic-50"
             >
-              {type === "registrations"
-                ? "註冊統計"
-                : type === "activity"
-                  ? "活躍度統計"
-                  : "完整資料"}
-            </button>
+              {getExportLabel(type)}
+            </a>
           ))}
         </div>
       )}

--- a/apps/product/src/components/admin/admin-sidebar.tsx
+++ b/apps/product/src/components/admin/admin-sidebar.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useAuth } from "@daodao/auth";
+import { Link, usePathname } from "@daodao/i18n/navigation";
+import { cn } from "@daodao/ui/lib/utils";
+import {
+  BarChart3,
+  ExternalLink,
+  LayoutDashboard,
+  Mail,
+  Menu,
+  Monitor,
+  Shield,
+  Target,
+  Users,
+  X,
+} from "lucide-react";
+import { useState } from "react";
+
+interface NavItem {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const navItems: NavItem[] = [
+  { label: "總覽", href: "/admin", icon: LayoutDashboard },
+  { label: "使用者", href: "/admin/users", icon: Users },
+  { label: "實踐", href: "/admin/practices", icon: Target },
+  { label: "郵件", href: "/admin/email", icon: Mail },
+  { label: "角色", href: "/admin/roles", icon: Shield },
+  { label: "系統", href: "/admin/system", icon: Monitor },
+];
+
+function NavContent({ onItemClick }: { onItemClick?: () => void }) {
+  const pathname = usePathname();
+  const { user } = useAuth();
+
+  const isActive = (href: string) => {
+    if (href === "/admin") {
+      return pathname === "/admin" || pathname === "/admin/";
+    }
+    return pathname.startsWith(href);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-border px-4 py-4">
+        <BarChart3 className="size-6 text-primary-base" />
+        <span className="text-lg font-semibold">Admin</span>
+      </div>
+
+      {/* Nav Items */}
+      <nav className="flex-1 space-y-1 p-3">
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          const active = isActive(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onItemClick}
+              className={cn(
+                "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
+                active
+                  ? "bg-primary-base/10 text-primary-base"
+                  : "text-basic-400 hover:bg-basic-100 hover:text-text-dark"
+              )}
+            >
+              <Icon className="size-5" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Footer */}
+      <div className="border-t border-border p-3">
+        <Link
+          href="/"
+          className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-basic-400 hover:bg-basic-100 hover:text-text-dark transition-colors"
+        >
+          <ExternalLink className="size-5" />
+          返回前台
+        </Link>
+        {user && (
+          <div className="mt-2 px-3 text-xs text-basic-300 truncate">
+            {user.email || user.name}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AdminSidebar() {
+  return (
+    <aside className="hidden lg:flex lg:w-60 lg:flex-col lg:border-r lg:border-border bg-white">
+      <NavContent />
+    </aside>
+  );
+}
+
+export function AdminMobileHeader() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      {/* Mobile top bar */}
+      <div className="flex items-center justify-between border-b border-border bg-white px-4 py-3 lg:hidden">
+        <div className="flex items-center gap-2">
+          <BarChart3 className="size-5 text-primary-base" />
+          <span className="font-semibold">Admin</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="rounded-lg p-2 hover:bg-basic-100"
+        >
+          <Menu className="size-5" />
+        </button>
+      </div>
+
+      {/* Mobile drawer overlay */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: overlay click to close */}
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: overlay click to close */}
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setIsOpen(false)}
+          />
+          <div className="absolute inset-y-0 left-0 w-64 bg-white shadow-xl">
+            <div className="absolute top-3 right-3">
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded-lg p-1 hover:bg-basic-100"
+              >
+                <X className="size-5" />
+              </button>
+            </div>
+            <NavContent onItemClick={() => setIsOpen(false)} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/product/src/components/admin/stat-card.tsx
+++ b/apps/product/src/components/admin/stat-card.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { cn } from "@daodao/ui/lib/utils";
+import { ArrowDown, ArrowUp } from "lucide-react";
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  change?: number;
+  changeLabel?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function StatCard({
+  title,
+  value,
+  change,
+  changeLabel,
+  icon,
+  className,
+}: StatCardProps) {
+  const isPositive = change !== undefined && change >= 0;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-white p-5 shadow-sm",
+        className
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <p className="text-sm text-basic-400">{title}</p>
+        {icon && <div className="text-basic-300">{icon}</div>}
+      </div>
+      <p className="mt-2 text-2xl font-bold text-text-dark">
+        {typeof value === "number" ? value.toLocaleString() : value}
+      </p>
+      {change !== undefined && (
+        <div className="mt-1 flex items-center gap-1 text-sm">
+          {isPositive ? (
+            <ArrowUp className="size-4 text-green-500" />
+          ) : (
+            <ArrowDown className="size-4 text-red-500" />
+          )}
+          <span
+            className={cn(
+              "font-medium",
+              isPositive ? "text-green-600" : "text-red-600"
+            )}
+          >
+            {Math.abs(change).toFixed(1)}%
+          </span>
+          {changeLabel && (
+            <span className="text-basic-300">{changeLabel}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/api/src/services/admin-hooks.ts
+++ b/packages/api/src/services/admin-hooks.ts
@@ -1,0 +1,290 @@
+"use client";
+
+/**
+ * Admin API Hooks
+ * 提供管理後台相關的 React Hooks（用於 Client Components）
+ */
+
+import { client } from "../client";
+import { useQuery } from "../hooks";
+import type {
+  IGetActivityParams,
+  IGetAdminUsersParams,
+  IGetDeviceAnalyticsParams,
+  IGetPopularProfilesParams,
+  IGetRegistrationsParams,
+  IGetRetentionParams,
+} from "./admin";
+
+// ============================================================================
+// User Stats Hooks
+// ============================================================================
+
+export const useAdminOverview = () => {
+  return useQuery("/api/v1/admin/user-stats/overview");
+};
+
+export const useAdminActiveUsers = () => {
+  return useQuery("/api/v1/admin/user-stats/active-users");
+};
+
+export const useAdminActiveUsersTrend = (days?: number) => {
+  return useQuery("/api/v1/admin/user-stats/active-users/trend", {
+    params: { query: { days: days ? String(days) : undefined } },
+  });
+};
+
+export const useAdminRegistrations = (params: IGetRegistrationsParams) => {
+  return useQuery("/api/v1/admin/user-stats/registrations", {
+    params: {
+      query: {
+        groupBy: params.groupBy,
+        startDate: params.startDate,
+        endDate: params.endDate,
+        locationId: params.locationId,
+        roleId: params.roleId,
+        educationStage: params.educationStage,
+        limit: params.limit ? String(params.limit) : undefined,
+        offset: params.offset ? String(params.offset) : undefined,
+      },
+    },
+  });
+};
+
+export const useAdminActivity = (params?: IGetActivityParams) => {
+  return useQuery("/api/v1/admin/user-stats/activity", {
+    params: {
+      query: {
+        activeWithinDays: params?.activeWithinDays ? String(params.activeWithinDays) : undefined,
+        groupBy: params?.groupBy,
+        limit: params?.limit ? String(params.limit) : undefined,
+        offset: params?.offset ? String(params.offset) : undefined,
+      },
+    },
+  });
+};
+
+export const useAdminDeviceAnalytics = (params?: IGetDeviceAnalyticsParams) => {
+  return useQuery("/api/v1/admin/user-stats/device-analytics", {
+    params: {
+      query: {
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        days: params?.days ? String(params.days) : undefined,
+      },
+    },
+  });
+};
+
+export const useAdminRetention = (params?: IGetRetentionParams) => {
+  return useQuery("/api/v1/admin/user-stats/retention", {
+    params: {
+      query: {
+        cohorts: params?.cohorts ? String(params.cohorts) : undefined,
+        trackDays: params?.trackDays ? String(params.trackDays) : undefined,
+        granularity: params?.granularity,
+      },
+    },
+  });
+};
+
+export const useAdminPopularProfiles = (params?: IGetPopularProfilesParams) => {
+  return useQuery("/api/v1/admin/user-stats/popular-profiles", {
+    params: {
+      query: {
+        limit: params?.limit ? String(params.limit) : undefined,
+        offset: params?.offset ? String(params.offset) : undefined,
+        minViews: params?.minViews ? String(params.minViews) : undefined,
+      },
+    },
+  });
+};
+
+export const useAdminSegmentation = () => {
+  return useQuery("/api/v1/admin/user-stats/segmentation");
+};
+
+// ============================================================================
+// Admin Users Hooks
+// ============================================================================
+
+export const useAdminUsers = (params?: IGetAdminUsersParams) => {
+  return useQuery("/api/v1/admin/users", {
+    params: {
+      query: {
+        search: params?.search,
+        roleId: params?.roleId,
+        isActive: params?.isActive,
+        isVerified: params?.isVerified,
+        page: params?.page ? String(params.page) : undefined,
+        limit: params?.limit ? String(params.limit) : undefined,
+        sortBy: params?.sortBy,
+        sortOrder: params?.sortOrder,
+      },
+    },
+  });
+};
+
+export const useAdminUserDetail = (userId: string) => {
+  return useQuery("/api/v1/admin/users/{userId}", {
+    params: { path: { userId } },
+  });
+};
+
+export const useAdminUserLoginHistory = (
+  userId: string,
+  params?: { startDate?: string; endDate?: string; page?: number; limit?: number }
+) => {
+  return useQuery("/api/v1/admin/users/{userId}/login-history", {
+    params: {
+      path: { userId },
+      query: {
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        page: params?.page ? String(params.page) : undefined,
+        limit: params?.limit ? String(params.limit) : undefined,
+      },
+    },
+  });
+};
+
+export const useAdminUserActivityStats = (userId: string) => {
+  return useQuery("/api/v1/admin/users/{userId}/activity-stats", {
+    params: { path: { userId } },
+  });
+};
+
+// ============================================================================
+// Roles & Permissions Hooks
+// ============================================================================
+
+export const useAdminRoles = () => {
+  return useQuery("/api/v1/admin/roles");
+};
+
+export const useAdminRole = (id: string) => {
+  return useQuery("/api/v1/admin/roles/{id}", {
+    params: { path: { id } },
+  });
+};
+
+export const useAdminPermissions = () => {
+  return useQuery("/api/v1/admin/permissions");
+};
+
+export const useUserRole = (userId: string) => {
+  return useQuery("/api/v1/admin/users/{userId}/role", {
+    params: { path: { userId } },
+  });
+};
+
+// ============================================================================
+// Practices Stats Hooks
+// ============================================================================
+
+export const useAdminPracticesStats = (params?: {
+  startDate?: string;
+  endDate?: string;
+}) => {
+  return useQuery("/api/v1/admin/practices/stats", {
+    params: { query: { startDate: params?.startDate, endDate: params?.endDate } },
+  });
+};
+
+export const useAdminPractices = (params?: {
+  page?: number;
+  limit?: number;
+  status?: "draft" | "not_started" | "active" | "completed" | "archived" | "all";
+  query?: string;
+  sort?: "createdAt" | "updatedAt" | "likeCount";
+  order?: "asc" | "desc";
+}) => {
+  return useQuery("/api/v1/practices", {
+    params: {
+      query: {
+        page: params?.page,
+        limit: params?.limit,
+        status: params?.status ?? "all",
+        ...(params?.query ? { query: params.query } : {}),
+        sort: params?.sort,
+        order: params?.order,
+      },
+    },
+  });
+};
+
+// ============================================================================
+// System Monitoring Hooks
+// ============================================================================
+
+export const useSystemMonitor = () => {
+  return useQuery("/api/v1/monitor");
+};
+
+export const useDbInfo = () => {
+  return useQuery("/api/v1/db-info");
+};
+
+export const useHealthCheck = () => {
+  return useQuery("/api/v1/health");
+};
+
+// ============================================================================
+// Admin Mutation helpers
+// ============================================================================
+
+export const useAdminMutations = () => {
+  return {
+    createRole: async (data: { name: string; description?: string }) => {
+      return client.POST("/api/v1/admin/roles", { body: data });
+    },
+    updateRole: async (id: string, data: { name?: string; description?: string }) => {
+      return client.PUT("/api/v1/admin/roles/{id}", {
+        params: { path: { id } },
+        body: data,
+      });
+    },
+    deleteRole: async (id: string) => {
+      return client.DELETE("/api/v1/admin/roles/{id}", {
+        params: { path: { id } },
+      });
+    },
+    createPermission: async (data: { name: string; description?: string }) => {
+      return client.POST("/api/v1/admin/permissions", { body: data });
+    },
+    updatePermission: async (id: string, data: { name?: string; description?: string }) => {
+      return client.PUT("/api/v1/admin/permissions/{id}", {
+        params: { path: { id } },
+        body: data,
+      });
+    },
+    deletePermission: async (id: string) => {
+      return client.DELETE("/api/v1/admin/permissions/{id}", {
+        params: { path: { id } },
+      });
+    },
+    addPermissionToRole: async (roleId: string, permissionId: number) => {
+      return client.POST("/api/v1/admin/roles/{roleId}/permissions", {
+        params: { path: { roleId } },
+        body: { permissionId },
+      });
+    },
+    removePermissionFromRole: async (roleId: string, permissionId: string) => {
+      return client.DELETE("/api/v1/admin/roles/{roleId}/permissions/{permissionId}", {
+        params: { path: { roleId, permissionId } },
+      });
+    },
+    updateUserRole: async (userId: string, roleId: number) => {
+      return client.PUT("/api/v1/admin/users/{userId}/role", {
+        params: { path: { userId } },
+        body: { roleId },
+      });
+    },
+    updateUserStatus: async (userId: string, isActive: boolean) => {
+      return client.PUT("/api/v1/admin/users/{userId}/status", {
+        params: { path: { userId } },
+        body: { isActive },
+      });
+    },
+  };
+};

--- a/packages/api/src/services/admin.ts
+++ b/packages/api/src/services/admin.ts
@@ -1,0 +1,371 @@
+/**
+ * Admin API Service
+ * 提供管理後台相關的 API 調用函數
+ */
+
+import { client } from "../client";
+import type { paths } from "../types";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// User Stats
+export type OverviewResponse =
+  paths["/api/v1/admin/user-stats/overview"]["get"]["responses"]["200"]["content"]["application/json"];
+export type ActiveUsersResponse =
+  paths["/api/v1/admin/user-stats/active-users"]["get"]["responses"]["200"]["content"]["application/json"];
+export type RegistrationsResponse =
+  paths["/api/v1/admin/user-stats/registrations"]["get"]["responses"]["200"]["content"]["application/json"];
+export type ActivityResponse =
+  paths["/api/v1/admin/user-stats/activity"]["get"]["responses"]["200"]["content"]["application/json"];
+export type DeviceAnalyticsResponse =
+  paths["/api/v1/admin/user-stats/device-analytics"]["get"]["responses"]["200"]["content"]["application/json"];
+export type RetentionResponse =
+  paths["/api/v1/admin/user-stats/retention"]["get"]["responses"]["200"]["content"]["application/json"];
+export type PopularProfilesResponse =
+  paths["/api/v1/admin/user-stats/popular-profiles"]["get"]["responses"]["200"]["content"]["application/json"];
+export type SegmentationResponse =
+  paths["/api/v1/admin/user-stats/segmentation"]["get"]["responses"]["200"]["content"]["application/json"];
+
+// Roles & Permissions
+export type RolesListResponse =
+  paths["/api/v1/admin/roles"]["get"]["responses"]["200"]["content"]["application/json"];
+export type RoleDetailResponse =
+  paths["/api/v1/admin/roles/{id}"]["get"]["responses"]["200"]["content"]["application/json"];
+export type PermissionsListResponse =
+  paths["/api/v1/admin/permissions"]["get"]["responses"]["200"]["content"]["application/json"];
+
+// Admin Users
+export type AdminUserListResponse =
+  paths["/api/v1/admin/users"]["get"]["responses"]["200"]["content"]["application/json"];
+export type AdminUserDetailResponse =
+  paths["/api/v1/admin/users/{userId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+// Param interfaces
+export interface IGetRegistrationsParams {
+  groupBy: "day" | "week" | "month" | "year" | "location" | "role" | "education_stage";
+  startDate?: string;
+  endDate?: string;
+  locationId?: string;
+  roleId?: string;
+  educationStage?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface IGetActivityParams {
+  activeWithinDays?: number;
+  groupBy?: "role" | "location" | "education_stage";
+  limit?: number;
+  offset?: number;
+}
+
+export interface IGetRetentionParams {
+  cohorts?: number;
+  trackDays?: number;
+  granularity?: "day" | "week";
+}
+
+export interface IGetPopularProfilesParams {
+  limit?: number;
+  offset?: number;
+  minViews?: number;
+}
+
+export interface IGetDeviceAnalyticsParams {
+  startDate?: string;
+  endDate?: string;
+  days?: number;
+}
+
+export interface IExportParams {
+  format: "csv" | "excel";
+  type: "registrations" | "activity" | "full";
+  startDate?: string;
+  endDate?: string;
+  groupBy?: "day" | "week" | "month" | "year" | "location" | "role" | "education_stage";
+}
+
+export interface IGetAdminUsersParams {
+  search?: string;
+  roleId?: string;
+  isActive?: "true" | "false";
+  isVerified?: "true" | "false";
+  page?: number;
+  limit?: number;
+  sortBy?: "createdAt" | "lastLoginAt" | "name" | "email";
+  sortOrder?: "asc" | "desc";
+}
+
+// ============================================================================
+// User Stats API
+// ============================================================================
+
+export const getAdminOverview = async () => {
+  return client.GET("/api/v1/admin/user-stats/overview");
+};
+
+export const getAdminActiveUsers = async () => {
+  return client.GET("/api/v1/admin/user-stats/active-users");
+};
+
+export const getAdminActiveUsersTrend = async (days?: number) => {
+  return client.GET("/api/v1/admin/user-stats/active-users/trend", {
+    params: { query: { days: days ? String(days) : undefined } },
+  });
+};
+
+export const getAdminRegistrations = async (params: IGetRegistrationsParams) => {
+  return client.GET("/api/v1/admin/user-stats/registrations", {
+    params: {
+      query: {
+        groupBy: params.groupBy,
+        startDate: params.startDate,
+        endDate: params.endDate,
+        locationId: params.locationId,
+        roleId: params.roleId,
+        educationStage: params.educationStage,
+        limit: params.limit ? String(params.limit) : undefined,
+        offset: params.offset ? String(params.offset) : undefined,
+      },
+    },
+  });
+};
+
+export const getAdminActivity = async (params?: IGetActivityParams) => {
+  return client.GET("/api/v1/admin/user-stats/activity", {
+    params: {
+      query: {
+        activeWithinDays: params?.activeWithinDays ? String(params.activeWithinDays) : undefined,
+        groupBy: params?.groupBy,
+        limit: params?.limit ? String(params.limit) : undefined,
+        offset: params?.offset ? String(params.offset) : undefined,
+      },
+    },
+  });
+};
+
+export const getAdminDeviceAnalytics = async (params?: IGetDeviceAnalyticsParams) => {
+  return client.GET("/api/v1/admin/user-stats/device-analytics", {
+    params: {
+      query: {
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        days: params?.days ? String(params.days) : undefined,
+      },
+    },
+  });
+};
+
+export const getAdminRetention = async (params?: IGetRetentionParams) => {
+  return client.GET("/api/v1/admin/user-stats/retention", {
+    params: {
+      query: {
+        cohorts: params?.cohorts ? String(params.cohorts) : undefined,
+        trackDays: params?.trackDays ? String(params.trackDays) : undefined,
+        granularity: params?.granularity,
+      },
+    },
+  });
+};
+
+export const getAdminPopularProfiles = async (params?: IGetPopularProfilesParams) => {
+  return client.GET("/api/v1/admin/user-stats/popular-profiles", {
+    params: {
+      query: {
+        limit: params?.limit ? String(params.limit) : undefined,
+        offset: params?.offset ? String(params.offset) : undefined,
+        minViews: params?.minViews ? String(params.minViews) : undefined,
+      },
+    },
+  });
+};
+
+export const getAdminSegmentation = async () => {
+  return client.GET("/api/v1/admin/user-stats/segmentation");
+};
+
+// ============================================================================
+// Admin Users API
+// ============================================================================
+
+export const getAdminUsers = async (params?: IGetAdminUsersParams) => {
+  return client.GET("/api/v1/admin/users", {
+    params: {
+      query: {
+        search: params?.search,
+        roleId: params?.roleId,
+        isActive: params?.isActive,
+        isVerified: params?.isVerified,
+        page: params?.page ? String(params.page) : undefined,
+        limit: params?.limit ? String(params.limit) : undefined,
+        sortBy: params?.sortBy,
+        sortOrder: params?.sortOrder,
+      },
+    },
+  });
+};
+
+export const getAdminUserDetail = async (userId: string) => {
+  return client.GET("/api/v1/admin/users/{userId}", {
+    params: { path: { userId } },
+  });
+};
+
+export const getAdminUserLoginHistory = async (
+  userId: string,
+  params?: { startDate?: string; endDate?: string; page?: number; limit?: number }
+) => {
+  return client.GET("/api/v1/admin/users/{userId}/login-history", {
+    params: {
+      path: { userId },
+      query: {
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        page: params?.page ? String(params.page) : undefined,
+        limit: params?.limit ? String(params.limit) : undefined,
+      },
+    },
+  });
+};
+
+export const getAdminUserActivityStats = async (userId: string) => {
+  return client.GET("/api/v1/admin/users/{userId}/activity-stats", {
+    params: { path: { userId } },
+  });
+};
+
+export const updateAdminUserStatus = async (userId: string, isActive: boolean) => {
+  return client.PUT("/api/v1/admin/users/{userId}/status", {
+    params: { path: { userId } },
+    body: { isActive },
+  });
+};
+
+// ============================================================================
+// Roles & Permissions API
+// ============================================================================
+
+export const getAdminRoles = async () => {
+  return client.GET("/api/v1/admin/roles");
+};
+
+export const getAdminRole = async (id: string) => {
+  return client.GET("/api/v1/admin/roles/{id}", {
+    params: { path: { id } },
+  });
+};
+
+export const createAdminRole = async (data: { name: string; description?: string }) => {
+  return client.POST("/api/v1/admin/roles", { body: data });
+};
+
+export const updateAdminRole = async (
+  id: string,
+  data: { name?: string; description?: string }
+) => {
+  return client.PUT("/api/v1/admin/roles/{id}", {
+    params: { path: { id } },
+    body: data,
+  });
+};
+
+export const deleteAdminRole = async (id: string) => {
+  return client.DELETE("/api/v1/admin/roles/{id}", {
+    params: { path: { id } },
+  });
+};
+
+export const getAdminPermissions = async () => {
+  return client.GET("/api/v1/admin/permissions");
+};
+
+export const createAdminPermission = async (data: { name: string; description?: string }) => {
+  return client.POST("/api/v1/admin/permissions", { body: data });
+};
+
+export const updateAdminPermission = async (
+  id: string,
+  data: { name?: string; description?: string }
+) => {
+  return client.PUT("/api/v1/admin/permissions/{id}", {
+    params: { path: { id } },
+    body: data,
+  });
+};
+
+export const deleteAdminPermission = async (id: string) => {
+  return client.DELETE("/api/v1/admin/permissions/{id}", {
+    params: { path: { id } },
+  });
+};
+
+export const addPermissionToRole = async (roleId: string, permissionId: number) => {
+  return client.POST("/api/v1/admin/roles/{roleId}/permissions", {
+    params: { path: { roleId } },
+    body: { permissionId },
+  });
+};
+
+export const removePermissionFromRole = async (roleId: string, permissionId: string) => {
+  return client.DELETE("/api/v1/admin/roles/{roleId}/permissions/{permissionId}", {
+    params: { path: { roleId, permissionId } },
+  });
+};
+
+export const getUserRole = async (userId: string) => {
+  return client.GET("/api/v1/admin/users/{userId}/role", {
+    params: { path: { userId } },
+  });
+};
+
+export const updateUserRole = async (userId: string, roleId: number) => {
+  return client.PUT("/api/v1/admin/users/{userId}/role", {
+    params: { path: { userId } },
+    body: { roleId },
+  });
+};
+
+// ============================================================================
+// Practices Stats API
+// ============================================================================
+
+export const getAdminPracticesStats = async (params?: {
+  startDate?: string;
+  endDate?: string;
+}) => {
+  return client.GET("/api/v1/admin/practices/stats", {
+    params: { query: { startDate: params?.startDate, endDate: params?.endDate } },
+  });
+};
+
+// ============================================================================
+// System Monitoring API
+// ============================================================================
+
+export const getSystemMonitor = async () => {
+  return client.GET("/api/v1/monitor");
+};
+
+export const getDbInfo = async () => {
+  return client.GET("/api/v1/db-info");
+};
+
+export const getHealthCheck = async () => {
+  return client.GET("/api/v1/health");
+};
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export const getAdminExportUrl = (params: IExportParams) => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("format", params.format);
+  searchParams.set("type", params.type);
+  if (params.startDate) searchParams.set("startDate", params.startDate);
+  if (params.endDate) searchParams.set("endDate", params.endDate);
+  if (params.groupBy) searchParams.set("groupBy", params.groupBy);
+  return `/api/v1/admin/user-stats/export?${searchParams.toString()}`;
+};

--- a/packages/api/src/services/email-hooks.ts
+++ b/packages/api/src/services/email-hooks.ts
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Email API Hooks
+ * 提供郵件服務相關的 React Hooks（用於 Client Components）
+ */
+
+import { useQuery } from "../hooks";
+import type { IGetEmailHistoryParams } from "./email";
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+export const useEmailStats = (params?: { startDate?: string; endDate?: string }) => {
+  return useQuery("/api/v1/email/stats", {
+    params: {
+      query: {
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+      },
+    },
+  });
+};
+
+export const useEmailHealth = () => {
+  return useQuery("/api/v1/email/health");
+};
+
+export const useEmailHistory = (params?: IGetEmailHistoryParams) => {
+  return useQuery("/api/v1/admin/email/history", {
+    params: {
+      query: {
+        emailType: params?.emailType,
+        status: params?.status,
+        recipient: params?.recipient,
+        userId: params?.userId,
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        page: params?.page ? String(params.page) : undefined,
+        limit: params?.limit ? String(params.limit) : undefined,
+        sortBy: params?.sortBy,
+        sortOrder: params?.sortOrder,
+      },
+    },
+  });
+};

--- a/packages/api/src/services/email.ts
+++ b/packages/api/src/services/email.ts
@@ -1,0 +1,129 @@
+/**
+ * Email API Service
+ * 提供郵件服務相關的 API 調用函數
+ */
+
+import { client } from "../client";
+import type { components, paths } from "../types";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type EmailStatsResponse = components["schemas"]["EmailStatsResponse"];
+export type EmailHealthResponse = components["schemas"]["EmailHealthResponse"];
+export type EmailPreviewResponse = components["schemas"]["EmailPreviewResponse"];
+export type EmailValidationResponse = components["schemas"]["EmailValidationResponse"];
+export type BulkEmailResponse = components["schemas"]["BulkEmailResponse"];
+export type CustomEmailRequest = components["schemas"]["CustomEmailRequest"];
+export type BulkEmailRequest = components["schemas"]["BulkEmailRequest"];
+export type PreviewEmailRequest = components["schemas"]["PreviewEmailRequest"];
+export type ValidateEmailRequest = components["schemas"]["ValidateEmailRequest"];
+export type EmailHistoryResponse =
+  paths["/api/v1/admin/email/history"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type EmailTemplate =
+  | "welcome"
+  | "verification"
+  | "password-reset"
+  | "contact"
+  | "marathon"
+  | "custom";
+
+export interface IGetEmailHistoryParams {
+  emailType?: string;
+  status?: "sent" | "failed" | "pending";
+  recipient?: string;
+  userId?: string;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: "sentAt" | "createdAt";
+  sortOrder?: "asc" | "desc";
+}
+
+// ============================================================================
+// Client Functions
+// ============================================================================
+
+export const getEmailStats = async (params?: { startDate?: string; endDate?: string }) => {
+  return client.GET("/api/v1/email/stats", {
+    params: {
+      query: {
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+      },
+    },
+  });
+};
+
+export const getEmailHealth = async () => {
+  return client.GET("/api/v1/email/health");
+};
+
+export const getEmailHistory = async (params?: IGetEmailHistoryParams) => {
+  return client.GET("/api/v1/admin/email/history", {
+    params: {
+      query: {
+        emailType: params?.emailType,
+        status: params?.status,
+        recipient: params?.recipient,
+        userId: params?.userId,
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        page: params?.page ? String(params.page) : undefined,
+        limit: params?.limit ? String(params.limit) : undefined,
+        sortBy: params?.sortBy,
+        sortOrder: params?.sortOrder,
+      },
+    },
+  });
+};
+
+export const sendVerificationEmail = async (data: {
+  email: string;
+  verifyLink: string;
+  name?: string;
+}) => {
+  return client.POST("/api/v1/email/verification", { body: data });
+};
+
+export const sendWelcomeEmail = async (data: {
+  email: string;
+  name: string;
+  hasCompletedQuiz: boolean;
+  practiceUrl?: string;
+  quizUrl?: string;
+  illustrationUrl?: string;
+  unsubscribeUrl?: string;
+  userId?: number;
+}) => {
+  return client.POST("/api/v1/email/welcome", { body: data });
+};
+
+export const sendMarathonEmail = async (data: {
+  email: string;
+  name: string;
+  marathonTitle: string;
+  marathonDate?: string;
+  marathonDescription?: string;
+}) => {
+  return client.POST("/api/v1/email/marathon", { body: data });
+};
+
+export const sendCustomEmail = async (data: CustomEmailRequest) => {
+  return client.POST("/api/v1/email/custom", { body: data });
+};
+
+export const sendBulkEmail = async (data: BulkEmailRequest) => {
+  return client.POST("/api/v1/email/bulk", { body: data });
+};
+
+export const previewEmail = async (data: PreviewEmailRequest) => {
+  return client.POST("/api/v1/email/preview", { body: data });
+};
+
+export const validateEmail = async (email: string) => {
+  return client.POST("/api/v1/email/validate", { body: { email } });
+};

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -3,9 +3,15 @@
  * 統一導出所有 domain-specific 的 API 服務
  */
 
+// Admin Service
+export * from "./admin";
+export * from "./admin-hooks";
 // Auth Service
 export * from "./auth";
 export * from "./auth-hooks";
+// Email Service
+export * from "./email";
+export * from "./email-hooks";
 // Image Service
 export * from "./image";
 // Location Service

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -18440,6 +18440,418 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得使用者列表
+         * @description 取得使用者列表，支援搜尋、篩選、分頁。包含 email_verified、is_active、roles、permissions 等管理欄位。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 搜尋名稱或 email */
+                    search?: string;
+                    /** @description 篩選角色 ID */
+                    roleId?: string;
+                    /** @description 篩選啟用狀態 */
+                    isActive?: "true" | "false";
+                    /** @description 篩選 email 驗證狀態 */
+                    isVerified?: "true" | "false";
+                    /** @description 頁數 */
+                    page?: string;
+                    /** @description 每頁數量 */
+                    limit?: string;
+                    /** @description 排序欄位 */
+                    sortBy?: "createdAt" | "lastLoginAt" | "name" | "email";
+                    /** @description 排序方向 */
+                    sortOrder?: "asc" | "desc";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得使用者列表 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminUserListResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/users/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得使用者詳情
+         * @description 取得使用者完整詳情，包含 roles、permissions、loginHistory、activityStats 等管理欄位。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 用戶內部 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得使用者詳情 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminUserDetailResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                404: components["responses"]["NotFoundError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/users/{userId}/login-history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得使用者登入歷史
+         * @description 取得指定使用者的登入歷史記錄，支援日期範圍篩選。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 開始日期 */
+                    startDate?: string;
+                    /** @description 結束日期 */
+                    endDate?: string;
+                    /** @description 頁數 */
+                    page?: string;
+                    /** @description 每頁數量 */
+                    limit?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description 用戶內部 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得登入歷史 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminLoginHistoryResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                404: components["responses"]["NotFoundError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/users/{userId}/activity-stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得使用者活躍統計
+         * @description 取得指定使用者的活躍統計數據。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 用戶內部 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得活躍統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminActivityStatsResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                404: components["responses"]["NotFoundError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/users/{userId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * 更新使用者狀態
+         * @description 啟用或停用使用者帳號。需要超級管理員權限。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 用戶內部 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdateUserStatusRequest"];
+                };
+            };
+            responses: {
+                /** @description 使用者狀態更新成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UpdateUserStatusResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                404: components["responses"]["NotFoundError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/practices/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得實踐統計
+         * @description 取得全站實踐統計數據，包含總數、各狀態數量、分類統計等。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 開始日期 */
+                    startDate?: string;
+                    /** @description 結束日期 */
+                    endDate?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得實踐統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PracticeStatsResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/active-users/trend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得活躍用戶趨勢
+         * @description 取得 DAU/WAU/MAU 時間序列資料，用於繪製趨勢圖表。預設 30 天，最多 90 天。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 查詢天數（預設 30，最大 90） */
+                    days?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得活躍用戶趨勢 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ActiveUsersTrendResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/email/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得郵件發送歷史
+         * @description 取得郵件發送歷史記錄，支援多條件篩選、分頁、排序。包含統計摘要。需要管理員權限。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 郵件類型 */
+                    emailType?: string;
+                    /** @description 發送狀態 */
+                    status?: "sent" | "failed" | "pending";
+                    /** @description 收件人 email */
+                    recipient?: string;
+                    /** @description 用戶 ID */
+                    userId?: string;
+                    /** @description 開始日期 */
+                    startDate?: string;
+                    /** @description 結束日期 */
+                    endDate?: string;
+                    /** @description 頁數 */
+                    page?: string;
+                    /** @description 每頁數量 */
+                    limit?: string;
+                    /** @description 排序欄位 */
+                    sortBy?: "sentAt" | "createdAt";
+                    /** @description 排序方向 */
+                    sortOrder?: "asc" | "desc";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得郵件歷史 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["EmailHistoryResponse"];
+                    };
+                };
+                401: components["responses"]["UnauthorizedError"];
+                403: components["responses"]["ForbiddenError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/db-info": {
         parameters: {
             query?: never;
@@ -26359,6 +26771,555 @@ export interface components {
              */
             userId: string;
         };
+        AdminUserListQuery: {
+            /**
+             * @description 搜尋名稱或 email
+             * @example john
+             */
+            search?: string;
+            /**
+             * @description 篩選角色 ID
+             * @example 2
+             */
+            roleId?: string;
+            /**
+             * @description 篩選啟用狀態
+             * @example true
+             * @enum {string}
+             */
+            isActive?: "true" | "false";
+            /**
+             * @description 篩選 email 驗證狀態
+             * @example true
+             * @enum {string}
+             */
+            isVerified?: "true" | "false";
+            /**
+             * @description 頁數
+             * @example 1
+             */
+            page?: string;
+            /**
+             * @description 每頁數量
+             * @example 20
+             */
+            limit?: string;
+            /**
+             * @description 排序欄位
+             * @default createdAt
+             * @example createdAt
+             * @enum {string}
+             */
+            sortBy: "createdAt" | "lastLoginAt" | "name" | "email";
+            /**
+             * @description 排序方向
+             * @default desc
+             * @example desc
+             * @enum {string}
+             */
+            sortOrder: "asc" | "desc";
+        };
+        AdminUserIdParam: {
+            /**
+             * @description 用戶內部 ID
+             * @example 123
+             */
+            userId: string;
+        };
+        AdminLoginHistoryQuery: {
+            /**
+             * @description 開始日期
+             * @example 2024-01-01
+             */
+            startDate?: string;
+            /**
+             * @description 結束日期
+             * @example 2024-01-31
+             */
+            endDate?: string;
+            /**
+             * @description 頁數
+             * @example 1
+             */
+            page?: string;
+            /**
+             * @description 每頁數量
+             * @example 20
+             */
+            limit?: string;
+        };
+        UpdateUserStatusRequest: {
+            /**
+             * @description 是否啟用帳號
+             * @example true
+             */
+            isActive: boolean;
+        };
+        RoleInfo: {
+            /**
+             * @description 角色 ID
+             * @example 1
+             */
+            id: number;
+            /**
+             * @description 角色名稱
+             * @example Admin
+             */
+            name: string;
+            /**
+             * @description 角色描述
+             * @example 系統管理員
+             */
+            description: string | null;
+        };
+        AdminUserListItem: {
+            /**
+             * @description 用戶外部 ID (UUID)
+             * @example 123e4567-e89b-12d3-a456-426614174000
+             */
+            id: string;
+            /**
+             * @description 用戶內部 ID
+             * @example 123
+             */
+            internalId: number;
+            /**
+             * @description 用戶名稱
+             * @example 王小明
+             */
+            name: string | null;
+            /**
+             * @description 電子郵件
+             * @example user@example.com
+             */
+            email: string | null;
+            /**
+             * @description 頭像 URL
+             * @example https://example.com/avatar.jpg
+             */
+            photoURL: string | null;
+            /**
+             * @description Email 是否已驗證
+             * @example true
+             */
+            emailVerified: boolean;
+            /**
+             * @description Email 驗證時間
+             * @example 2024-01-15T10:30:00.000Z
+             */
+            emailVerifiedAt: string | null;
+            /**
+             * @description 帳號是否啟用
+             * @example true
+             */
+            isActive: boolean;
+            /** @description 用戶角色列表 */
+            roles: components["schemas"]["RoleInfo"][];
+            /**
+             * @description 用戶權限列表
+             * @example [
+             *       "users:read",
+             *       "users:write"
+             *     ]
+             */
+            permissions: string[];
+            /**
+             * @description 建立時間
+             * @example 2024-01-15T10:30:00.000Z
+             */
+            createdAt: string;
+            /**
+             * @description 最後登入時間
+             * @example 2024-01-20T08:30:00.000Z
+             */
+            lastLoginAt: string | null;
+        };
+        AdminUserDetailData: {
+            /** @description 用戶外部 ID (UUID) */
+            id: string;
+            /** @description 用戶內部 ID */
+            internalId: number;
+            /** @description 用戶名稱 */
+            name: string | null;
+            /** @description 電子郵件 */
+            email: string | null;
+            /** @description 頭像 URL */
+            photoURL: string | null;
+            /** @description Email 是否已驗證 */
+            emailVerified: boolean;
+            /** @description Email 驗證時間 */
+            emailVerifiedAt: string | null;
+            /** @description 帳號是否啟用 */
+            isActive: boolean;
+            /** @description 用戶角色列表 */
+            roles: components["schemas"]["RoleInfo"][];
+            /** @description 用戶權限列表 */
+            permissions: string[];
+            /** @description 最近登入歷史（最近 10 筆） */
+            recentLoginHistory: components["schemas"]["LoginHistoryRecord"][];
+            activityStats: components["schemas"]["UserActivityStats"];
+            /** @description 建立時間 */
+            createdAt: string;
+            /** @description 更新時間 */
+            updatedAt: string;
+        };
+        LoginHistoryRecord: {
+            /**
+             * @description 記錄 ID
+             * @example 1
+             */
+            id: number;
+            /**
+             * @description 裝置類型
+             * @example desktop
+             */
+            deviceType: string | null;
+            /**
+             * @description 作業系統
+             * @example macOS 14.0
+             */
+            os: string | null;
+            /**
+             * @description 瀏覽器
+             * @example Chrome 120
+             */
+            browser: string | null;
+            /** @description User-Agent 字串 */
+            userAgent: string | null;
+            /**
+             * @description IP 地址
+             * @example 192.168.1.1
+             */
+            ipAddress: string | null;
+            /**
+             * @description 登入時間
+             * @example 2024-01-20T08:30:00.000Z
+             */
+            loginAt: string | null;
+        };
+        /** @description 活躍統計 */
+        UserActivityStats: {
+            /** @description 最後登入時間 */
+            lastLoginAt: string | null;
+            /** @description 最後活動時間 */
+            lastActiveAt: string | null;
+            /**
+             * @description 總登入次數
+             * @example 42
+             */
+            loginCount: number;
+            /**
+             * @description 個人檔案被查看次數
+             * @example 128
+             */
+            profileViews: number;
+            /**
+             * @description 最近 30 天登入次數
+             * @example 15
+             */
+            recentLoginCount: number;
+        };
+        PracticeStatsQuery: {
+            /**
+             * @description 開始日期
+             * @example 2024-01-01
+             */
+            startDate?: string;
+            /**
+             * @description 結束日期
+             * @example 2024-01-31
+             */
+            endDate?: string;
+        };
+        ActiveUsersTrendQuery: {
+            /**
+             * @description 查詢天數（預設 30，最大 90）
+             * @example 30
+             */
+            days?: string;
+        };
+        PracticeStatsData: {
+            /**
+             * @description 總實踐數
+             * @example 500
+             */
+            totalPractices: number;
+            /**
+             * @description 進行中的實踐數
+             * @example 150
+             */
+            activePractices: number;
+            /**
+             * @description 已完成的實踐數
+             * @example 300
+             */
+            completedPractices: number;
+            /**
+             * @description 平均完成率（百分比）
+             * @example 65.5
+             */
+            averageCompletionRate: number;
+            /** @description 依分類統計 */
+            practicesByCategory: components["schemas"]["PracticesByCategory"][];
+            /** @description 依狀態統計 */
+            practicesByStatus: components["schemas"]["PracticesByStatus"][];
+        };
+        PracticesByCategory: {
+            /**
+             * @description 分類名稱
+             * @example 程式設計
+             */
+            category: string;
+            /**
+             * @description 數量
+             * @example 25
+             */
+            count: number;
+        };
+        PracticesByStatus: {
+            /**
+             * @description 狀態名稱
+             * @example active
+             */
+            status: string;
+            /**
+             * @description 數量
+             * @example 100
+             */
+            count: number;
+        };
+        ActiveUsersTrendData: {
+            /** @description 時間序列資料 */
+            trend: components["schemas"]["ActiveUsersTrendDataPoint"][];
+            metadata: components["schemas"]["ActiveUsersTrendMetadata"];
+        };
+        ActiveUsersTrendDataPoint: {
+            /**
+             * @description 日期 (YYYY-MM-DD)
+             * @example 2024-01-15
+             */
+            date: string;
+            /**
+             * @description 日活躍用戶數
+             * @example 156
+             */
+            dau: number;
+            /**
+             * @description 週活躍用戶數
+             * @example 534
+             */
+            wau: number;
+            /**
+             * @description 月活躍用戶數
+             * @example 892
+             */
+            mau: number;
+        };
+        /** @description 元資料 */
+        ActiveUsersTrendMetadata: {
+            /**
+             * @description 查詢的天數
+             * @example 30
+             */
+            days: number;
+            /**
+             * @description 開始日期
+             * @example 2024-01-01
+             */
+            startDate: string;
+            /**
+             * @description 結束日期
+             * @example 2024-01-30
+             */
+            endDate: string;
+            /**
+             * @description 是否因超過最大範圍而被限制
+             * @example false
+             */
+            isLimited: boolean;
+            /**
+             * @description 資料生成時間
+             * @example 2024-01-31T10:30:00.000Z
+             */
+            generatedAt: string;
+        };
+        EmailHistoryQuery: {
+            /**
+             * @description 郵件類型
+             * @example verification
+             */
+            emailType?: string;
+            /**
+             * @description 發送狀態
+             * @example sent
+             * @enum {string}
+             */
+            status?: "sent" | "failed" | "pending";
+            /**
+             * Format: email
+             * @description 收件人 email
+             * @example user@example.com
+             */
+            recipient?: string;
+            /**
+             * @description 用戶 ID
+             * @example 123
+             */
+            userId?: string;
+            /**
+             * @description 開始日期
+             * @example 2024-01-01
+             */
+            startDate?: string;
+            /**
+             * @description 結束日期
+             * @example 2024-01-31
+             */
+            endDate?: string;
+            /**
+             * @description 頁數
+             * @example 1
+             */
+            page?: string;
+            /**
+             * @description 每頁數量
+             * @example 50
+             */
+            limit?: string;
+            /**
+             * @description 排序欄位
+             * @default sentAt
+             * @example sentAt
+             * @enum {string}
+             */
+            sortBy: "sentAt" | "createdAt";
+            /**
+             * @description 排序方向
+             * @default desc
+             * @example desc
+             * @enum {string}
+             */
+            sortOrder: "asc" | "desc";
+        };
+        EmailHistoryRecord: {
+            /**
+             * @description 記錄 ID
+             * @example 1
+             */
+            id: number;
+            /**
+             * @description 用戶 ID
+             * @example 123
+             */
+            userId: number;
+            /**
+             * @description 收件人 email
+             * @example user@example.com
+             */
+            recipientEmail: string | null;
+            /**
+             * @description 郵件類型
+             * @example verification
+             */
+            emailType: string;
+            /**
+             * @description 郵件主題
+             * @example 請驗證您的電子郵件
+             */
+            subject: string | null;
+            /**
+             * @description 發送狀態
+             * @example sent
+             * @enum {string}
+             */
+            status: "sent" | "failed" | "pending";
+            /**
+             * @description 發送時間
+             * @example 2024-01-15T10:30:00.000Z
+             */
+            sentAt: string | null;
+            /**
+             * @description 建立時間
+             * @example 2024-01-15T10:30:00.000Z
+             */
+            createdAt: string | null;
+            /**
+             * @description 關聯實體類型
+             * @example practice
+             */
+            entityType: string | null;
+            /**
+             * @description 關聯實體 ID
+             * @example 456
+             */
+            entityId: number | null;
+        };
+        EmailHistoryStats: {
+            /**
+             * @description 總記錄數
+             * @example 1000
+             */
+            totalRecords: number;
+            /**
+             * @description 已發送數量
+             * @example 950
+             */
+            sentCount: number;
+            /**
+             * @description 失敗數量
+             * @example 30
+             */
+            failedCount: number;
+            /**
+             * @description 待發送數量
+             * @example 20
+             */
+            pendingCount: number;
+            /**
+             * @description 成功率（百分比）
+             * @example 95
+             */
+            successRate: number;
+        };
+        EmailHistoryResponseData: {
+            /** @description 郵件記錄列表 */
+            records: components["schemas"]["EmailHistoryRecord"][];
+            pagination: components["schemas"]["Pagination"];
+            stats: components["schemas"]["EmailHistoryStats"] & unknown;
+        };
+        /** @description 分頁資訊 */
+        Pagination: {
+            /**
+             * @description 當前頁數
+             * @example 1
+             */
+            currentPage: number;
+            /**
+             * @description 總頁數
+             * @example 10
+             */
+            totalPages: number;
+            /**
+             * @description 總記錄數
+             * @example 500
+             */
+            totalCount: number;
+            /**
+             * @description 是否有下一頁
+             * @example true
+             */
+            hasNext: boolean;
+            /**
+             * @description 是否有上一頁
+             * @example false
+             */
+            hasPrev: boolean;
+            /**
+             * @description 每頁數量
+             * @example 50
+             */
+            limit: number;
+        };
         /**
          * @description 城市資料
          * @example {
@@ -26517,7 +27478,7 @@ export interface components {
              */
             hasResources: boolean;
             /**
-             * @description 進度百分比 (0-100)
+             * @description 進度百分比 (可超過 100%，表示超額完成)
              * @example 45
              */
             progressPercentage?: number;
@@ -26897,7 +27858,7 @@ export interface components {
              */
             success: true;
             /** @description The main response data */
-            data: components["schemas"]["LoginHistoryRecord"][];
+            data: (components["schemas"]["LoginHistoryRecord"] & unknown)[];
             /**
              * Format: date-time
              * @description ISO 8601 timestamp of the response
@@ -26950,48 +27911,6 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
-        };
-        /** @description 登入歷史記錄 */
-        LoginHistoryRecord: {
-            /**
-             * @description 登入記錄 ID
-             * @example 1
-             */
-            id: number;
-            /**
-             * @description 裝置類型
-             * @example desktop
-             * @example desktop
-             * @example mobile
-             * @example tablet
-             */
-            deviceType: string | null;
-            /**
-             * @description 作業系統
-             * @example macOS 14.0
-             */
-            os: string | null;
-            /**
-             * @description 瀏覽器
-             * @example Chrome 120
-             */
-            browser: string | null;
-            /**
-             * @description 完整 User-Agent 字串
-             * @example Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
-             */
-            userAgent: string | null;
-            /**
-             * @description IP 地址
-             * @example 192.168.1.1
-             */
-            ipAddress: string | null;
-            /**
-             * Format: date-time
-             * @description 登入時間
-             * @example 2024-01-20T08:30:00.000Z
-             */
-            loginAt: string | null;
         };
         /**
          * @description 用戶活躍統計回應
@@ -27027,7 +27946,7 @@ export interface components {
              * @enum {boolean}
              */
             success: true;
-            data: components["schemas"]["UserActivityStats"];
+            data: components["schemas"]["UserActivityStats"] & unknown;
             /**
              * Format: date-time
              * @description ISO 8601 timestamp of the response
@@ -27082,42 +28001,813 @@ export interface components {
             };
         };
         /** @description The main response data */
-        UserActivityStats: {
-            /**
-             * Format: date-time
-             * @description 最後登入時間
-             * @example 2024-01-20T08:30:00.000Z
-             */
-            lastLoginAt: string | null;
-            /**
-             * Format: date-time
-             * @description 最後活動時間
-             * @example 2024-01-20T14:25:00.000Z
-             */
-            lastActiveAt: string | null;
-            /**
-             * @description 總登入次數
-             * @example 42
-             */
-            loginCount: number;
-            /**
-             * @description 個人檔案被查看次數
-             * @example 128
-             */
-            profileViews: number;
-            /**
-             * @description 最近 30 天登入次數
-             * @example 15
-             */
-            recentLoginCount: number;
-        };
-        /** @description The main response data */
         DeleteTemplateResponse: {
             /**
              * @description 是否成功刪除
              * @example true
              */
             deleted: boolean;
+        };
+        /**
+         * @description Paginated response format for page-based pagination
+         * @example {
+         *       "success": true,
+         *       "data": [
+         *         {
+         *           "id": 1,
+         *           "title": "React 入門教程",
+         *           "category": "前端開發",
+         *           "createdAt": "2024-01-10T10:00:00Z"
+         *         },
+         *         {
+         *           "id": 2,
+         *           "title": "Vue.js 進階指南",
+         *           "category": "前端開發",
+         *           "createdAt": "2024-01-11T10:00:00Z"
+         *         }
+         *       ],
+         *       "pagination": {
+         *         "currentPage": 1,
+         *         "totalPages": 5,
+         *         "totalItems": 50,
+         *         "itemsPerPage": 10,
+         *         "hasNext": true,
+         *         "hasPrev": false
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "searchTime": 45,
+         *         "cacheHit": false,
+         *         "categoryCounts": {
+         *           "前端開發": 25,
+         *           "後端開發": 18,
+         *           "資料科學": 7
+         *         }
+         *       }
+         *     }
+         */
+        AdminUserListResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            /** @description Array of paginated data items */
+            data: components["schemas"]["AdminUserListItem"][];
+            /**
+             * @description Pagination information
+             * @example {
+             *       "currentPage": 1,
+             *       "totalPages": 5,
+             *       "totalItems": 50,
+             *       "itemsPerPage": 10,
+             *       "hasNext": true,
+             *       "hasPrev": false
+             *     }
+             * @example {
+             *       "currentPage": 3,
+             *       "totalPages": 8,
+             *       "totalItems": 156,
+             *       "itemsPerPage": 20,
+             *       "hasNext": true,
+             *       "hasPrev": true
+             *     }
+             */
+            pagination: {
+                /** @description Current page number (1-based) */
+                currentPage: number;
+                /** @description Total number of pages */
+                totalPages: number;
+                /** @description Total number of items across all pages */
+                totalItems: number;
+                /** @description Number of items per page */
+                itemsPerPage: number;
+                /** @description Whether there are more pages after current page */
+                hasNext: boolean;
+                /** @description Whether there are pages before current page */
+                hasPrev: boolean;
+            };
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        AdminUserDetailResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            data: components["schemas"]["AdminUserDetailData"] & unknown;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description Paginated response format for page-based pagination
+         * @example {
+         *       "success": true,
+         *       "data": [
+         *         {
+         *           "id": 1,
+         *           "title": "React 入門教程",
+         *           "category": "前端開發",
+         *           "createdAt": "2024-01-10T10:00:00Z"
+         *         },
+         *         {
+         *           "id": 2,
+         *           "title": "Vue.js 進階指南",
+         *           "category": "前端開發",
+         *           "createdAt": "2024-01-11T10:00:00Z"
+         *         }
+         *       ],
+         *       "pagination": {
+         *         "currentPage": 1,
+         *         "totalPages": 5,
+         *         "totalItems": 50,
+         *         "itemsPerPage": 10,
+         *         "hasNext": true,
+         *         "hasPrev": false
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "searchTime": 45,
+         *         "cacheHit": false,
+         *         "categoryCounts": {
+         *           "前端開發": 25,
+         *           "後端開發": 18,
+         *           "資料科學": 7
+         *         }
+         *       }
+         *     }
+         */
+        AdminLoginHistoryResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            /** @description Array of paginated data items */
+            data: components["schemas"]["LoginHistoryRecord"][];
+            /**
+             * @description Pagination information
+             * @example {
+             *       "currentPage": 1,
+             *       "totalPages": 5,
+             *       "totalItems": 50,
+             *       "itemsPerPage": 10,
+             *       "hasNext": true,
+             *       "hasPrev": false
+             *     }
+             * @example {
+             *       "currentPage": 3,
+             *       "totalPages": 8,
+             *       "totalItems": 156,
+             *       "itemsPerPage": 20,
+             *       "hasNext": true,
+             *       "hasPrev": true
+             *     }
+             */
+            pagination: {
+                /** @description Current page number (1-based) */
+                currentPage: number;
+                /** @description Total number of pages */
+                totalPages: number;
+                /** @description Total number of items across all pages */
+                totalItems: number;
+                /** @description Number of items per page */
+                itemsPerPage: number;
+                /** @description Whether there are more pages after current page */
+                hasNext: boolean;
+                /** @description Whether there are pages before current page */
+                hasPrev: boolean;
+            };
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        AdminActivityStatsResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            data: components["schemas"]["UserActivityStats"] & unknown;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        UpdateUserStatusResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            data: components["schemas"]["UpdateUserStatusData"];
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /** @description The main response data */
+        UpdateUserStatusData: {
+            /** @description 用戶外部 ID */
+            id: string;
+            /** @description 更新後的狀態 */
+            isActive: boolean;
+            /** @description 更新時間 */
+            updatedAt: string;
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        PracticeStatsResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            data: components["schemas"]["PracticeStatsData"] & unknown;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        ActiveUsersTrendResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            data: components["schemas"]["ActiveUsersTrendData"] & unknown;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        EmailHistoryResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            data: components["schemas"]["EmailHistoryResponseData"] & unknown;
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
         };
         /**
          * @description 城市列表回應

--- a/packages/auth/src/lib/auth-provider.tsx
+++ b/packages/auth/src/lib/auth-provider.tsx
@@ -204,6 +204,8 @@ export const AuthProvider = ({
   const [isLoading, setIsLoading] = useState(true);
   const [isTemporary, setIsTemporary] = useState(false);
   const [isEmailVerified, setIsEmailVerified] = useState(true); // 預設為 true，避免閃爍
+  const [roles, setRoles] = useState<string[]>([]);
+  const [permissions, setPermissions] = useState<string[]>([]);
   const [isLoginDialogOpen, setIsLoginDialogOpen] = useState(false);
   const [loginDialogRedirectUrl, setLoginDialogRedirectUrl] = useState<string | undefined>();
   const [loginDialogSource, setLoginDialogSource] = useState<"website" | "app" | undefined>();
@@ -260,6 +262,11 @@ export const AuthProvider = ({
         setIsTemporary(temporary);
         setIsEmailVerified(emailVerified);
 
+        const userRoles = userData.roles ?? [];
+        const userPermissions = userData.permissions ?? [];
+        setRoles(userRoles);
+        setPermissions(userPermissions);
+
         // 即使是臨時用戶也要設置基本的認證狀態
         const storedUser: StoredUser = {
           id: userData.id,
@@ -267,6 +274,8 @@ export const AuthProvider = ({
           email: userData.email ?? null,
           name: userData.name ?? null,
           photoUrl: userData.photo_url ?? null,
+          roles: userRoles,
+          permissions: userPermissions,
         };
         setAuthState(storedUser);
       } else {
@@ -274,12 +283,16 @@ export const AuthProvider = ({
         clearAuthState();
         setIsTemporary(false);
         setIsEmailVerified(true); // 重置為 true
+        setRoles([]);
+        setPermissions([]);
       }
     } catch (error) {
       console.error("Failed to check auth status:", error);
       clearAuthState();
       setIsTemporary(false);
       setIsEmailVerified(true); // 重置為 true
+      setRoles([]);
+      setPermissions([]);
     } finally {
       setIsLoading(false);
     }
@@ -323,6 +336,8 @@ export const AuthProvider = ({
     if (cachedUser) {
       setUser(cachedUser);
       setIsAuthenticated(true);
+      setRoles(cachedUser.roles ?? []);
+      setPermissions(cachedUser.permissions ?? []);
       setIsLoading(false);
     }
 
@@ -342,8 +357,12 @@ export const AuthProvider = ({
         if (newUserInfo) {
           setUser(newUserInfo);
           setIsAuthenticated(true);
+          setRoles(newUserInfo.roles ?? []);
+          setPermissions(newUserInfo.permissions ?? []);
         } else {
           clearAuthState();
+          setRoles([]);
+          setPermissions([]);
         }
       }
     };
@@ -577,6 +596,19 @@ export const AuthProvider = ({
     }
   }, [handleTokenRefresh, clearAuthState, openLoginDialog]);
 
+  const hasRole = useCallback((role: string) => roles.includes(role), [roles]);
+  const hasPermission = useCallback(
+    (permission: string) => permissions.includes(permission),
+    [permissions]
+  );
+  const isAdmin = useMemo(
+    () =>
+      roles.some(
+        (r) => r === "admin" || r === "Admin" || r === "SuperAdmin" || r === "superadmin"
+      ),
+    [roles]
+  );
+
   const value: AuthContextValue = useMemo(
     () => ({
       user,
@@ -590,6 +622,11 @@ export const AuthProvider = ({
       openLoginDialog,
       requireAuth,
       refreshAuth: checkAuth,
+      roles,
+      permissions,
+      hasRole,
+      hasPermission,
+      isAdmin,
     }),
     [
       user,
@@ -603,6 +640,11 @@ export const AuthProvider = ({
       openLoginDialog,
       requireAuth,
       checkAuth,
+      roles,
+      permissions,
+      hasRole,
+      hasPermission,
+      isAdmin,
     ]
   );
 

--- a/packages/auth/src/lib/auth-provider.tsx
+++ b/packages/auth/src/lib/auth-provider.tsx
@@ -602,10 +602,7 @@ export const AuthProvider = ({
     [permissions]
   );
   const isAdmin = useMemo(
-    () =>
-      roles.some(
-        (r) => r === "admin" || r === "Admin" || r === "SuperAdmin" || r === "superadmin"
-      ),
+    () => roles.some((r) => r.toLowerCase().includes("admin")),
     [roles]
   );
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -8,6 +8,8 @@ export interface StoredUser {
   email: string | null;
   name: string | null;
   photoUrl?: string | null;
+  roles: string[];
+  permissions: string[];
 }
 
 /**
@@ -51,4 +53,14 @@ export interface AuthContextValue {
   ) => T | Promise<T> | undefined;
   /** 重新檢查認證狀態（用於 onboarding 完成後刷新 isTemporary 狀態） */
   refreshAuth: () => Promise<void>;
+
+  // 角色與權限
+  roles: string[];
+  permissions: string[];
+  /** 檢查使用者是否擁有指定角色 */
+  hasRole: (role: string) => boolean;
+  /** 檢查使用者是否擁有指定權限 */
+  hasPermission: (permission: string) => boolean;
+  /** 檢查使用者是否為管理員（擁有任何 admin 相關角色） */
+  isAdmin: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       react-hook-form:
         specifier: 'catalog:'
         version: 7.69.0(react@19.2.3)
+      recharts:
+        specifier: 'catalog:'
+        version: 2.15.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       swr:
         specifier: ^2.2.5
         version: 2.3.8(react@19.2.3)
@@ -6498,7 +6501,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}


### PR DESCRIPTION
## Why is this necessary?

- 管理後台頁面（實踐列表、使用者列表）的 API 調用使用了錯誤的相對路徑和欄位映射，導致 404 錯誤和顯示為空/Unknown
- Admin 頁面（Dashboard、使用者管理、角色管理、Email 管理、系統監控、使用者詳情）尚未建立
- `admin.ts`、`email.ts`、`email-hooks.ts` 等 API 服務檔案未被 commit 至版控，導致 CI 編譯失敗（TS2307 找不到模組、TS2345 路徑不符合型別）
- `types.ts` 的 OpenAPI 型別定義缺少 admin API 路徑，CI 無法通過型別檢查
- AuthProvider 缺少角色（roles）與權限（permissions）支援，無法實現 RBAC（角色存取控制）
- Admin Dashboard 缺少統計卡片元件和 recharts 圖表依賴

---

## How does it address?

### 1. 修正實踐列表與熱門排行的 API 調用和欄位映射

**功能說明：** 修正 admin 實踐列表和熱門排行頁面的 API 調用路徑和欄位名稱映射。

- 實踐列表改用 `useAdminPractices` hook 取代直接 fetch 相對路徑（修正 404）
- 修正欄位名：`creatorName` → `user.name`、`totalDays` → `durationDays`、`likeCount` → `stats.likeCount`
- 修正 status 預設值，明確傳送 `"all"` 避免後端預設為 active
- 熱門排行修正欄位名：`name` → `nickname`、`total` → `totalCount`
- 修正 admin-sidebar biome-ignore 註解類別名稱

**變更位置：**
- `apps/product/src/app/[locale]/admin/practices/page.tsx` — 實踐列表頁面
- `apps/product/src/app/[locale]/admin/users/page.tsx` — 使用者列表頁面
- `apps/product/src/components/admin/admin-sidebar.tsx` — 側邊欄元件
- `packages/api/src/services/admin-hooks.ts` — Admin API hooks

### 2. 修正 Admin 頁面欄位映射與 lint 錯誤

**功能說明：** 修正 admin 頁面中裝置分析、用戶分群等 tab 的後端欄位映射問題，並修正所有 lint 錯誤。

- Device tab：映射後端欄位（`deviceType`、`browser`、`operatingSystems`）到前端格式，修正全部顯示為 Unknown 的問題
- Segmentation tab：使用後端欄位（`label`、`userCount`）取代（`key`、`count`），修正用戶數量缺失
- 增大圓餅圖半徑和高度，防止標籤被裁切
- 修正所有 lint 錯誤：未使用的 import/變數、缺少 label 的控制項、陣列 index key、非空斷言、靜態元素互動等

**新增檔案：**
- `apps/product/src/app/[locale]/admin/email/page.tsx` — Email 管理頁面
- `apps/product/src/app/[locale]/admin/layout.tsx` — Admin layout（含側邊欄）
- `apps/product/src/app/[locale]/admin/page.tsx` — Admin Dashboard 主頁
- `apps/product/src/app/[locale]/admin/roles/page.tsx` — 角色與權限管理頁面
- `apps/product/src/app/[locale]/admin/system/page.tsx` — 系統監控頁面
- `apps/product/src/app/[locale]/admin/users/[userId]/page.tsx` — 使用者詳情頁面

### 3. 補齊 Admin 與 Email API 服務和 OpenAPI 型別

**功能說明：** 將遺漏的 API 服務檔案加入版控，並更新 OpenAPI 型別定義，修正 CI 編譯失敗。

- 新增 `admin.ts`：Admin API 服務函式（使用者統計、使用者管理、角色權限、實踐統計、系統監控、匯出等）
- 新增 `email.ts`：Email API 服務函式
- 新增 `email-hooks.ts`：Email React Hooks
- 更新 `index.ts`：匯出 admin 和 email 模組
- 更新 `types.ts`：新增所有 admin API 路徑的 OpenAPI 型別定義

**新增檔案：**
- `packages/api/src/services/admin.ts` — Admin API 服務（371 行）
- `packages/api/src/services/email.ts` — Email API 服務（129 行）
- `packages/api/src/services/email-hooks.ts` — Email React Hooks（47 行）

**變更位置：**
- `packages/api/src/services/index.ts` — 新增 admin、email 導出
- `packages/api/src/types.ts` — 新增 admin API 路徑型別定義

### 4. AuthProvider 新增 RBAC 支援與 Admin StatCard 元件

**功能說明：** 在認證上下文中加入角色與權限機制，並新增 admin dashboard 統計卡片元件。

- `AuthProvider` 新增 `roles`、`permissions` state
- 新增 `hasRole(role)`、`hasPermission(permission)` 函式和 `isAdmin` 計算屬性
- 從後端 `userData.roles` / `userData.permissions` 載入角色權限資料
- `StoredUser` 和 `AuthContextValue` 型別擴充 roles/permissions 欄位
- 新增 `StatCard` 元件：顯示標題、數值、變化百分比（含箭頭圖示）
- 新增 `recharts` 依賴用於 admin dashboard 圖表

**新增檔案：**
- `apps/product/src/components/admin/stat-card.tsx` — 統計卡片元件

**變更位置：**
- `packages/auth/src/lib/auth-provider.tsx` — 新增 RBAC 邏輯
- `packages/auth/src/types.ts` — 擴充型別定義
- `apps/product/package.json` — 新增 recharts 依賴
- `pnpm-lock.yaml` — lockfile 更新
