### PR TITLE
Add ownership check and improve image export format

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePracticeById, usePracticeCheckIns, useUpdatePracticeCheckIn } from "@daodao/api";
+import { useCurrentUser, usePracticeById, usePracticeCheckIns, useUpdatePracticeCheckIn } from "@daodao/api";
 import { Deco4Svg } from "@daodao/assets";
 import { useParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
@@ -69,6 +69,8 @@ export default function CheckInDetailPage() {
 
   // 獲取 practice 資料
   const { data: practiceData, isLoading: isLoadingPractice } = usePracticeById(practiceId);
+
+  const { data: currentUserData } = useCurrentUser();
 
   // 更新打卡記錄
   const { updateCheckIn } = useUpdatePracticeCheckIn(practiceId, checkInId);
@@ -244,6 +246,9 @@ export default function CheckInDetailPage() {
     );
   }
 
+  // 判斷當前用戶是否為實踐的擁有者
+  const isOwner = practiceData?.data?.user?.id === currentUserData?.data?.id;
+
   const handleCheckInComplete = (data: unknown) => {
     // TODO: 處理打卡資料
     console.log("打卡資料:", data);
@@ -304,21 +309,23 @@ export default function CheckInDetailPage() {
         />
       </main>
 
-      <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-6 p-6 border-t border-light-gray bg-very-light-gray z-20">
-        {/* 打卡按鈕 */}
-        <CheckInButton
-          variant="orange"
-          className="w-full sm:max-w-[288px]"
-          practiceId={practiceId}
-          practiceStatus={practiceData?.data?.status}
-          lastCheckInDate={checkInIdToDateMap.get(checkInId) || null}
-          startDate={practiceData?.data?.startDate || null}
-          endDate={practiceData?.data?.endDate || null}
-          taskTitle={checkInData.practiceTitle}
-          onComplete={handleCheckInComplete}
-          progressPercentage={practiceData?.data?.progressPercentage ?? 0}
-        />
-      </footer>
+      {isOwner && (
+        <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-6 p-6 border-t border-light-gray bg-very-light-gray z-20">
+          {/* 打卡按鈕 */}
+          <CheckInButton
+            variant="orange"
+            className="w-full sm:max-w-[288px]"
+            practiceId={practiceId}
+            practiceStatus={practiceData?.data?.status}
+            lastCheckInDate={checkInIdToDateMap.get(checkInId) || null}
+            startDate={practiceData?.data?.startDate || null}
+            endDate={practiceData?.data?.endDate || null}
+            taskTitle={checkInData.practiceTitle}
+            onComplete={handleCheckInComplete}
+            progressPercentage={practiceData?.data?.progressPercentage ?? 0}
+          />
+        </footer>
+      )}
     </div>
   );
 }

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -70,7 +70,7 @@ export default function CheckInDetailPage() {
   // 獲取 practice 資料
   const { data: practiceData, isLoading: isLoadingPractice } = usePracticeById(practiceId);
 
-  const { data: currentUserData } = useCurrentUser();
+  const { data: currentUserData, isLoading: isLoadingCurrentUser } = useCurrentUser();
 
   // 更新打卡記錄
   const { updateCheckIn } = useUpdatePracticeCheckIn(practiceId, checkInId);
@@ -211,7 +211,7 @@ export default function CheckInDetailPage() {
   }, [checkInsMap]);
 
   // Loading 狀態
-  if (isLoadingPractice || isLoadingCheckIns) {
+  if (isLoadingPractice || isLoadingCheckIns || isLoadingCurrentUser) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-logo-cyan">
         <Deco4Svg className="absolute top-0 right-0 -z-10" width={270} height={484} />
@@ -247,7 +247,7 @@ export default function CheckInDetailPage() {
   }
 
   // 判斷當前用戶是否為實踐的擁有者
-  const isOwner = practiceData?.data?.user?.id === currentUserData?.data?.id;
+  const isOwner = !!practiceData?.data?.user?.id && practiceData.data.user.id === currentUserData?.data?.id;
 
   const handleCheckInComplete = (data: unknown) => {
     // TODO: 處理打卡資料

--- a/apps/product/src/components/practice/summary/hooks/use-practice-summary-image.tsx
+++ b/apps/product/src/components/practice/summary/hooks/use-practice-summary-image.tsx
@@ -151,7 +151,7 @@ export const usePracticeSummaryImage = ({
       const date = new Date();
       const dateString = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, "0")}${String(date.getDate()).padStart(2, "0")}`;
       const sanitizedName = sanitizeFilename(practiceName);
-      link.download = `${sanitizedName}_總結_${dateString}.jpg`;
+      link.download = `${sanitizedName}_總結_${dateString}.png`;
 
       // 觸發下載
       document.body.appendChild(link);

--- a/apps/product/src/components/practice/summary/practice-summary-card.tsx
+++ b/apps/product/src/components/practice/summary/practice-summary-card.tsx
@@ -130,7 +130,7 @@ export const PracticeSummaryCard = forwardRef<HTMLDivElement, PracticeSummaryCar
 
             {/* 過程心情 - 右上 */}
             {summary.topMoods.length > 0 && (
-              <div className="absolute right-0 top-0">
+              <div className="absolute right-2 top-0">
                 <div className="text-sm text-text-dark mb-2">過程心情</div>
                 <div className="relative">
                   {summary.topMoods.map((moodStat, index) => {
@@ -138,7 +138,7 @@ export const PracticeSummaryCard = forwardRef<HTMLDivElement, PracticeSummaryCar
                     return index === 0 ? (
                       <MoodIcon key={moodStat.mood} className="w-14 h-14 relative z-10" />
                     ) : (
-                      <MoodIcon key={moodStat.mood} className="w-10 h-10 absolute -top-1 -right-6 z-0" />
+                      <MoodIcon key={moodStat.mood} className="w-10 h-10 absolute -top-1 -right-4 z-0" />
                     );
                   })}
                 </div>

--- a/apps/product/src/components/practice/summary/practice-summary-page.tsx
+++ b/apps/product/src/components/practice/summary/practice-summary-page.tsx
@@ -208,7 +208,7 @@ export function PracticeSummaryPage({ summary }: PracticeSummaryPageProps) {
             </Button>
           </div>
 
-          {/* 下載打卡圖片按鈕 */}
+          {/* 下載圖片按鈕 */}
           <Button
             type="button"
             variant="ctaOrange"
@@ -217,7 +217,7 @@ export function PracticeSummaryPage({ summary }: PracticeSummaryPageProps) {
             disabled={isGenerating}
           >
             <Download className="size-4.5" />
-            {isGenerating ? "正在生成圖片..." : "下載打卡圖片"}
+            {isGenerating ? "正在生成圖片..." : "下載圖片"}
           </Button>
         </motion.section>
 

--- a/packages/shared/src/lib/capture-element-as-image.ts
+++ b/packages/shared/src/lib/capture-element-as-image.ts
@@ -83,7 +83,7 @@ const cropImage = async (
           options.height
         );
 
-        const croppedDataUrl = canvas.toDataURL("image/jpeg", 0.95);
+        const croppedDataUrl = canvas.toDataURL("image/png");
 
         resolve({
           src: croppedDataUrl,
@@ -108,10 +108,9 @@ export const captureElementAsImage = async (
   cropOptions?: CropOptions
 ): Promise<CapturedImageData | null> => {
   try {
-    const { toJpeg } = await import("html-to-image");
+    const { toPng } = await import("html-to-image");
     const devicePixelRatio = window.devicePixelRatio || 1;
-    const dataUrl = await toJpeg(element, {
-      quality: 0.95,
+    const dataUrl = await toPng(element, {
       pixelRatio: devicePixelRatio,
       // 添加 cacheBust 繞過 Cloudflare 快取，確保獲取帶有 CORS headers 的回應
       cacheBust: true,


### PR DESCRIPTION
## Why is this necessary?

This change addresses two main improvements:

1. **Access Control**: The check-in detail page should only allow the practice owner to submit check-ins. Currently, any user viewing the page can submit check-ins, which is a security/permission issue.

2. **Image Export Quality**: The summary card image export was using JPEG format with compression, which can result in quality loss. PNG format provides lossless compression and better quality for the summary card visualization.

## How does it address?

### Access Control Implementation
- Added `useCurrentUser()` hook to fetch the current user's data
- Implemented ownership verification by comparing the practice owner's ID with the current user's ID
- Conditionally render the check-in submission footer only if the user is the practice owner
- This prevents unauthorized users from submitting check-ins

### Image Export Format Improvement
- Changed image capture from JPEG (quality 0.95) to PNG format in `captureElementAsImage()`
- Updated the `html-to-image` import from `toJpeg` to `toPng`
- Changed downloaded file extension from `.jpg` to `.png`
- Adjusted mood icon positioning in the summary card for better visual alignment (right padding and spacing adjustments)
- Updated button label from "下載打卡圖片" to "下載圖片" for consistency

### Files Modified
- `apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx`: Added ownership check
- `packages/shared/src/lib/capture-element-as-image.ts`: Changed to PNG export
- `apps/product/src/components/practice/summary/practice-summary-card.tsx`: Adjusted mood icon positioning
- `apps/product/src/components/practice/summary/practice-summary-page.tsx`: Updated button label
- `apps/product/src/components/practice/summary/hooks/use-practice-summary-image.tsx`: Updated file extension

## Test Plan

- Verify that non-owners cannot see the check-in submission button on the detail page
- Verify that practice owners can still submit check-ins normally
- Verify that exported summary images are in PNG format with proper quality
- Verify that mood icons display correctly without overlapping in the summary card

https://claude.ai/code/session_013xmqZbse8Mziw8SaNSQifp