### PR TITLE
fix: remove 居住地 from account settings and fix resource deletion

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -67,9 +67,7 @@ const convertFormValuesToApiRequest = (
     request.practiceTimePeriods = practiceTimePeriods;
   }
 
-  if (values.tags && values.tags.length > 0) {
-    request.tags = values.tags;
-  }
+  request.tags = values.tags || [];
 
   request.resources = (values.resources || []).map((resource) => ({
     name: resource.name,

--- a/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/edit/page.tsx
@@ -71,12 +71,10 @@ const convertFormValuesToApiRequest = (
     request.tags = values.tags;
   }
 
-  if (values.resources && values.resources.length > 0) {
-    request.resources = values.resources.map((resource) => ({
-      name: resource.name,
-      url: resource.url || undefined,
-    }));
-  }
+  request.resources = (values.resources || []).map((resource) => ({
+    name: resource.name,
+    url: resource.url || undefined,
+  }));
 
   if (values.customTiming) {
     request.otherContext = values.customTiming;

--- a/apps/product/src/components/settings/account/account-form.tsx
+++ b/apps/product/src/components/settings/account/account-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { type UpdateUserRequest, useCities, useCurrentUser, useUserMutations } from "@daodao/api";
-import { useLocale } from "@daodao/i18n";
+import { type UpdateUserRequest, useCurrentUser, useUserMutations } from "@daodao/api";
 import { Button } from "@daodao/ui/components/button";
 import { Form } from "@daodao/ui/components/form";
 import { toast } from "@daodao/ui/components/sonner";
@@ -24,25 +23,15 @@ import {
 
 export const AccountForm = () => {
   const router = useRouter();
-  const locale = useLocale();
   const { data: userData, isLoading, error: userError } = useCurrentUser();
   const { updateCurrentUser } = useUserMutations();
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  // 使用 search 參數精確搜尋用戶的城市，以獲取 countryCode
-  const userLocation = userData?.data?.location;
-  const { data: citiesData } = useCities({
-    search: userLocation || undefined,
-    locale: locale === "en" ? "en" : "zh-TW",
-  });
 
   const form = useForm<AccountFormValues>({
     resolver: zodResolver(accountFormSchema),
     defaultValues: {
       email: "",
       birthday: undefined,
-      country: "",
-      location: "",
       position: [],
       educationStage: "",
       professionalFields: [],
@@ -52,31 +41,19 @@ export const AccountForm = () => {
 
   // 當用戶資料載入完成時，更新表單預設值
   useEffect(() => {
-    // 確保 userData 和 citiesData 都載入完成後才初始化表單
-    if (userData?.data && citiesData?.data) {
+    if (userData?.data) {
       const user = userData.data;
-
-      // 根據 location 找到對應的 countryCode
-      let countryCode = "";
-      if (user.location) {
-        const city = citiesData.data.find((c) => c.code === user.location);
-        if (city?.countryCode) {
-          countryCode = city.countryCode;
-        }
-      }
 
       form.reset({
         email: user.email || "",
         birthday: user.birthDay ? parse(user.birthDay, "yyyy-MM-dd", new Date()) : undefined,
-        country: countryCode,
-        location: user.location || "",
         position: user.positionList || [],
         educationStage: user.educationStage || "",
         professionalFields: user.professionalField || [],
         explorationFields: user.interestList || [],
       });
     }
-  }, [userData, citiesData, form.reset]);
+  }, [userData, form.reset]);
 
   const handleSubmit = async (values: AccountFormValues) => {
     setIsSubmitting(true);
@@ -85,7 +62,6 @@ export const AccountForm = () => {
       // 準備 API 請求資料
       const updateData: {
         birthDay?: string;
-        location?: string;
         positionList?: string[];
         educationStage?: string;
         professionalField?: string[];
@@ -95,11 +71,6 @@ export const AccountForm = () => {
       // 轉換生日
       if (values.birthday) {
         updateData.birthDay = format(values.birthday, "yyyy-MM-dd");
-      }
-
-      // 居住地（城市代碼）
-      if (values.location) {
-        updateData.location = values.location;
       }
 
       // 身份（直接對應資料庫值，允許多選）
@@ -133,7 +104,6 @@ export const AccountForm = () => {
                 // 將錯誤設置到對應的表單欄位
                 const formFieldMap: Record<string, keyof AccountFormValues> = {
                   birthDay: "birthday",
-                  location: "location",
                   positionList: "position",
                   educationStage: "educationStage",
                   professionalField: "professionalFields",

--- a/apps/product/src/components/settings/account/personal-info-section.tsx
+++ b/apps/product/src/components/settings/account/personal-info-section.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useCities, useCountries } from "@daodao/api";
-import { useLocale } from "@daodao/i18n";
 import {
   FormControl,
   FormField,
@@ -19,7 +17,7 @@ import {
 } from "@daodao/ui/components/select";
 import { cn } from "@daodao/ui/lib/utils";
 import { format } from "date-fns";
-import { Calendar, Mail, MapPin } from "lucide-react";
+import { Calendar, Mail } from "lucide-react";
 import type { UseFormReturn } from "react-hook-form";
 import type { AccountFormValues } from "./schema";
 
@@ -34,27 +32,6 @@ interface PersonalInfoSectionProps {
 }
 
 export const PersonalInfoSection = ({ form, educationStageOptions }: PersonalInfoSectionProps) => {
-  const locale = useLocale();
-  const selectedCountry = form.watch("country");
-
-  // 獲取國家列表
-  const { data: countriesData, isLoading: isLoadingCountries } = useCountries();
-
-  // 根據選擇的國家獲取城市列表（傳入 locale 以支援多語系）
-  const { data: citiesData, isLoading: isLoadingCities } = useCities({
-    country: selectedCountry || undefined,
-    locale: locale === "en" ? "en" : "zh-TW",
-  });
-
-  const countries = (countriesData?.data ?? []).filter((c) => c.code);
-  const cities = (citiesData?.data ?? []).filter((c) => c.code);
-
-  // 當國家變更時，清空城市選擇
-  const handleCountryChange = (value: string) => {
-    form.setValue("country", value);
-    form.setValue("location", "");
-  };
-
   return (
     <div className="bg-white rounded-xl p-4 space-y-4">
       {/* Email */}
@@ -106,102 +83,6 @@ export const PersonalInfoSection = ({ form, educationStageOptions }: PersonalInf
             </FormItem>
           );
         }}
-      />
-
-      {/* 居住地 - 國家 */}
-      <FormField
-        control={form.control}
-        name="country"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel className="block font-medium text-text-dark mb-3">居住地</FormLabel>
-            <FormControl>
-              <div className="relative">
-                <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-light-gray z-10" />
-                <Select
-                  value={field.value || ""}
-                  onValueChange={handleCountryChange}
-                  disabled={field.disabled || isLoadingCountries}
-                >
-                  <SelectTrigger
-                    className={cn(
-                      "w-full h-10 pl-11 pr-4 py-2 text-left font-normal text-sm",
-                      "border border-bg-gray hover:border-logo-cyan bg-background rounded-lg",
-                      "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
-                      form.formState.errors.country && "border-red",
-                      "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray",
-                      "data-placeholder:text-light-gray"
-                    )}
-                    aria-invalid={!!form.formState.errors.country}
-                  >
-                    <SelectValue placeholder={isLoadingCountries ? "載入中..." : "請選擇國家"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {countries.map((country) => (
-                      <SelectItem key={country.code} value={country.code}>
-                        {locale === "en" ? country.nameEn || country.name : country.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      {/* 居住地 - 城市 */}
-      <FormField
-        control={form.control}
-        name="location"
-        render={({ field }) => (
-          <FormItem>
-            <FormControl>
-              <div className="relative">
-                <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 size-5 text-light-gray z-10" />
-                <Select
-                  value={field.value || ""}
-                  onValueChange={(value) => {
-                    field.onChange(value);
-                    field.onBlur();
-                  }}
-                  disabled={field.disabled || !selectedCountry || isLoadingCities}
-                >
-                  <SelectTrigger
-                    className={cn(
-                      "w-full h-10 pl-11 pr-4 py-2 text-left font-normal text-sm",
-                      "border border-bg-gray hover:border-logo-cyan bg-background rounded-lg",
-                      "focus-visible:border-2 focus-visible:border-logo-cyan focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[#DEF5F5]",
-                      form.formState.errors.location && "border-red",
-                      "disabled:cursor-not-allowed disabled:border-bg-gray disabled:bg-very-light-gray",
-                      "data-placeholder:text-light-gray"
-                    )}
-                    aria-invalid={!!form.formState.errors.location}
-                  >
-                    <SelectValue
-                      placeholder={
-                        !selectedCountry
-                          ? "請先選擇國家"
-                          : isLoadingCities
-                            ? "載入中..."
-                            : "請選擇城市"
-                      }
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {cities.map((city) => (
-                      <SelectItem key={city.code} value={city.code}>
-                        {city.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
       />
 
       {/* 教育階段 */}

--- a/apps/product/src/components/settings/account/schema.ts
+++ b/apps/product/src/components/settings/account/schema.ts
@@ -21,8 +21,6 @@ export const accountFormSchema = z.object({
       { message: "必須年滿16歲" }
     )
     .optional(),
-  country: z.string().optional(),
-  location: z.string().optional(),
   position: z.array(z.string()).min(1, "請至少選擇一個身份").default([]),
   educationStage: z.string().min(1, "請選擇教育階段"),
   professionalFields: z.array(z.string()).max(5, "最多只能選擇5個專業領域").default([]),


### PR DESCRIPTION
- Remove 居住地 (country/city) fields from account settings since public
  info already has the same field
- Remove related country/location state, API calls, and form handling
  from account-form.tsx and personal-info-section.tsx
- Remove country/location fields from account form schema

- Fix resource deletion not working after editing a practice
  The resources array was only sent to the API when non-empty, causing
  deletions to be silently ignored. Always send the resources array
  (including empty) so the API can replace/clear resources correctly.

https://claude.ai/code/session_01FPb149vaxu56ymTqmHMWeH