### PR TITLE
fix(admin): use string type for isActive/isVerified query params

### DIFF
--- a/apps/product/src/app/[locale]/admin/users/page.tsx
+++ b/apps/product/src/app/[locale]/admin/users/page.tsx
@@ -249,8 +249,8 @@ function RecentActiveSection() {
   const limit = 20;
 
   const { data, isLoading } = useAdminUsers({
-    isActive: true,
-    isVerified: true,
+    isActive: "true",
+    isVerified: "true",
     sortBy,
     sortOrder: "desc",
     page: page + 1,


### PR DESCRIPTION
The IGetAdminUsersParams interface expects "true" | "false" strings, not boolean values. This fixes the CI build type error.
