### PR TITLE
Admin Dashboard & RBAC 支援

### DIFF
--- a/apps/product/src/app/[locale]/admin/email/page.tsx
+++ b/apps/product/src/app/[locale]/admin/email/page.tsx
@@ -7,13 +7,12 @@ import { useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { StatCard } from "../../../../components/admin/stat-card";
 
-type TabId = "stats" | "health" | "send" | "tracking";
+type TabId = "stats" | "health" | "send";
 
 const tabs: { id: TabId; label: string }[] = [
   { id: "stats", label: "郵件統計" },
   { id: "health", label: "服務健康" },
   { id: "send", label: "發送郵件" },
-  { id: "tracking", label: "開啟追蹤" },
 ];
 
 export default function EmailPage() {
@@ -44,18 +43,29 @@ export default function EmailPage() {
       {activeTab === "stats" && <EmailStatsTab />}
       {activeTab === "health" && <EmailHealthTab />}
       {activeTab === "send" && <EmailSendTab />}
-      {activeTab === "tracking" && <EmailTrackingTab />}
     </div>
   );
 }
 
 // ============================================================================
-// Tab 1: Email Stats
+// Tab 1: Email Stats (merged with Open Tracking)
 // ============================================================================
 
+const EMAIL_TYPE_OPTIONS = [
+  { value: "", label: "全部類型" },
+  { value: "auth_register", label: "註冊確認" },
+  { value: "auth_password_reset", label: "密碼重設" },
+  { value: "auth_email_verify", label: "信箱驗證" },
+  { value: "practice_created", label: "實踐建立" },
+  { value: "practice_first_checkin", label: "首次打卡" },
+  { value: "practice_weekly_summary", label: "每週回顧" },
+  { value: "practice_final_summary", label: "實踐完成" },
+  { value: "notification", label: "一般通知" },
+];
+
 function EmailStatsTab() {
-  const { data, isLoading } = useEmailStats();
-  const emailStats = data?.data as
+  const { data: statsData, isLoading: statsLoading } = useEmailStats();
+  const emailStats = statsData?.data as
     | {
         totalSent?: number;
         totalFailed?: number;
@@ -70,13 +80,54 @@ function EmailStatsTab() {
   const chartData = useMemo(
     () =>
       (emailStats?.byTemplate ?? []).map((item) => ({
-        name: item.template ?? "Unknown",
+        name: EMAIL_TYPE_OPTIONS.find((o) => o.value === item.template)?.label ?? item.template ?? "Unknown",
         count: item.count ?? 0,
       })),
     [emailStats]
   );
 
-  if (isLoading) {
+  // Tracking state
+  const [openedFilter, setOpenedFilter] = useState<"true" | "false" | "">("");
+  const [emailTypeFilter, setEmailTypeFilter] = useState<string>("");
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
+  const [page, setPage] = useState(1);
+  const limit = 20;
+
+  const { data: historyRaw, isLoading: historyLoading } = useEmailHistory({
+    opened: openedFilter || undefined,
+    emailType: emailTypeFilter || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    page,
+    limit,
+    sortBy: "sentAt",
+    sortOrder: "desc",
+  });
+
+  const historyData = historyRaw?.data;
+  const records = historyData?.records ?? [];
+  const pagination = historyData?.pagination;
+  const trackingStats = historyData?.stats;
+
+  const formatDate = (dateStr: string | null | undefined) => {
+    if (!dateStr) return "-";
+    const d = new Date(dateStr);
+    return d.toLocaleString("zh-TW", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const getEmailTypeLabel = (type: string) => {
+    const found = EMAIL_TYPE_OPTIONS.find((o) => o.value === type);
+    return found?.label ?? type;
+  };
+
+  if (statsLoading && historyLoading) {
     return (
       <div className="flex h-48 items-center justify-center">
         <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
@@ -86,15 +137,22 @@ function EmailStatsTab() {
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
         <StatCard title="總發送數" value={emailStats?.totalSent ?? 0} />
         <StatCard title="總失敗數" value={emailStats?.totalFailed ?? 0} />
         <StatCard
           title="成功率"
           value={emailStats?.successRate !== undefined ? `${emailStats.successRate}%` : "N/A"}
         />
+        <StatCard title="總開啟數" value={trackingStats?.openedCount ?? 0} />
+        <StatCard
+          title="開啟率"
+          value={(trackingStats?.sentCount ?? 0) > 0 ? `${trackingStats?.openRate ?? 0}%` : "N/A"}
+        />
       </div>
 
+      {/* Chart */}
       <div className="rounded-xl border border-border bg-white p-5 shadow-sm">
         <h3 className="mb-4 text-lg font-semibold">按模板分類</h3>
         {chartData.length === 0 ? (
@@ -111,6 +169,168 @@ function EmailStatsTab() {
           </ResponsiveContainer>
         )}
       </div>
+
+      {/* Tracking Section */}
+      <h3 className="text-lg font-semibold text-text-dark">開啟追蹤</h3>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 rounded-xl border border-border bg-white p-4 shadow-sm">
+        <div>
+          <label htmlFor="tracking-opened" className="block text-xs font-medium text-basic-400 mb-1">
+            開啟狀態
+          </label>
+          <select
+            id="tracking-opened"
+            value={openedFilter}
+            onChange={(e) => { setOpenedFilter(e.target.value as "true" | "false" | ""); setPage(1); }}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm"
+          >
+            <option value="">全部</option>
+            <option value="true">已開啟</option>
+            <option value="false">未開啟</option>
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="tracking-email-type" className="block text-xs font-medium text-basic-400 mb-1">
+            郵件類型
+          </label>
+          <select
+            id="tracking-email-type"
+            value={emailTypeFilter}
+            onChange={(e) => { setEmailTypeFilter(e.target.value); setPage(1); }}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm"
+          >
+            {EMAIL_TYPE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="tracking-start-date" className="block text-xs font-medium text-basic-400 mb-1">
+            開始日期
+          </label>
+          <input
+            id="tracking-start-date"
+            type="date"
+            value={startDate}
+            onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="tracking-end-date" className="block text-xs font-medium text-basic-400 mb-1">
+            結束日期
+          </label>
+          <input
+            id="tracking-end-date"
+            type="date"
+            value={endDate}
+            onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm"
+          />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-border bg-white shadow-sm">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-border bg-basic-50">
+              <th className="px-4 py-3 font-medium text-basic-400">收件人</th>
+              <th className="px-4 py-3 font-medium text-basic-400">郵件類型</th>
+              <th className="px-4 py-3 font-medium text-basic-400">主旨</th>
+              <th className="px-4 py-3 font-medium text-basic-400">發送時間</th>
+              <th className="px-4 py-3 font-medium text-basic-400">狀態</th>
+              <th className="px-4 py-3 font-medium text-basic-400">首次開啟</th>
+              <th className="px-4 py-3 font-medium text-basic-400 text-right">開啟次數</th>
+            </tr>
+          </thead>
+          <tbody>
+            {records.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-basic-300">
+                  暫無資料
+                </td>
+              </tr>
+            ) : (
+              records.map((record) => (
+                <tr key={record.id} className="border-b border-border last:border-0 hover:bg-basic-50/50">
+                  <td className="px-4 py-3 text-text-dark">
+                    {record.recipientEmail ?? "-"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="inline-block rounded-full bg-primary-base/10 px-2 py-0.5 text-xs font-medium text-primary-base">
+                      {getEmailTypeLabel(record.emailType ?? "")}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 max-w-[200px] truncate" title={record.subject ?? ""}>
+                    {record.subject ?? "-"}
+                  </td>
+                  <td className="px-4 py-3 text-basic-400 whitespace-nowrap">
+                    {formatDate(record.sentAt)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={cn(
+                        "inline-block rounded-full px-2 py-0.5 text-xs font-medium",
+                        record.status === "sent"
+                          ? "bg-green-50 text-green-700"
+                          : record.status === "failed"
+                            ? "bg-red-50 text-red-700"
+                            : "bg-yellow-50 text-yellow-700"
+                      )}
+                    >
+                      {record.status === "sent" ? "已發送" : record.status === "failed" ? "失敗" : "待發送"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-basic-400 whitespace-nowrap">
+                    {formatDate(record.openedAt)}
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium">
+                    {(record.openCount ?? 0) > 0 ? (
+                      <span className="text-primary-base">{record.openCount}</span>
+                    ) : (
+                      <span className="text-basic-300">0</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {pagination && (pagination.totalPages ?? 0) > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-basic-400">
+            共 {pagination.totalCount ?? 0} 筆，第 {pagination.currentPage ?? 1} / {pagination.totalPages ?? 1} 頁
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={!pagination.hasPrev}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+            >
+              上一頁
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!pagination.hasNext}
+              className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+            >
+              下一頁
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -400,249 +620,3 @@ function EmailSendTab() {
   );
 }
 
-// ============================================================================
-// Tab 4: Email Tracking
-// ============================================================================
-
-const EMAIL_TYPE_OPTIONS = [
-  { value: "", label: "全部類型" },
-  { value: "auth_register", label: "註冊確認" },
-  { value: "auth_password_reset", label: "密碼重設" },
-  { value: "auth_email_verify", label: "信箱驗證" },
-  { value: "practice_created", label: "實踐建立" },
-  { value: "practice_first_checkin", label: "首次打卡" },
-  { value: "practice_weekly_summary", label: "每週回顧" },
-  { value: "practice_final_summary", label: "實踐完成" },
-  { value: "notification", label: "一般通知" },
-];
-
-function EmailTrackingTab() {
-  const [openedFilter, setOpenedFilter] = useState<"true" | "false" | "">("");
-  const [emailTypeFilter, setEmailTypeFilter] = useState<string>("");
-  const [startDate, setStartDate] = useState<string>("");
-  const [endDate, setEndDate] = useState<string>("");
-  const [page, setPage] = useState(1);
-  const limit = 20;
-
-  const { data, isLoading } = useEmailHistory({
-    opened: openedFilter || undefined,
-    emailType: emailTypeFilter || undefined,
-    startDate: startDate || undefined,
-    endDate: endDate || undefined,
-    page,
-    limit,
-    sortBy: "sentAt",
-    sortOrder: "desc",
-  });
-
-  const historyData = data?.data;
-
-  const records = historyData?.records ?? [];
-  const pagination = historyData?.pagination;
-  const stats = historyData?.stats;
-
-  const totalOpened = stats?.openedCount ?? 0;
-  const openRate = stats?.openRate ?? 0;
-  const totalSent = stats?.sentCount ?? 0;
-
-  const formatDate = (dateStr: string | null | undefined) => {
-    if (!dateStr) return "-";
-    const d = new Date(dateStr);
-    return d.toLocaleString("zh-TW", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  };
-
-  const getEmailTypeLabel = (type: string) => {
-    const found = EMAIL_TYPE_OPTIONS.find((o) => o.value === type);
-    return found?.label ?? type;
-  };
-
-  if (isLoading) {
-    return (
-      <div className="flex h-48 items-center justify-center">
-        <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-4">
-      {/* Stats Cards */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <StatCard title="總開啟數" value={totalOpened} />
-        <StatCard
-          title="開啟率"
-          value={totalSent > 0 ? `${openRate}%` : "N/A"}
-        />
-        <StatCard
-          title="總發送數"
-          value={totalSent}
-        />
-      </div>
-
-      {/* Filters */}
-      <div className="flex flex-wrap gap-3 rounded-xl border border-border bg-white p-4 shadow-sm">
-        <div>
-          <label htmlFor="tracking-opened" className="block text-xs font-medium text-basic-400 mb-1">
-            開啟狀態
-          </label>
-          <select
-            id="tracking-opened"
-            value={openedFilter}
-            onChange={(e) => { setOpenedFilter(e.target.value as "true" | "false" | ""); setPage(1); }}
-            className="rounded-lg border border-border px-3 py-1.5 text-sm"
-          >
-            <option value="">全部</option>
-            <option value="true">已開啟</option>
-            <option value="false">未開啟</option>
-          </select>
-        </div>
-
-        <div>
-          <label htmlFor="tracking-email-type" className="block text-xs font-medium text-basic-400 mb-1">
-            郵件類型
-          </label>
-          <select
-            id="tracking-email-type"
-            value={emailTypeFilter}
-            onChange={(e) => { setEmailTypeFilter(e.target.value); setPage(1); }}
-            className="rounded-lg border border-border px-3 py-1.5 text-sm"
-          >
-            {EMAIL_TYPE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label htmlFor="tracking-start-date" className="block text-xs font-medium text-basic-400 mb-1">
-            開始日期
-          </label>
-          <input
-            id="tracking-start-date"
-            type="date"
-            value={startDate}
-            onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
-            className="rounded-lg border border-border px-3 py-1.5 text-sm"
-          />
-        </div>
-
-        <div>
-          <label htmlFor="tracking-end-date" className="block text-xs font-medium text-basic-400 mb-1">
-            結束日期
-          </label>
-          <input
-            id="tracking-end-date"
-            type="date"
-            value={endDate}
-            onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
-            className="rounded-lg border border-border px-3 py-1.5 text-sm"
-          />
-        </div>
-      </div>
-
-      {/* Table */}
-      <div className="overflow-x-auto rounded-xl border border-border bg-white shadow-sm">
-        <table className="w-full text-left text-sm">
-          <thead>
-            <tr className="border-b border-border bg-basic-50">
-              <th className="px-4 py-3 font-medium text-basic-400">收件人</th>
-              <th className="px-4 py-3 font-medium text-basic-400">郵件類型</th>
-              <th className="px-4 py-3 font-medium text-basic-400">主旨</th>
-              <th className="px-4 py-3 font-medium text-basic-400">發送時間</th>
-              <th className="px-4 py-3 font-medium text-basic-400">狀態</th>
-              <th className="px-4 py-3 font-medium text-basic-400">首次開啟</th>
-              <th className="px-4 py-3 font-medium text-basic-400 text-right">開啟次數</th>
-            </tr>
-          </thead>
-          <tbody>
-            {records.length === 0 ? (
-              <tr>
-                <td colSpan={7} className="px-4 py-8 text-center text-basic-300">
-                  暫無資料
-                </td>
-              </tr>
-            ) : (
-              records.map((record) => (
-                <tr key={record.id} className="border-b border-border last:border-0 hover:bg-basic-50/50">
-                  <td className="px-4 py-3 text-text-dark">
-                    {record.recipientEmail ?? "-"}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="inline-block rounded-full bg-primary-base/10 px-2 py-0.5 text-xs font-medium text-primary-base">
-                      {getEmailTypeLabel(record.emailType ?? "")}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 max-w-[200px] truncate" title={record.subject ?? ""}>
-                    {record.subject ?? "-"}
-                  </td>
-                  <td className="px-4 py-3 text-basic-400 whitespace-nowrap">
-                    {formatDate(record.sentAt)}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={cn(
-                        "inline-block rounded-full px-2 py-0.5 text-xs font-medium",
-                        record.status === "sent"
-                          ? "bg-green-50 text-green-700"
-                          : record.status === "failed"
-                            ? "bg-red-50 text-red-700"
-                            : "bg-yellow-50 text-yellow-700"
-                      )}
-                    >
-                      {record.status === "sent" ? "已發送" : record.status === "failed" ? "失敗" : "待發送"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-basic-400 whitespace-nowrap">
-                    {formatDate(record.openedAt)}
-                  </td>
-                  <td className="px-4 py-3 text-right font-medium">
-                    {(record.openCount ?? 0) > 0 ? (
-                      <span className="text-primary-base">{record.openCount}</span>
-                    ) : (
-                      <span className="text-basic-300">0</span>
-                    )}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Pagination */}
-      {pagination && (pagination.totalPages ?? 0) > 1 && (
-        <div className="flex items-center justify-between">
-          <p className="text-sm text-basic-400">
-            共 {pagination.totalCount ?? 0} 筆，第 {pagination.currentPage ?? 1} / {pagination.totalPages ?? 1} 頁
-          </p>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={!pagination.hasPrev}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
-            >
-              上一頁
-            </button>
-            <button
-              type="button"
-              onClick={() => setPage((p) => p + 1)}
-              disabled={!pagination.hasNext}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
-            >
-              下一頁
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/apps/product/src/app/[locale]/admin/email/page.tsx
+++ b/apps/product/src/app/[locale]/admin/email/page.tsx
@@ -127,7 +127,7 @@ function EmailStatsTab() {
     return found?.label ?? type;
   };
 
-  if (statsLoading && historyLoading) {
+  if (statsLoading || historyLoading) {
     return (
       <div className="flex h-48 items-center justify-center">
         <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />

--- a/apps/product/src/app/[locale]/admin/users/page.tsx
+++ b/apps/product/src/app/[locale]/admin/users/page.tsx
@@ -2,12 +2,12 @@
 
 import {
   getAdminExportUrl,
-  useAdminActivity,
   useAdminDeviceAnalytics,
   useAdminPopularProfiles,
   useAdminRegistrations,
   useAdminRetention,
   useAdminSegmentation,
+  useAdminUsers,
 } from "@daodao/api";
 import { Link } from "@daodao/i18n/navigation";
 import { cn } from "@daodao/ui/lib/utils";
@@ -26,19 +26,17 @@ import {
   YAxis,
 } from "recharts";
 
-type TabId = "registrations" | "activity" | "retention" | "devices" | "segmentation" | "popular";
+type TabId = "overview" | "retention" | "devices" | "popular";
 
 const tabs: { id: TabId; label: string }[] = [
-  { id: "registrations", label: "註冊統計" },
-  { id: "activity", label: "活躍度" },
+  { id: "overview", label: "使用者總覽" },
   { id: "retention", label: "留存率" },
   { id: "devices", label: "裝置" },
-  { id: "segmentation", label: "分群" },
   { id: "popular", label: "熱門排行" },
 ];
 
 export default function UsersStatsPage() {
-  const [activeTab, setActiveTab] = useState<TabId>("registrations");
+  const [activeTab, setActiveTab] = useState<TabId>("overview");
 
   return (
     <div className="space-y-6">
@@ -67,11 +65,9 @@ export default function UsersStatsPage() {
       </div>
 
       {/* Tab Content */}
-      {activeTab === "registrations" && <RegistrationsTab />}
-      {activeTab === "activity" && <ActivityTab />}
+      {activeTab === "overview" && <OverviewTab />}
       {activeTab === "retention" && <RetentionTab />}
       {activeTab === "devices" && <DevicesTab />}
-      {activeTab === "segmentation" && <SegmentationTab />}
       {activeTab === "popular" && <PopularTab />}
     </div>
   );
@@ -132,10 +128,38 @@ function ExportButton() {
 }
 
 // ============================================================================
-// Tab 1: Registrations
+// Tab: Overview (合併 註冊統計 + 活躍度 + 使用者清單 + 分群)
 // ============================================================================
 
-function RegistrationsTab() {
+function OverviewTab() {
+  return (
+    <div className="space-y-8">
+      {/* 註冊統計 */}
+      <section>
+        <h2 className="mb-4 text-lg font-bold text-text-dark">註冊統計</h2>
+        <RegistrationsSection />
+      </section>
+
+      {/* 分群 */}
+      <section>
+        <h2 className="mb-4 text-lg font-bold text-text-dark">分群</h2>
+        <SegmentationSection />
+      </section>
+
+      {/* 使用者清單 */}
+      <section>
+        <h2 className="mb-4 text-lg font-bold text-text-dark">使用者清單</h2>
+        <RecentActiveSection />
+      </section>
+    </div>
+  );
+}
+
+// ============================================================================
+// Section: Registrations
+// ============================================================================
+
+function RegistrationsSection() {
   const [groupBy, setGroupBy] = useState<
     "day" | "week" | "month" | "year" | "location" | "role" | "education_stage"
   >("month");
@@ -216,138 +240,207 @@ function RegistrationsTab() {
 }
 
 // ============================================================================
-// Tab 2: Activity
+// Section: Recent Active Users
 // ============================================================================
 
-const ACTIVITY_COLORS = ["#16B9B3", "#E5E7EB"];
+function RecentActiveSection() {
+  const [page, setPage] = useState(0);
+  const [sortBy, setSortBy] = useState<"lastLoginAt" | "createdAt" | "name" | "email">("lastLoginAt");
+  const limit = 20;
 
-function ActivityTab() {
-  const [groupBy, setGroupBy] = useState<"role" | "location" | "education_stage" | undefined>(
-    undefined
-  );
-  const { data, isLoading } = useAdminActivity({ groupBy });
+  const { data, isLoading } = useAdminUsers({
+    isActive: true,
+    isVerified: true,
+    sortBy,
+    sortOrder: "desc",
+    page: page + 1,
+    limit,
+  });
 
-  const activityData = data?.data as
+  type UserItem = {
+    id: string;
+    internalId: number;
+    name: string | null;
+    email: string | null;
+    photoURL: string | null;
+    lastLoginAt: string | null;
+    lastActiveAt: string | null;
+    createdAt: string;
+    isActive: boolean;
+    roles: Array<{ id: number; name: string; description: string | null }>;
+  };
+
+  // swr-openapi 的 data = response body = { success, data: [...], pagination: {...} }
+  const response = data as
     | {
-        activeUsers?: number;
-        inactiveUsers?: number;
-        activeRate?: number;
-        groups?: Array<{
-          group?: string;
-          activeUsers?: number;
-          inactiveUsers?: number;
-        }>;
+        data?: UserItem[];
+        pagination?: {
+          currentPage: number;
+          totalPages: number;
+          totalItems: number;
+          itemsPerPage: number;
+          hasNext: boolean;
+          hasPrev: boolean;
+        };
       }
     | undefined;
 
-  const pieData = useMemo(() => {
-    if (!activityData) return [];
-    return [
-      { name: "活躍", value: activityData.activeUsers ?? 0 },
-      { name: "不活躍", value: activityData.inactiveUsers ?? 0 },
-    ];
-  }, [activityData]);
+  const users = response?.data ?? [];
+  const pagination = response?.pagination;
+  const totalPages = pagination?.totalPages ?? 1;
+
+  function formatRelativeTime(dateStr: string | null | undefined) {
+    if (!dateStr) return "—";
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 1) return "剛剛";
+    if (diffMin < 60) return `${diffMin} 分鐘前`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour} 小時前`;
+    const diffDay = Math.floor(diffHour / 24);
+    if (diffDay < 30) return `${diffDay} 天前`;
+    return date.toLocaleDateString();
+  }
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        {/* Pie Chart */}
-        <div className="min-w-0 rounded-xl border border-border bg-white p-5 shadow-sm">
-          <h3 className="mb-4 text-lg font-semibold">活躍度比例</h3>
-          {isLoading ? (
-            <div className="flex h-64 items-center justify-center">
-              <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
-            </div>
-          ) : (
-            <>
-              <ResponsiveContainer width="100%" height={250}>
-                <PieChart>
-                  <Pie
-                    data={pieData}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={50}
-                    outerRadius={80}
-                    dataKey="value"
-                    label={({ name, percent }: { name: string; percent: number }) =>
-                      `${name} ${(percent * 100).toFixed(1)}%`
-                    }
-                  >
-                    {pieData.map((entry, index) => (
-                      <Cell
-                        key={entry.name}
-                        fill={ACTIVITY_COLORS[index % ACTIVITY_COLORS.length]}
-                      />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                </PieChart>
-              </ResponsiveContainer>
-              <div className="mt-2 text-center text-sm text-basic-400">
-                活躍: {activityData?.activeUsers?.toLocaleString()} / 不活躍:{" "}
-                {activityData?.inactiveUsers?.toLocaleString()}
-              </div>
-            </>
-          )}
-        </div>
-
-        {/* Group Analysis */}
-        <div className="min-w-0 rounded-xl border border-border bg-white p-5 shadow-sm">
-          <div className="mb-4 flex items-center justify-between">
-            <h3 className="text-lg font-semibold">分組分析</h3>
-            <select
-              value={groupBy ?? ""}
-              onChange={(e) => setGroupBy((e.target.value || undefined) as typeof groupBy)}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm"
-            >
-              <option value="">不分組</option>
-              <option value="role">按角色</option>
-              <option value="location">按地區</option>
-              <option value="education_stage">按教育階段</option>
-            </select>
-          </div>
-          {isLoading ? (
-            <div className="flex h-48 items-center justify-center">
-              <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
-            </div>
-          ) : activityData?.groups && activityData.groups.length > 0 ? (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border text-left text-basic-400">
-                    <th className="pb-2 pr-4">分組</th>
-                    <th className="pb-2 pr-4">活躍</th>
-                    <th className="pb-2">不活躍</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {activityData.groups.map((group) => (
-                    <tr key={group.group} className="border-b border-border/50">
-                      <td className="py-2 pr-4">{group.group}</td>
-                      <td className="py-2 pr-4 font-medium text-green-600">
-                        {group.activeUsers?.toLocaleString()}
-                      </td>
-                      <td className="py-2 text-basic-400">
-                        {group.inactiveUsers?.toLocaleString()}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <div className="flex h-48 items-center justify-center text-basic-300">
-              請選擇分組方式
-            </div>
-          )}
-        </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-sm text-basic-400">
+          排序依據
+          <select
+            value={sortBy}
+            onChange={(e) => { setSortBy(e.target.value as typeof sortBy); setPage(0); }}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm text-text-dark"
+          >
+            <option value="lastLoginAt">上次登入</option>
+            <option value="createdAt">加入時間</option>
+            <option value="name">姓名</option>
+            <option value="email">Email</option>
+          </select>
+        </label>
+        {pagination && (
+          <span className="text-sm text-basic-400">
+            共 {pagination.totalItems.toLocaleString()} 位
+          </span>
+        )}
       </div>
+
+      <div className="rounded-xl border border-border bg-white shadow-sm overflow-x-auto">
+        {isLoading ? (
+          <div className="flex h-48 items-center justify-center">
+            <div className="size-6 animate-spin rounded-full border-2 border-primary-base border-t-transparent" />
+          </div>
+        ) : users.length === 0 ? (
+          <div className="flex h-48 items-center justify-center text-basic-300">暫無資料</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-basic-400">
+                <th className="px-4 py-3">#</th>
+                <th className="px-4 py-3">頭像</th>
+                <th className="px-4 py-3">姓名</th>
+                <th className="px-4 py-3">Email</th>
+                <th className="px-4 py-3">角色</th>
+                <th className="px-4 py-3">加入時間</th>
+                <th className="px-4 py-3">上次登入</th>
+                <th className="px-4 py-3">上次操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user, i) => (
+                <tr key={user.id} className="border-b border-border/50 hover:bg-basic-50">
+                  <td className="px-4 py-3 text-basic-400">{page * limit + i + 1}</td>
+                  <td className="px-4 py-3">
+                    {user.photoURL ? (
+                      <img
+                        src={user.photoURL}
+                        alt=""
+                        className="size-8 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex size-8 items-center justify-center rounded-full bg-basic-100 text-xs text-basic-400">
+                        {user.name?.[0] ?? "?"}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/admin/users/${user.internalId}`}
+                      className="text-primary-base hover:underline"
+                    >
+                      {user.name ?? "—"}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-basic-400">{user.email ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    {user.roles.length > 0 ? (
+                      <div className="flex flex-wrap gap-1">
+                        {user.roles.map((role) => (
+                          <span
+                            key={role.id}
+                            className="inline-block rounded-full bg-primary-base/10 px-2 py-0.5 text-xs font-medium text-primary-base"
+                          >
+                            {role.name}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-basic-300">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-basic-400">
+                    <span title={new Date(user.createdAt).toLocaleString()}>
+                      {formatRelativeTime(user.createdAt)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-basic-400">
+                    <span title={user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleString() : ""}>
+                      {formatRelativeTime(user.lastLoginAt)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-basic-400">
+                    <span title={user.lastActiveAt ? new Date(user.lastActiveAt).toLocaleString() : ""}>
+                      {formatRelativeTime(user.lastActiveAt)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button
+            type="button"
+            disabled={page === 0}
+            onClick={() => setPage(page - 1)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            上一頁
+          </button>
+          <span className="text-sm text-basic-400">
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages - 1}
+            onClick={() => setPage(page + 1)}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            下一頁
+          </button>
+        </div>
+      )}
     </div>
   );
 }
 
 // ============================================================================
-// Tab 3: Retention
+// Tab: Retention
 // ============================================================================
 
 function RetentionTab() {
@@ -492,7 +585,7 @@ function RetentionTab() {
 }
 
 // ============================================================================
-// Tab 4: Devices
+// Tab: Devices
 // ============================================================================
 
 const DEVICE_COLORS = ["#16B9B3", "#FF9F1C", "#6366F1", "#EC4899", "#94A3B8"];
@@ -619,7 +712,7 @@ function DeviceChart({
 }
 
 // ============================================================================
-// Tab 5: Segmentation
+// Section: Segmentation
 // ============================================================================
 
 const SEGMENT_COLORS: Record<string, string> = {
@@ -630,7 +723,7 @@ const SEGMENT_COLORS: Record<string, string> = {
   dormant: "#EF4444",
 };
 
-function SegmentationTab() {
+function SegmentationSection() {
   const { data, isLoading } = useAdminSegmentation();
 
   const segmentData = data?.data as
@@ -726,7 +819,7 @@ function SegmentationTab() {
 }
 
 // ============================================================================
-// Tab 6: Popular Profiles
+// Tab: Popular Profiles
 // ============================================================================
 
 function PopularTab() {

--- a/packages/features/action-maker/src/components/starry-background.tsx
+++ b/packages/features/action-maker/src/components/starry-background.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { amVarStyle } from "./styled";
 
 const STAR_COUNT = 60;
@@ -12,12 +13,13 @@ function generateStars() {
 		size: Math.random() * 2 + 1,
 		delay: `${Math.random() * 3}s`,
 		duration: `${Math.random() * 2 + 2}s`,
+		opacity: 0.6 + Math.random() * 0.4,
 	}));
 }
 
-const stars = generateStars();
-
 export function StarryBackground({ children }: React.PropsWithChildren) {
+	const [stars] = useState(() => generateStars());
+
 	return (
 		<div
 			className="relative min-h-dvh overflow-hidden"
@@ -39,7 +41,7 @@ export function StarryBackground({ children }: React.PropsWithChildren) {
 							height: `${star.size}px`,
 							animationDelay: star.delay,
 							animationDuration: star.duration,
-							opacity: 0.6 + Math.random() * 0.4,
+							opacity: star.opacity,
 						}}
 					/>
 				))}

--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,18 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "concurrency": "12",
+  "concurrency": "13",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "out/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**",
+        "out/**"
+      ]
     },
     "dev": {
       "cache": false,
@@ -16,11 +23,15 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "format": {
@@ -32,7 +43,9 @@
       "outputs": []
     },
     "check": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "check:fix": {
@@ -43,5 +56,9 @@
       "cache": false
     }
   },
-  "globalDependencies": ["tsconfig.json", "turbo.json", "biome.json"]
+  "globalDependencies": [
+    "tsconfig.json",
+    "turbo.json",
+    "biome.json"
+  ]
 }


### PR DESCRIPTION
## Why is this necessary?
- 管理後台頁面（實踐列表、使用者列表）的 API 調用使用了錯誤的相對路徑和欄位映射，導致 404 錯誤和顯示為空/Unknown
- Admin 頁面（Dashboard、使用者管理、角色管理、Email 管理、系統監控、使用者詳情）尚未建立
- `admin.ts`、`email.ts`、`email-hooks.ts` 等 API 服務檔案未被 commit 至版控，導致 CI 編譯失敗（TS2307 找不到模組、TS2345 路徑不符合型別）
- `types.ts` 的 OpenAPI 型別定義缺少 admin API 路徑，CI 無法通過型別檢查
- AuthProvider 缺少角色（roles）與權限（permissions）支援，無法實現 RBAC（角色存取控制）
- Admin Dashboard 缺少統計卡片元件和 recharts 圖表依賴

---

## How does it address?

### 1. 修正實踐列表與熱門排行的 API 調用和欄位映射

**功能說明：** 修正 admin 實踐列表和熱門排行頁面的 API 調用路徑和欄位名稱映射。

- 實踐列表改用 `useAdminPractices` hook 取代直接 fetch 相對路徑（修正 404）
- 修正欄位名：`creatorName` → `user.name`、`totalDays` → `durationDays`、`likeCount` → `stats.likeCount`
- 修正 status 預設值，明確傳送 `"all"` 避免後端預設為 active
- 熱門排行修正欄位名：`name` → `nickname`、`total` → `totalCount`
- 修正 admin-sidebar biome-ignore 註解類別名稱

**變更位置：**
- `apps/product/src/app/[locale]/admin/practices/page.tsx` — 實踐列表頁面
- `apps/product/src/app/[locale]/admin/users/page.tsx` — 使用者列表頁面
- `apps/product/src/components/admin/admin-sidebar.tsx` — 側邊欄元件
- `packages/api/src/services/admin-hooks.ts` — Admin API hooks

### 2. 修正 Admin 頁面欄位映射與 lint 錯誤

**功能說明：** 修正 admin 頁面中裝置分析、用戶分群等 tab 的後端欄位映射問題，並修正所有 lint 錯誤。

- Device tab：映射後端欄位（`deviceType`、`browser`、`operatingSystems`）到前端格式，修正全部顯示為 Unknown 的問題
- Segmentation tab：使用後端欄位（`label`、`userCount`）取代（`key`、`count`），修正用戶數量缺失
- 增大圓餅圖半徑和高度，防止標籤被裁切
- 修正所有 lint 錯誤：未使用的 import/變數、缺少 label 的控制項、陣列 index key、非空斷言、靜態元素互動等

**新增檔案：**
- `apps/product/src/app/[locale]/admin/email/page.tsx` — Email 管理頁面
- `apps/product/src/app/[locale]/admin/layout.tsx` — Admin layout（含側邊欄）
- `apps/product/src/app/[locale]/admin/page.tsx` — Admin Dashboard 主頁
- `apps/product/src/app/[locale]/admin/roles/page.tsx` — 角色與權限管理頁面
- `apps/product/src/app/[locale]/admin/system/page.tsx` — 系統監控頁面
- `apps/product/src/app/[locale]/admin/users/[userId]/page.tsx` — 使用者詳情頁面

### 3. 補齊 Admin 與 Email API 服務和 OpenAPI 型別

**功能說明：** 將遺漏的 API 服務檔案加入版控，並更新 OpenAPI 型別定義，修正 CI 編譯失敗。

- 新增 `admin.ts`：Admin API 服務函式（使用者統計、使用者管理、角色權限、實踐統計、系統監控、匯出等）
- 新增 `email.ts`：Email API 服務函式
- 新增 `email-hooks.ts`：Email React Hooks
- 更新 `index.ts`：匯出 admin 和 email 模組
- 更新 `types.ts`：新增所有 admin API 路徑的 OpenAPI 型別定義

**新增檔案：**
- `packages/api/src/services/admin.ts` — Admin API 服務（371 行）
- `packages/api/src/services/email.ts` — Email API 服務（129 行）
- `packages/api/src/services/email-hooks.ts` — Email React Hooks（47 行）

**變更位置：**
- `packages/api/src/services/index.ts` — 新增 admin、email 導出
- `packages/api/src/types.ts` — 新增 admin API 路徑型別定義

### 4. AuthProvider 新增 RBAC 支援與 Admin StatCard 元件

**功能說明：** 在認證上下文中加入角色與權限機制，並新增 admin dashboard 統計卡片元件。

- `AuthProvider` 新增 `roles`、`permissions` state
- 新增 `hasRole(role)`、`hasPermission(permission)` 函式和 `isAdmin` 計算屬性
- 從後端 `userData.roles` / `userData.permissions` 載入角色權限資料
- `StoredUser` 和 `AuthContextValue` 型別擴充 roles/permissions 欄位
- 新增 `StatCard` 元件：顯示標題、數值、變化百分比（含箭頭圖示）
- 新增 `recharts` 依賴用於 admin dashboard 圖表

**新增檔案：**
- `apps/product/src/components/admin/stat-card.tsx` — 統計卡片元件

**變更位置：**
- `packages/auth/src/lib/auth-provider.tsx` — 新增 RBAC 邏輯
- `packages/auth/src/types.ts` — 擴充型別定義
- `apps/product/package.json` — 新增 recharts 依賴
- `pnpm-lock.yaml` — lockfile 更新
