### PR TITLE
同日多筆打卡切換功能

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -6,7 +6,7 @@ import { useParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
 import { addDays, format, isValid, parse } from "date-fns";
 import { useMemo } from "react";
-import { CheckInButton, CheckInDateSelector, CheckInDetail } from "@/components/check-in";
+import { CheckInButton, CheckInDateSelector, CheckInDetail, SameDayCheckInNav } from "@/components/check-in";
 import type { ICheckInDisplayData, ICheckInFormData } from "@/components/check-in/types";
 import { PageHeader } from "@/components/layout";
 import { mapApiMoodToMoodType, mapMoodTypeToApiMood } from "@/constants/mood";
@@ -110,6 +110,7 @@ export default function CheckInDetailPage() {
   }, [checkInsData, practiceData]);
 
   // 建立日期到 check-in 資訊的映射（用於生成日期列表，包含打卡次數）
+  // 按 createdAt 排序後再建立，確保每日第一筆 ID 與同日切換導航的排序一致
   const checkInDateToIdMap = useMemo(() => {
     const map = new Map<string, IDateCheckInInfo>();
 
@@ -117,13 +118,15 @@ export default function CheckInDetailPage() {
       return map;
     }
 
-    checkInsData.data.forEach((checkIn) => {
+    const sorted = [...checkInsData.data].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+
+    sorted.forEach((checkIn) => {
       const existing = map.get(checkIn.checkinDate);
       if (existing) {
-        // 同一天有多筆打卡，累加次數
         existing.count += 1;
       } else {
-        // 第一筆打卡，設定 ID 和次數
         map.set(checkIn.checkinDate, {
           id: String(checkIn.id),
           count: 1,
@@ -148,6 +151,35 @@ export default function CheckInDetailPage() {
 
     return map;
   }, [checkInsData]);
+
+  // 計算同日打卡 ID 列表（用於同日多筆打卡切換）
+  const { sameDayCheckInIds, currentIndexInDay, activeCheckInDate } = useMemo(() => {
+    if (!checkInsData?.data) {
+      return { sameDayCheckInIds: [], currentIndexInDay: 0, activeCheckInDate: "" };
+    }
+
+    // 找到目前打卡的日期
+    const currentCheckIn = checkInsData.data.find((c) => String(c.id) === checkInId);
+    if (!currentCheckIn) {
+      return { sameDayCheckInIds: [], currentIndexInDay: 0, activeCheckInDate: "" };
+    }
+
+    const currentDate = currentCheckIn.checkinDate;
+
+    // 篩選同日所有打卡，按 createdAt 排序（舊→新）
+    const sameDayItems = checkInsData.data
+      .filter((c) => c.checkinDate === currentDate)
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+    const ids = sameDayItems.map((c) => String(c.id));
+    const index = ids.indexOf(checkInId);
+
+    return {
+      sameDayCheckInIds: ids,
+      currentIndexInDay: index >= 0 ? index : 0,
+      activeCheckInDate: currentDate,
+    };
+  }, [checkInsData, checkInId]);
 
   // 獲取目標 check-in 資料
   const checkInData = useMemo(() => {
@@ -243,6 +275,7 @@ export default function CheckInDetailPage() {
         checkInDates={fullCheckInDates}
         checkIns={checkInsRecord}
         activeCheckInId={checkInId}
+        activeDate={activeCheckInDate}
         practiceId={practiceId}
         title="打卡紀錄"
         closeActionTo={`/practices/${practiceId}`}
@@ -257,8 +290,18 @@ export default function CheckInDetailPage() {
         />
       </div>
 
-      <main className="max-w-[448px] mx-auto pt-[150px] md:pt-3 px-5 pb-52">
-        <CheckInDetail checkInData={checkInData} onEditComplete={handleEditComplete} />
+      <main className="max-w-[448px] mx-auto pt-[150px] md:pt-10 px-5 pb-52">
+        <CheckInDetail
+          checkInData={checkInData}
+          onEditComplete={handleEditComplete}
+          afterTitle={
+            <SameDayCheckInNav
+              sameDayCheckInIds={sameDayCheckInIds}
+              currentIndex={currentIndexInDay}
+              practiceId={practiceId}
+            />
+          }
+        />
       </main>
 
       <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-6 p-6 border-t border-light-gray bg-very-light-gray z-20">

--- a/apps/product/src/components/check-in/date-selector/check-in-date-button.tsx
+++ b/apps/product/src/components/check-in/date-selector/check-in-date-button.tsx
@@ -10,6 +10,8 @@ interface ICheckInDateButtonProps {
   index: number;
   checkIns: Record<string, ICheckInDisplayData>;
   activeCheckInId: string;
+  /** 目前打卡的日期（yyyy-MM-dd），用於同日多筆打卡時正確高亮 */
+  activeDate?: string;
   onSelect: (checkInId: string) => void;
   className?: string;
 }
@@ -28,11 +30,13 @@ export const CheckInDateButton = ({
   index,
   checkIns,
   activeCheckInId,
+  activeDate,
   onSelect,
   className,
 }: ICheckInDateButtonProps) => {
   const hasCheckIn = item.hasCheckIn ?? !!checkIns[item.id];
-  const isActive = hasCheckIn && item.id === activeCheckInId;
+  // 優先使用日期比對（支援同日多筆打卡切換時仍正確高亮），否則降級為 ID 比對
+  const isActive = hasCheckIn && (activeDate ? item.date === activeDate : item.id === activeCheckInId);
   const itemCheckIn = checkIns[item.id];
   const itemMood = itemCheckIn?.mood;
   const itemMoodOption = itemMood ? MOOD_OPTIONS.find((option) => option.id === itemMood) : null;

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -4,7 +4,7 @@ import { useSafeRouter } from "@daodao/ui/hooks/use-safe-router";
 import { Button } from "@daodao/ui/components/button";
 import { cn } from "@daodao/ui/lib/utils";
 import { X } from "lucide-react";
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
 import { CheckInDateButton } from "./check-in-date-button";
 import type { ICheckInDateSelectorProps } from "./types";
 
@@ -13,6 +13,7 @@ export const MobileCheckInDateSelector = ({
   checkIns,
   practiceId,
   activeCheckInId,
+  activeDate,
   title,
   closeActionTo,
 }: ICheckInDateSelectorProps) => {
@@ -20,6 +21,8 @@ export const MobileCheckInDateSelector = ({
   const [isVisible, setIsVisible] = useState(true);
   const lastScrollY = useRef(0);
   const navRef = useRef<HTMLElement>(null);
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // 滑鼠拖曳滾動相關
   const isMouseDown = useRef(false);
@@ -62,6 +65,20 @@ export const MobileCheckInDateSelector = ({
       cancelAnimationFrame(rafId);
     };
   }, []);
+
+  // 元件掛載時立即定位到選中的日期按鈕（不使用動畫，避免閃跳）
+  useLayoutEffect(() => {
+    if (!activeDate || !scrollContainerRef.current) return;
+
+    const activeIndex = checkInDates.findIndex((item) => item.date === activeDate);
+    if (activeIndex < 0) return;
+
+    const buttons = scrollContainerRef.current.querySelectorAll("button");
+    const activeButton = buttons[activeIndex];
+    if (activeButton) {
+      activeButton.scrollIntoView({ behavior: "instant", inline: "center", block: "nearest" });
+    }
+  }, [activeDate, checkInDates]);
 
   // 滑鼠拖曳：按下
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -162,7 +179,7 @@ export const MobileCheckInDateSelector = ({
       </div>
 
       {/* 日期選擇器 */}
-      <div className="overflow-x-auto scrollbar-hide px-10">
+      <div ref={scrollContainerRef} className="overflow-x-auto scrollbar-hide px-10">
         <div className="flex items-center justify-center gap-4 w-fit mx-auto pb-5 pt-4">
           {checkInDates.map((item, index) => (
             <CheckInDateButton
@@ -171,6 +188,7 @@ export const MobileCheckInDateSelector = ({
               index={index}
               checkIns={checkIns}
               activeCheckInId={activeCheckInId}
+              activeDate={activeDate}
               onSelect={handleDateSelect}
             />
           ))}

--- a/apps/product/src/components/check-in/date-selector/types.ts
+++ b/apps/product/src/components/check-in/date-selector/types.ts
@@ -8,6 +8,8 @@ export interface ICheckInDateSelectorProps {
   checkIns: Record<string, ICheckInDisplayData>;
   practiceId: string;
   activeCheckInId: string;
+  /** 目前打卡的日期（yyyy-MM-dd），用於同日多筆打卡時正確高亮日期按鈕 */
+  activeDate?: string;
   /** 標題（整合到日期選擇器中，用於 mobile 版本同步顯示/隱藏） */
   title?: string;
   /** 關閉按鈕的目標路由 */

--- a/apps/product/src/components/check-in/display/check-in-card.tsx
+++ b/apps/product/src/components/check-in/display/check-in-card.tsx
@@ -4,6 +4,7 @@ import { NotebookHoleSvg, StampSvg, TapeSvg } from "@daodao/assets";
 import { type CapturedImageData, captureElementAsImage } from "@daodao/shared";
 import { cn } from "@daodao/ui/lib/utils";
 import { format, isValid } from "date-fns";
+import type * as React from "react";
 import { useEffect, useRef } from "react";
 import { MOOD_OPTIONS, type MoodType } from "@/constants/mood";
 
@@ -18,6 +19,8 @@ interface ICheckInCardProps {
   onImageClick?: (index: number) => void;
   showTape?: boolean;
   onMaskedImageReady?: (maskedImageData: CapturedImageData) => void;
+  /** 標題下方插入的額外內容（例如同日打卡切換導航） */
+  afterTitle?: React.ReactNode;
 }
 
 /**
@@ -91,6 +94,7 @@ export const CheckInCard = ({
   onImageClick,
   showTape = true,
   onMaskedImageReady,
+  afterTitle,
 }: ICheckInCardProps) => {
   const moodOption = mood ? MOOD_OPTIONS.find((option) => option.id === mood) : null;
   const MoodEmoji = moodOption?.emoji;
@@ -138,6 +142,9 @@ export const CheckInCard = ({
       <div className={`px-2 pb-5 text-center ${titleClassName}`}>
         <h2 className="text-lg font-semibold line-clamp-2">{taskTitle}</h2>
       </div>
+
+      {/* 標題下方額外內容（如同日打卡切換） */}
+      {afterTitle}
 
       {/* 筆記本風格內容區 */}
       <div className="relative bg-white pb-9 mb-5 mt-5 rounded-b">

--- a/apps/product/src/components/check-in/display/check-in-detail.tsx
+++ b/apps/product/src/components/check-in/display/check-in-detail.tsx
@@ -21,9 +21,11 @@ interface ICheckInDetailProps {
   checkInData: ICheckInDisplayData;
   /** 編輯完成回調 */
   onEditComplete?: (data: ICheckInFormData) => Promise<void> | void;
+  /** 標題下方額外內容（如同日打卡切換導航） */
+  afterTitle?: React.ReactNode;
 }
 
-export const CheckInDetail = ({ checkInData, onEditComplete }: ICheckInDetailProps) => {
+export const CheckInDetail = ({ checkInData, onEditComplete, afterTitle }: ICheckInDetailProps) => {
   const { date, mood, content, tags, images, practiceTitle } = checkInData;
 
   const [lightboxOpen, setLightboxOpen] = React.useState(false);
@@ -92,6 +94,7 @@ export const CheckInDetail = ({ checkInData, onEditComplete }: ICheckInDetailPro
         images={images}
         onImageClick={handleImageClick}
         showTape={true}
+        afterTitle={afterTitle}
       />
 
       <div className="flex flex-col w-fit gap-4 mx-auto">

--- a/apps/product/src/components/check-in/display/index.ts
+++ b/apps/product/src/components/check-in/display/index.ts
@@ -4,3 +4,4 @@ export type { CheckInData as CheckInDetailData } from "./check-in-detail";
 export { CheckInDetail } from "./check-in-detail";
 export { CheckInRecordCard } from "./check-in-record-card";
 export { CheckInStack } from "./check-in-stack";
+export { SameDayCheckInNav } from "./same-day-check-in-nav";

--- a/apps/product/src/components/check-in/display/same-day-check-in-nav.tsx
+++ b/apps/product/src/components/check-in/display/same-day-check-in-nav.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useSafeRouter } from "@daodao/ui/hooks/use-safe-router";
+import { Button } from "@daodao/ui/components/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface ISameDayCheckInNavProps {
+  /** 同一天所有打卡的 ID 陣列（按 createdAt 排序） */
+  sameDayCheckInIds: string[];
+  /** 目前顯示的打卡在同日中的索引（0-based） */
+  currentIndex: number;
+  practiceId: string;
+}
+
+export const SameDayCheckInNav = ({
+  sameDayCheckInIds,
+  currentIndex,
+  practiceId,
+}: ISameDayCheckInNavProps) => {
+  const router = useSafeRouter();
+  const total = sameDayCheckInIds.length;
+
+  if (total <= 1) return null;
+
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < total - 1;
+
+  const handlePrev = () => {
+    if (hasPrev) {
+      router.push(`/practices/${practiceId}/check-ins/${sameDayCheckInIds[currentIndex - 1]}`);
+    }
+  };
+
+  const handleNext = () => {
+    if (hasNext) {
+      router.push(`/practices/${practiceId}/check-ins/${sameDayCheckInIds[currentIndex + 1]}`);
+    }
+  };
+
+  return (
+    <div className="relative flex items-center justify-between mb-6 pb-5">
+      {/* 左箭頭 */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handlePrev}
+        disabled={!hasPrev}
+        className="size-12 rounded-full bg-white text-logo-cyan shadow-md hover:bg-white/90 disabled:bg-white/20 disabled:text-logo-cyan/40 disabled:shadow-none"
+        aria-label="上一筆打卡"
+        animation="none"
+      >
+        <ChevronLeft className="size-6" />
+      </Button>
+
+      {/* 中間指示器 */}
+      <span className="text-white text-lg font-medium tabular-nums">
+        {currentIndex + 1} / {total}
+      </span>
+
+      {/* 右箭頭 */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleNext}
+        disabled={!hasNext}
+        className="size-12 rounded-full bg-white text-logo-cyan shadow-md hover:bg-white/90 disabled:bg-white/20 disabled:text-logo-cyan/40 disabled:shadow-none"
+        aria-label="下一筆打卡"
+        animation="none"
+      >
+        <ChevronRight className="size-6" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/product/src/components/check-in/display/same-day-check-in-nav.tsx
+++ b/apps/product/src/components/check-in/display/same-day-check-in-nav.tsx
@@ -25,17 +25,17 @@ export const SameDayCheckInNav = ({
   const hasPrev = currentIndex > 0;
   const hasNext = currentIndex < total - 1;
 
-  const handlePrev = () => {
+  const handlePrev = useCallback(() => {
     if (hasPrev) {
       router.push(`/practices/${practiceId}/check-ins/${sameDayCheckInIds[currentIndex - 1]}`);
     }
-  };
+  }, [hasPrev, router, practiceId, sameDayCheckInIds, currentIndex]);
 
-  const handleNext = () => {
+  const handleNext = useCallback(() => {
     if (hasNext) {
       router.push(`/practices/${practiceId}/check-ins/${sameDayCheckInIds[currentIndex + 1]}`);
     }
-  };
+  }, [hasNext, router, practiceId, sameDayCheckInIds, currentIndex]);
 
   return (
     <div className="relative flex items-center justify-between mb-6 pb-5">

--- a/apps/product/src/components/check-in/display/same-day-check-in-nav.tsx
+++ b/apps/product/src/components/check-in/display/same-day-check-in-nav.tsx
@@ -3,6 +3,7 @@
 import { useSafeRouter } from "@daodao/ui/hooks/use-safe-router";
 import { Button } from "@daodao/ui/components/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useCallback } from "react";
 
 interface ISameDayCheckInNavProps {
   /** 同一天所有打卡的 ID 陣列（按 createdAt 排序） */


### PR DESCRIPTION
## Why is this necessary?

- 同一天可以打卡多次，但打卡紀錄頁面只能看到該日第一筆打卡，無法瀏覽或切換到同日的其他打卡記錄
- 日期選擇器的 active 狀態使用 check-in ID 比對，當用戶透過其他方式（如 URL 直接訪問）查看同日第 2、3 筆打卡時，日期按鈕不會正確高亮
- `checkInDateToIdMap` 依賴 API 回傳順序決定每日「第一筆」打卡 ID，但 API 回傳順序可能與 `createdAt` 排序不一致，導致日期按鈕連結的打卡與同日導航的 "1 / N" 不同步
- 切換打卡時元件重新掛載，日期選擇器的水平捲動位置重置為 0，再以 smooth 動畫捲回選中位置，產生明顯的閃跳

---

## How does it address?

### 1. 新增同日打卡切換導航元件

**功能說明：** 當同一天有 2 筆以上打卡時，在卡片標題下方顯示「← 1 / 3 →」導航，用戶可透過左右箭頭在同日不同打卡間切換。

- 新增 `SameDayCheckInNav` 元件，包含左右圓形白色箭頭按鈕和 "X / Y" 指示器
- 按鈕 enabled 時為實心白色背景 + 陰影，disabled 時為半透明 `bg-white/20`
- 同日只有 1 筆打卡時自動隱藏（`total <= 1` return null）
- 點擊箭頭透過 `router.push` 導航到對應的 check-in ID

**新增檔案：**
- `apps/product/src/components/check-in/display/same-day-check-in-nav.tsx`

### 2. 頁面計算同日打卡資料並透過 afterTitle slot 傳遞

**功能說明：** 在打卡詳情頁計算同日所有打卡 ID 列表，透過 `afterTitle` render prop 將導航元件插入卡片標題與筆記本內容之間。

- 新增 `sameDayCheckInIds` 計算：從 API 資料篩選同日打卡，按 `createdAt` 升序排列
- 新增 `currentIndexInDay`：目前打卡在同日列表中的位置索引
- 新增 `activeCheckInDate`：目前打卡的日期（yyyy-MM-dd），傳遞給日期選擇器
- `CheckInDetail` 和 `CheckInCard` 新增 `afterTitle?: React.ReactNode` prop，作為標題下方的 slot

**變更位置：**
- `apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx`
- `apps/product/src/components/check-in/display/check-in-detail.tsx`
- `apps/product/src/components/check-in/display/check-in-card.tsx`
- `apps/product/src/components/check-in/display/index.ts`

### 3. 修正日期選擇器的 active 狀態比對邏輯

**功能說明：** 將日期按鈕的 active 狀態從 check-in ID 比對改為日期比對，確保查看同日第 2、3 筆打卡時日期按鈕仍正確高亮。

- `ICheckInDateSelectorProps` 新增 `activeDate?: string` prop
- `CheckInDateButton` 的 `isActive` 優先使用 `item.date === activeDate` 比對，降級為 ID 比對

**變更位置：**
- `apps/product/src/components/check-in/date-selector/types.ts`
- `apps/product/src/components/check-in/date-selector/mobile.tsx`
- `apps/product/src/components/check-in/date-selector/check-in-date-button.tsx`

### 4. 統一 checkInDateToIdMap 排序與同日導航一致

**功能說明：** `checkInDateToIdMap` 改為先按 `createdAt` 升序排列後再建立，確保每日第一筆 ID 與同日切換導航的 "1 / N" 一致。

**變更位置：**
- `apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx`

### 5. 日期選擇器掛載時立即定位到選中日期

**功能說明：** 使用 `useLayoutEffect` + `behavior: "instant"` 在元件掛載時立即將捲動位置定位到選中的日期按鈕，避免「跳回最前面再捲回來」的閃跳。

**變更位置：**
- `apps/product/src/components/check-in/date-selector/mobile.tsx`

## Why is this necessary?

<!-- 請說明為什麼需要這個變更：
- 解決了什麼問題？
- 實現了什麼新功能？
- 改善了什麼現有功能？
- 相關的 Issue 或需求連結
-->



## How does it address?

<!-- 請說明這個變更如何解決問題：
- 採用了什麼解決方案？
- 主要的變更內容有哪些？
- 技術實現的方式
- 對現有程式碼的影響
-->

## Screenshots/Demo

<!-- 如果有 UI 變更，請提供截圖或 Demo -->
