### PR TITLE
Feat/practice detail page

### DIFF
--- a/.github/workflows/linode-cd.yml
+++ b/.github/workflows/linode-cd.yml
@@ -604,7 +604,10 @@ jobs:
           DEPLOY_WEBSITE: ${{ needs.build-website.result == 'success' }}
           DEPLOY_PRODUCT: ${{ needs.build-product.result == 'success' }}
         run: |
-          ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=3 root@$LINODE_INSTANCE_IP "
+          DEPLOY_WEBSITE=${{ env.DEPLOY_WEBSITE }}
+          DEPLOY_PRODUCT=${{ env.DEPLOY_PRODUCT }}
+          APP_ENV=${{ env.APP_ENV }}
+          ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=3 root@$LINODE_INSTANCE_IP << ENDSSH
             set -e
             echo '=== Deployment Verification Started ==='
 
@@ -615,45 +618,44 @@ jobs:
             echo 'Memory Usage:' && free -h
             echo 'Disk Usage:' && df -h /
 
-            if [ \"${{ env.DEPLOY_WEBSITE }}\" = \"true\" ]; then
+            if [ "$DEPLOY_WEBSITE" = "true" ]; then
               echo '=== Verifying Website ==='
-              WEBSITE_STATUS=\$(docker inspect --format='{{.State.Status}}' ${{ env.APP_ENV }}_website 2>/dev/null || echo 'not found')
-              WEBSITE_HEALTH=\$(docker inspect --format='{{.State.Health.Status}}' ${{ env.APP_ENV }}_website 2>/dev/null || echo 'no health check')
+              WEBSITE_STATUS=\$(docker inspect --format='{{.State.Status}}' ${APP_ENV}_website 2>/dev/null || echo 'not found')
+              WEBSITE_HEALTH=\$(docker inspect --format='{{.State.Health.Status}}' ${APP_ENV}_website 2>/dev/null || echo 'no health check')
               echo "Container Status: \$WEBSITE_STATUS"
               echo "Health Status: \$WEBSITE_HEALTH"
 
               if [ "\$WEBSITE_STATUS" != "running" ]; then
                 echo "❌ Website container is not running"
-                # 嘗試讀取日誌（如果支援的話）
-                docker logs ${{ env.APP_ENV }}_website --tail=20 2>/dev/null || echo "Logs not available (logging driver may not support reading)"
+                docker logs ${APP_ENV}_website --tail=20 2>/dev/null || echo 'Logs not available'
                 exit 1
               fi
 
               if [ "\$WEBSITE_HEALTH" = "unhealthy" ]; then
                 echo "❌ Website container is unhealthy"
-                docker logs ${{ env.APP_ENV }}_website --tail=20 2>/dev/null || echo "Logs not available"
+                docker logs ${APP_ENV}_website --tail=20 2>/dev/null || echo 'Logs not available'
                 exit 1
               fi
 
               echo "✅ Website is running and healthy"
             fi
 
-            if [ \"${{ env.DEPLOY_PRODUCT }}\" = \"true\" ]; then
+            if [ "$DEPLOY_PRODUCT" = "true" ]; then
               echo '=== Verifying Product ==='
-              PRODUCT_STATUS=\$(docker inspect --format='{{.State.Status}}' ${{ env.APP_ENV }}_product 2>/dev/null || echo 'not found')
-              PRODUCT_HEALTH=\$(docker inspect --format='{{.State.Health.Status}}' ${{ env.APP_ENV }}_product 2>/dev/null || echo 'no health check')
+              PRODUCT_STATUS=\$(docker inspect --format='{{.State.Status}}' ${APP_ENV}_product 2>/dev/null || echo 'not found')
+              PRODUCT_HEALTH=\$(docker inspect --format='{{.State.Health.Status}}' ${APP_ENV}_product 2>/dev/null || echo 'no health check')
               echo "Container Status: \$PRODUCT_STATUS"
               echo "Health Status: \$PRODUCT_HEALTH"
 
               if [ "\$PRODUCT_STATUS" != "running" ]; then
                 echo "❌ Product container is not running"
-                docker logs ${{ env.APP_ENV }}_product --tail=20 2>/dev/null || echo "Logs not available (logging driver may not support reading)"
+                docker logs ${APP_ENV}_product --tail=20 2>/dev/null || echo 'Logs not available'
                 exit 1
               fi
 
               if [ "\$PRODUCT_HEALTH" = "unhealthy" ]; then
                 echo "❌ Product container is unhealthy"
-                docker logs ${{ env.APP_ENV }}_product --tail=20 2>/dev/null || echo "Logs not available"
+                docker logs ${APP_ENV}_product --tail=20 2>/dev/null || echo 'Logs not available'
                 exit 1
               fi
 
@@ -661,7 +663,7 @@ jobs:
             fi
 
             echo '=== Deployment Verification Complete ==='
-          "
+          ENDSSH
 
   # ===== Discord 通知 =====
   notify:

--- a/apps/product/src/app/[locale]/auth/login/page.tsx
+++ b/apps/product/src/app/[locale]/auth/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAuth } from "@daodao/auth";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 /**
@@ -9,8 +9,9 @@ import { useEffect } from "react";
  * 自動打開登入 Dialog，並處理 redirect 參數
  */
 export default function LoginPage() {
-  const { openLoginDialog } = useAuth();
+  const { openLoginDialog, isAuthenticated, isLoading } = useAuth();
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   useEffect(() => {
     // 從 URL 參數中取得 redirect URL
@@ -18,6 +19,15 @@ export default function LoginPage() {
     // 打開登入 Dialog，強制不可關閉
     openLoginDialog({ redirectUrl, source: "app", dismissible: false });
   }, [searchParams, openLoginDialog]);
+
+  // Android Chrome Custom Tab 場景：CCT 完成 OAuth 後主 tab 會觸發 checkAuth()
+  // 認證成功後跳轉到目標頁面
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      const redirectUrl = searchParams.get("redirect") || "/";
+      router.push(redirectUrl);
+    }
+  }, [isLoading, isAuthenticated, searchParams, router]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/apps/product/src/app/global-provider.tsx
+++ b/apps/product/src/app/global-provider.tsx
@@ -52,6 +52,7 @@ function GlobalProvider({
                         "^/auth/callback",
                         "^/auth/onboarding",
                         "^/auth/verify-email(/.*)?$",
+                        "^/auth/error",
                         "^/users/",
                         "^/practices/[^/]+$",
                       ]}

--- a/apps/product/src/components/check-in/reactions/comment-section.tsx
+++ b/apps/product/src/components/check-in/reactions/comment-section.tsx
@@ -8,7 +8,9 @@ import { useDialog } from "@daodao/ui/hooks/use-dialog";
 import { cn } from "@daodao/ui/lib/utils";
 import { MoreHorizontal, Pencil, Send, Trash2 } from "lucide-react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { upsertReaction, removeReaction, useReactions } from "@daodao/api";
+import type { ReactionTypeValue } from "@daodao/api";
 import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
 import { ReactionPickerButton } from "./reaction-picker-button";
 
@@ -84,8 +86,36 @@ function CommentBubble({
   const [menuOpen, setMenuOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(comment.content);
-  const [commentReactions, setCommentReactions] = useState<ReactionTypeType[]>([]);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  const commentNumericId = Number(comment.id);
+  const { data: reactionsData, mutate: mutateReactions } = useReactions({
+    targetType: "comment",
+    targetId: commentNumericId,
+  });
+  const [, startReactionTransition] = useTransition();
+
+  const currentUserReaction = (reactionsData?.data?.currentUserReaction ?? null) as ReactionTypeType | null;
+  const commentReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
+
+  const handleCommentReactionToggle = useCallback(
+    (type: ReactionTypeType) => {
+      const isSelected = currentUserReaction === type;
+      startReactionTransition(async () => {
+        if (isSelected) {
+          await removeReaction({ targetType: "comment", targetId: commentNumericId });
+        } else {
+          await upsertReaction({
+            targetType: "comment",
+            targetId: commentNumericId,
+            reactionType: type as ReactionTypeValue,
+          });
+        }
+        await mutateReactions();
+      });
+    },
+    [currentUserReaction, commentNumericId, mutateReactions],
+  );
   const { openWarningDialog } = useDialog();
 
   useEffect(() => {
@@ -257,9 +287,7 @@ function CommentBubble({
           <div className="flex items-center gap-3 mt-1.5">
             <ReactionPickerButton
               selectedReactions={commentReactions}
-              onToggle={(type) =>
-                setCommentReactions((prev) => (prev.includes(type) ? [] : [type]))
-              }
+              onToggle={handleCommentReactionToggle}
               variant="comment"
             />
             {!isReply && onReply && (

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useExtractOgImage } from "@daodao/api";
+import { useExtractOgImage, useReactions, upsertReaction, removeReaction } from "@daodao/api";
+import type { ReactionTypeValue } from "@daodao/api";
 import {
   BookSvg,
   ChartColumnIncreasingSvg,
@@ -18,7 +19,7 @@ import { useDialog } from "@daodao/ui/hooks/use-dialog";
 import { cn } from "@daodao/ui/lib/utils";
 import { Archive, ChevronDown, ChevronUp, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { CheckInRecordCard, CheckInStack } from "@/components/check-in";
 import { CommentSection, ReactionPickerButton, type IComment } from "@/components/check-in/reactions";
 import { LottieEmoji } from "@/components/check-in/reactions/lottie-emoji";
@@ -434,8 +435,36 @@ export function PracticeDetailShell({
   const [activeTab, setActiveTab] = useState<TabType>("comments");
   const [infoExpanded, setInfoExpanded] = useState(false);
   const [practiceMenuOpen, setPracticeMenuOpen] = useState(false);
-  const [headerReactions, setHeaderReactions] = useState<ReactionTypeType[]>([]);
   const commentsRef = useRef<HTMLDivElement>(null);
+
+  const numericPracticeId = Number(practiceId);
+  const { data: reactionsData, mutate: mutateReactions } = useReactions({
+    targetType: "practice",
+    targetId: numericPracticeId,
+  });
+  const [, startReactionTransition] = useTransition();
+
+  const currentUserReaction = (reactionsData?.data?.currentUserReaction ?? null) as ReactionTypeType | null;
+  const headerReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
+
+  const handleHeaderReactionToggle = useCallback(
+    (type: ReactionTypeType) => {
+      const isSelected = currentUserReaction === type;
+      startReactionTransition(async () => {
+        if (isSelected) {
+          await removeReaction({ targetType: "practice", targetId: numericPracticeId });
+        } else {
+          await upsertReaction({
+            targetType: "practice",
+            targetId: numericPracticeId,
+            reactionType: type as ReactionTypeValue,
+          });
+        }
+        await mutateReactions();
+      });
+    },
+    [currentUserReaction, numericPracticeId, mutateReactions],
+  );
   const { open: openSheet } = useSheetManager();
   const { openWarningDialog } = useDialog();
 
@@ -705,9 +734,7 @@ export function PracticeDetailShell({
             <div className="flex-1 flex justify-center rounded-xl hover:bg-gray-100 transition-colors py-1">
               <ReactionPickerButton
                 selectedReactions={headerReactions}
-                onToggle={(type) =>
-                  setHeaderReactions((prev) => (prev.includes(type) ? [] : [type]))
-                }
+                onToggle={handleHeaderReactionToggle}
                 variant="card"
               />
             </div>

--- a/apps/product/src/components/practice/shared/practice-overview-card.tsx
+++ b/apps/product/src/components/practice/shared/practice-overview-card.tsx
@@ -6,6 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avata
 import { Badge } from "@daodao/ui/components/badge";
 import type { ManualPracticeFormValues } from "../create/manual/schema";
 import { CircularProgress } from "./circular-progress";
+import { ReactionSection } from "@/components/social";
 
 interface CreatorInfo {
   id: string;
@@ -20,10 +21,12 @@ interface PracticeOverviewCardProps {
   durationMinutes: ManualPracticeFormValues["durationMinutes"];
   tags?: ManualPracticeFormValues["tags"];
   // 詳情頁專用屬性
-  progress?: number; // 進度值
-  showProgress?: boolean; // 是否顯示進度條
+  progress?: number;
+  showProgress?: boolean;
   // 公開頁面顯示建立者資訊
   creator?: CreatorInfo;
+  // 快速反應 + 留言（提供 practiceId 時顯示）
+  practiceId?: number;
 }
 
 export const PracticeOverviewCard = ({
@@ -34,6 +37,7 @@ export const PracticeOverviewCard = ({
   progress,
   showProgress = false,
   creator,
+  practiceId,
 }: PracticeOverviewCardProps) => {
   return (
     <div className="relative bg-white rounded-lg p-4 mb-4 shadow-sm">
@@ -107,6 +111,14 @@ export const PracticeOverviewCard = ({
           </div>
         )}
       </div>
+
+      {/* 反應列 */}
+      {practiceId !== undefined && (
+        <ReactionSection
+          targetType="practice"
+          targetId={practiceId}
+        />
+      )}
     </div>
   );
 };

--- a/apps/product/src/components/practice/shared/reaction-aggregate-label.tsx
+++ b/apps/product/src/components/practice/shared/reaction-aggregate-label.tsx
@@ -1,0 +1,39 @@
+import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
+
+interface ReactionAggregateLabelProps {
+  type: ReactionTypeType;
+  count: number;
+  latestActorName?: string | null;
+}
+
+/**
+ * 反應聚合顯示文字
+ * 例：「王小明 與其他 5 人覺得很有啟發」
+ */
+export function ReactionAggregateLabel({ type, count, latestActorName }: ReactionAggregateLabelProps) {
+  if (count === 0) return null;
+
+  const config = REACTION_CONFIG[type];
+
+  if (count === 1 && latestActorName) {
+    return (
+      <span className="text-xs text-text-dark/60">
+        {latestActorName} {config.label}
+      </span>
+    );
+  }
+
+  if (latestActorName) {
+    return (
+      <span className="text-xs text-text-dark/60">
+        {latestActorName} 與其他 {count - 1} 人{config.label}
+      </span>
+    );
+  }
+
+  return (
+    <span className="text-xs text-text-dark/60">
+      {count} 人{config.label}
+    </span>
+  );
+}

--- a/apps/product/src/components/social/comment-input.tsx
+++ b/apps/product/src/components/social/comment-input.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useRef, useEffect, useCallback, useState } from "react";
+import { Button } from "@daodao/ui/components/button";
+import { Send } from "lucide-react";
+import { cn } from "@daodao/ui/lib/utils";
+import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CommentInputProps {
+  /** 目前選取的反應類型，決定 placeholder 文字 */
+  reactionType?: ReactionTypeType | null;
+  onSubmit: (content: string, reactionType?: ReactionTypeType | null) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * 留言輸入框
+ * - 根據 reactionType 動態切換 placeholder 引導文字
+ * - 當 reactionType 改變時自動聚焦
+ */
+export function CommentInput({ reactionType, onSubmit, disabled, className }: CommentInputProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const prevReactionTypeRef = useRef<ReactionTypeType | null | undefined>(undefined);
+
+  // reactionType 改變時聚焦輸入框
+  useEffect(() => {
+    if (reactionType && reactionType !== prevReactionTypeRef.current) {
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        el.focus();
+        const len = el.value.length;
+        el.setSelectionRange(len, len);
+      });
+    }
+    prevReactionTypeRef.current = reactionType;
+  }, [reactionType]);
+
+  const placeholder = reactionType
+    ? REACTION_CONFIG[reactionType].placeholder
+    : "寫下你的留言...";
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed, reactionType);
+    setValue("");
+  }, [value, reactionType, onSubmit]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className={cn("flex gap-2 items-center", className)}>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        rows={1}
+        disabled={disabled}
+        className="flex-1 resize-none rounded-lg border border-[#E4EAE9] bg-white px-4 py-2 text-sm text-[#295E5C] placeholder:text-[#9FB5B8] focus:outline-none focus:border-logo-cyan transition-colors h-10 disabled:opacity-50"
+      />
+      <Button
+        type="button"
+        size="icon"
+        onClick={handleSubmit}
+        disabled={!value.trim() || disabled}
+        className="shrink-0 size-10 rounded-full bg-logo-cyan hover:bg-logo-cyan/80 disabled:opacity-40"
+      >
+        <Send className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/product/src/components/social/index.ts
+++ b/apps/product/src/components/social/index.ts
@@ -1,0 +1,4 @@
+export { ReactionSection } from "./reaction-section";
+export type { ReactionSectionProps } from "./reaction-section";
+export { CommentInput } from "./comment-input";
+export type { CommentInputProps } from "./comment-input";

--- a/apps/product/src/components/social/reaction-section.tsx
+++ b/apps/product/src/components/social/reaction-section.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useCallback, useTransition } from "react";
+import { upsertReaction, removeReaction, useReactions } from "@daodao/api";
+import type { ReactionTypeValue } from "@daodao/api";
+import { ReactionBar, ReactionPickerButton } from "@/components/check-in/reactions";
+import type { IReactionCount } from "@/components/check-in/reactions";
+import type { ReactionTypeType } from "@/constants/reaction-type";
+
+export interface ReactionSectionProps {
+  /** 目標類型，目前支援 'practice' */
+  targetType: "practice";
+  /** 目標的內部 ID */
+  targetId: number;
+  /** 反應變更回調（可選） */
+  onReactionChange?: (type: ReactionTypeType | null) => void;
+}
+
+/**
+ * 通用反應列元件（Quick Reactions）
+ *
+ * 顯示 ReactionPickerButton + ReactionBar，並直接呼叫 reactions API。
+ * 與留言區完全分開，可獨立使用於任何支援 reactions 的目標。
+ */
+export function ReactionSection({ targetType, targetId, onReactionChange }: ReactionSectionProps) {
+  const { data, mutate } = useReactions({ targetType, targetId });
+  const [, startTransition] = useTransition();
+
+  const reactions: IReactionCount[] = (data?.data?.reactions ?? []).map((r) => ({
+    type: r.type as ReactionTypeType,
+    count: r.count,
+    latestActorName: r.latestActorName ?? undefined,
+  }));
+
+  const currentUserReaction = (data?.data?.currentUserReaction ?? null) as ReactionTypeType | null;
+  const selectedReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
+
+  const handleToggle = useCallback(
+    (type: ReactionTypeType) => {
+      const isSelected = currentUserReaction === type;
+
+      startTransition(async () => {
+        if (isSelected) {
+          await removeReaction({ targetType, targetId });
+          onReactionChange?.(null);
+        } else {
+          await upsertReaction({
+            targetType,
+            targetId,
+            reactionType: type as ReactionTypeValue,
+          });
+          onReactionChange?.(type);
+        }
+        await mutate();
+      });
+    },
+    [currentUserReaction, targetType, targetId, mutate, onReactionChange],
+  );
+
+  return (
+    <div className="flex items-center gap-3 border-t border-bg-gray pt-3 mt-3">
+      <ReactionPickerButton
+        selectedReactions={selectedReactions}
+        onToggle={handleToggle}
+        variant="card"
+      />
+      <ReactionBar
+        reactions={reactions}
+        selectedReactions={selectedReactions}
+        onReactionClick={handleToggle}
+        className="flex-wrap flex-1"
+      />
+    </div>
+  );
+}

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -25,6 +25,9 @@ export * from "./og-image-hooks";
 // Practice Service
 export * from "./practice";
 export * from "./practice-hooks";
+// Reaction Service
+export * from "./reaction";
+export * from "./reaction-hooks";
 // Resource Service
 export * from "./resource";
 export * from "./resource-hooks";

--- a/packages/api/src/services/reaction-hooks.ts
+++ b/packages/api/src/services/reaction-hooks.ts
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * Reaction API Hooks
+ * 提供快速反應相關的 React Hooks（用於 Client Components）
+ */
+
+import { useQuery } from "../hooks";
+import type { IGetReactionsParams } from "./reaction";
+
+// ============================================================================
+// Query Hooks
+// ============================================================================
+
+/**
+ * 取得目標反應計數的 Hook
+ */
+export const useReactions = (params: IGetReactionsParams) => {
+  return useQuery("/api/v1/reactions", {
+    params: {
+      query: {
+        targetType: params.targetType,
+        targetId: params.targetId,
+      },
+    },
+  });
+};

--- a/packages/api/src/services/reaction.ts
+++ b/packages/api/src/services/reaction.ts
@@ -1,0 +1,62 @@
+/**
+ * Reaction API Service
+ * 提供快速反應相關的 API 調用函數
+ */
+
+import { client } from "../client";
+import type { components, paths } from "../types";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type GetReactionsQuery = NonNullable<
+  paths["/api/v1/reactions"]["get"]["parameters"]["query"]
+>;
+
+export type ReactionTargetType = GetReactionsQuery["targetType"];
+
+export type ReactionTypeValue = components["schemas"]["UpsertReactionRequest"]["reactionType"];
+
+export type GetReactionsResponse =
+  paths["/api/v1/reactions"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type UpsertReactionRequest = components["schemas"]["UpsertReactionRequest"];
+export type RemoveReactionRequest = components["schemas"]["RemoveReactionRequest"];
+
+export interface IGetReactionsParams {
+  targetType: ReactionTargetType;
+  targetId: number;
+}
+
+// ============================================================================
+// Client Functions
+// ============================================================================
+
+/**
+ * 取得目標的反應計數
+ */
+export const getReactions = async (params: IGetReactionsParams) => {
+  return client.GET("/api/v1/reactions", {
+    params: {
+      query: {
+        targetType: params.targetType,
+        targetId: params.targetId,
+      },
+    },
+  });
+};
+
+/**
+ * 新增或更換反應
+ */
+export const upsertReaction = async (data: UpsertReactionRequest) => {
+  return client.POST("/api/v1/reactions", { body: data });
+};
+
+/**
+ * 取消反應
+ */
+export const removeReaction = async (data: RemoveReactionRequest) => {
+  return client.DELETE("/api/v1/reactions", { body: data });
+};

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -10656,7 +10656,7 @@ export interface paths {
             parameters: {
                 query: {
                     /** @description 查詢的目標類型 */
-                    targetType: "post" | "resource" | "note" | "outcome" | "review" | "circle" | "idea" | "portfolio" | "practice";
+                    targetType: "post" | "resource" | "note" | "outcome" | "review" | "circle" | "idea" | "practice" | "portfolio";
                     /** @description 目標對象ID */
                     targetId: string;
                 };
@@ -11114,6 +11114,289 @@ export interface paths {
                 401: components["responses"]["UnauthorizedError"];
                 403: components["responses"]["ForbiddenError"];
                 404: components["responses"]["NotFoundError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/reactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得反應計數
+         * @description 取得指定目標的各類型反應計數與當前用戶狀態
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description 反應目標類型 */
+                    targetType: "practice" | "comment";
+                    /** @description 目標內部 ID */
+                    targetId: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得反應資料 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description Indicates successful API response
+                             * @enum {boolean}
+                             */
+                            success: true;
+                            data: components["schemas"]["GetReactionsResponse"] & unknown;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp of the response
+                             */
+                            timestamp: string;
+                            /**
+                             * @description Optional metadata about the response
+                             * @example {
+                             *       "searchQuery": "JavaScript教程",
+                             *       "searchTime": 45,
+                             *       "cacheHit": false,
+                             *       "processingTime": 123.5,
+                             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+                             *     }
+                             * @example {
+                             *       "categoryCounts": {
+                             *         "前端開發": 25,
+                             *         "後端開發": 18,
+                             *         "資料科學": 12
+                             *       },
+                             *       "filters": {
+                             *         "difficulty": "intermediate",
+                             *         "language": "zh-TW"
+                             *       }
+                             *     }
+                             */
+                            meta?: {
+                                /** @description Search query used for filtering results */
+                                searchQuery?: string;
+                                /** @description Time taken to execute the search query in milliseconds */
+                                searchTime?: number;
+                                /** @description Applied filters for the request */
+                                filters?: {
+                                    [key: string]: unknown;
+                                };
+                                /** @description Count of items per category */
+                                categoryCounts?: {
+                                    [key: string]: number;
+                                };
+                                /** @description Aggregated statistical data */
+                                aggregateData?: {
+                                    [key: string]: unknown;
+                                };
+                                /** @description Unique identifier for request tracking */
+                                requestId?: string;
+                                /** @description Whether the response was served from cache */
+                                cacheHit?: boolean;
+                                /** @description Total processing time in milliseconds */
+                                processingTime?: number;
+                            } & {
+                                [key: string]: unknown;
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        /**
+         * 新增或更換反應
+         * @description 對指定目標送出快速反應；同一用戶同一目標只保留一筆（UPSERT）
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpsertReactionRequest"];
+                };
+            };
+            responses: {
+                /** @description 反應已更新，回傳最新計數 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description Indicates successful API response
+                             * @enum {boolean}
+                             */
+                            success: true;
+                            data: components["schemas"]["GetReactionsResponse"] & unknown;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp of the response
+                             */
+                            timestamp: string;
+                            /**
+                             * @description Optional metadata about the response
+                             * @example {
+                             *       "searchQuery": "JavaScript教程",
+                             *       "searchTime": 45,
+                             *       "cacheHit": false,
+                             *       "processingTime": 123.5,
+                             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+                             *     }
+                             * @example {
+                             *       "categoryCounts": {
+                             *         "前端開發": 25,
+                             *         "後端開發": 18,
+                             *         "資料科學": 12
+                             *       },
+                             *       "filters": {
+                             *         "difficulty": "intermediate",
+                             *         "language": "zh-TW"
+                             *       }
+                             *     }
+                             */
+                            meta?: {
+                                /** @description Search query used for filtering results */
+                                searchQuery?: string;
+                                /** @description Time taken to execute the search query in milliseconds */
+                                searchTime?: number;
+                                /** @description Applied filters for the request */
+                                filters?: {
+                                    [key: string]: unknown;
+                                };
+                                /** @description Count of items per category */
+                                categoryCounts?: {
+                                    [key: string]: number;
+                                };
+                                /** @description Aggregated statistical data */
+                                aggregateData?: {
+                                    [key: string]: unknown;
+                                };
+                                /** @description Unique identifier for request tracking */
+                                requestId?: string;
+                                /** @description Whether the response was served from cache */
+                                cacheHit?: boolean;
+                                /** @description Total processing time in milliseconds */
+                                processingTime?: number;
+                            } & {
+                                [key: string]: unknown;
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                401: components["responses"]["UnauthorizedError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        /**
+         * 取消反應
+         * @description 刪除當前用戶對指定目標的反應
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RemoveReactionRequest"];
+                };
+            };
+            responses: {
+                /** @description 反應已刪除，回傳最新計數 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description Indicates successful API response
+                             * @enum {boolean}
+                             */
+                            success: true;
+                            data: components["schemas"]["GetReactionsResponse"] & unknown;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp of the response
+                             */
+                            timestamp: string;
+                            /**
+                             * @description Optional metadata about the response
+                             * @example {
+                             *       "searchQuery": "JavaScript教程",
+                             *       "searchTime": 45,
+                             *       "cacheHit": false,
+                             *       "processingTime": 123.5,
+                             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+                             *     }
+                             * @example {
+                             *       "categoryCounts": {
+                             *         "前端開發": 25,
+                             *         "後端開發": 18,
+                             *         "資料科學": 12
+                             *       },
+                             *       "filters": {
+                             *         "difficulty": "intermediate",
+                             *         "language": "zh-TW"
+                             *       }
+                             *     }
+                             */
+                            meta?: {
+                                /** @description Search query used for filtering results */
+                                searchQuery?: string;
+                                /** @description Time taken to execute the search query in milliseconds */
+                                searchTime?: number;
+                                /** @description Applied filters for the request */
+                                filters?: {
+                                    [key: string]: unknown;
+                                };
+                                /** @description Count of items per category */
+                                categoryCounts?: {
+                                    [key: string]: number;
+                                };
+                                /** @description Aggregated statistical data */
+                                aggregateData?: {
+                                    [key: string]: unknown;
+                                };
+                                /** @description Unique identifier for request tracking */
+                                requestId?: string;
+                                /** @description Whether the response was served from cache */
+                                cacheHit?: boolean;
+                                /** @description Total processing time in milliseconds */
+                                processingTime?: number;
+                            } & {
+                                [key: string]: unknown;
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                401: components["responses"]["UnauthorizedError"];
                 500: components["responses"]["InternalServerError"];
             };
         };
@@ -24353,7 +24636,7 @@ export interface components {
              * @example resource
              * @enum {string}
              */
-            targetType: "post" | "resource" | "note" | "outcome" | "review" | "circle" | "idea" | "portfolio" | "practice";
+            targetType: "post" | "resource" | "note" | "outcome" | "review" | "circle" | "idea" | "practice" | "portfolio";
             /**
              * @description 留言內容
              * @example 這個資源非常有用，謝謝分享！
@@ -24400,7 +24683,7 @@ export interface components {
              * @example outcome
              * @enum {string}
              */
-            targetType: "post" | "resource" | "note" | "outcome" | "review" | "circle" | "idea" | "portfolio" | "practice";
+            targetType: "post" | "resource" | "note" | "outcome" | "review" | "circle" | "idea" | "practice" | "portfolio";
             /**
              * @description 目標對象的唯一識別碼
              * @example 123e4567-e89b-12d3-a456-426614174000
@@ -26823,6 +27106,72 @@ export interface components {
              * @example 123
              */
             userId: string;
+        };
+        /** @description 單種反應的計數資訊 */
+        ReactionCount: {
+            /**
+             * @description 反應類型
+             * @example fire
+             */
+            type: string;
+            /**
+             * @description 計數
+             * @example 3
+             */
+            count: number;
+            /**
+             * @description 最新反應的用戶名稱
+             * @example 王小明
+             */
+            latestActorName: string | null;
+        };
+        /** @description 反應查詢回應 */
+        GetReactionsResponse: {
+            /** @description 各類型反應計數 */
+            reactions: components["schemas"]["ReactionCount"][];
+            /**
+             * @description 當前用戶的反應類型（未反應為 null）
+             * @example fire
+             */
+            currentUserReaction: string | null;
+        };
+        /** @description 新增或更換反應的請求資料 */
+        UpsertReactionRequest: {
+            /**
+             * @description 反應目標類型
+             * @example practice
+             * @enum {string}
+             */
+            targetType: "practice" | "comment";
+            /**
+             * @description 目標內部 ID
+             * @example 1
+             */
+            targetId: number;
+            /**
+             * @description 反應類型
+             * @example fire
+             * @example useful
+             * @example fire
+             * @example touched
+             * @example curious
+             * @enum {string}
+             */
+            reactionType: "useful" | "fire" | "touched" | "curious";
+        };
+        /** @description 刪除反應的請求資料 */
+        RemoveReactionRequest: {
+            /**
+             * @description 反應目標類型
+             * @example practice
+             * @enum {string}
+             */
+            targetType: "practice" | "comment";
+            /**
+             * @description 目標內部 ID
+             * @example 1
+             */
+            targetId: number;
         };
         AdminUserListQuery: {
             /**

--- a/packages/auth/src/hooks/use-redirect-after-login.ts
+++ b/packages/auth/src/hooks/use-redirect-after-login.ts
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
+import { getStorage, StorageEnum } from "@daodao/shared";
 import { decodeOAuthState, verifyAndConsumeOAuthState } from "../lib/auth-client";
 import { DEFAULT_REDIRECT_URL, ONBOARDING_URL } from "../lib/auth-constants";
 
@@ -30,6 +31,10 @@ export const useRedirectAfterLogin = () => {
   useEffect(() => {
     const stateParam = searchParams.get("state");
     const isNewUser = searchParams.get("isNewUser") === "true";
+
+    // 通知其他 tab/window OAuth 已完成（處理 Android Chrome Custom Tab 場景）
+    // CCT 與主 Chrome 共享 localStorage，主 tab 可以透過 storage event 偵測並重新驗證
+    getStorage<number>(StorageEnum.AuthSignal).set(Date.now());
 
     if (!stateParam) {
       // 沒有 state 參數，根據是否為新用戶決定跳轉

--- a/packages/auth/src/lib/auth-provider.tsx
+++ b/packages/auth/src/lib/auth-provider.tsx
@@ -351,6 +351,13 @@ export const AuthProvider = ({
    */
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
+      // Android Chrome Custom Tab 場景：CCT 完成 OAuth 後 callback 頁面會寫入此信號
+      // CCT 與主 Chrome 共享 localStorage，主 tab 的 storage event 會觸發，然後重新驗證
+      if (e.key === getStorageKey(StorageEnum.AuthSignal)) {
+        checkAuth();
+        return;
+      }
+
       // 檢查是否是使用者資訊的變化
       if (e.key === getStorageKey(StorageEnum.UserInfo)) {
         const newUserInfo = userInfoStorage.get();
@@ -369,7 +376,24 @@ export const AuthProvider = ({
 
     window.addEventListener("storage", handleStorageChange);
     return () => window.removeEventListener("storage", handleStorageChange);
-  }, [userInfoStorage, clearAuthState]);
+  }, [checkAuth, userInfoStorage, clearAuthState]);
+
+  /**
+   * Android Chrome Custom Tab 場景補充機制
+   * storage event 在 CCT → 主 tab 之間不可靠（CCT 是獨立 renderer process）
+   * 改用 visibilitychange：CCT 關閉後主 tab 重新可見時重新驗證
+   * 僅在未登入時才重新驗證，避免正常切換 tab 時發出多餘的 API 請求
+   */
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && !isAuthenticated) {
+        checkAuth();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [checkAuth, isAuthenticated]);
 
   /**
    * 路由保護：檢查當前路徑是否需要登入

--- a/packages/shared/src/lib/storage.ts
+++ b/packages/shared/src/lib/storage.ts
@@ -15,6 +15,8 @@ export enum StorageEnum {
   ManualPracticeDraft = "ManualPracticeDraft",
   /** 用於存儲 Action Maker 流程進度的 sessionStorage */
   ActionMaker = "ActionMaker",
+  /** 用於跨 tab 通知 OAuth 完成（Android Chrome Custom Tab 場景） */
+  AuthSignal = "AuthSignal",
 }
 
 const mapStorageKeyToStorageType: Record<StorageEnum, StorageType> = {
@@ -24,6 +26,7 @@ const mapStorageKeyToStorageType: Record<StorageEnum, StorageType> = {
   OAuthNonce: "sessionStorage",
   ManualPracticeDraft: "sessionStorage",
   ActionMaker: "sessionStorage",
+  AuthSignal: "localStorage",
 };
 
 export interface StorageInstance<T> {


### PR DESCRIPTION
## Why is this necessary?

- Android Chrome Custom Tab（CCT）完成 OAuth 後，主 tab 不一定能透過 `storage event` 得知登入完成，導致主 tab 停留在未登入狀態、需要手動重新整理
- 實踐卡片和留言只有 Reaction Picker 按鈕，但缺少完整的 Reaction 系統：沒有計數顯示、無法查詢/儲存/刪除 Reaction、留言也不支援 Reaction
- CI 部署驗證腳本（`linode-cd.yml`）中大量使用內嵌環境變數，可讀性差，維護困難

---

## How does it address?

### 1. OAuth 跨 Tab 認證改進（Android Chrome Custom Tab）

**功能說明：** 透過雙重機制解決 Android CCT OAuth 回調後主 tab 停留在未登入狀態的問題。

- 新增 `StorageEnum.AuthSignal`（存入 `localStorage`），OAuth 回調完成時由 `useRedirectAfterLogin` 寫入當前時間戳
- `AuthProvider` 的 `storage` event 監聽器新增對 `AuthSignal` 的處理：偵測到變化後立即呼叫 `checkAuth()`
- 新增 `visibilitychange` 監聽器作為補充機制：CCT 是獨立 renderer process，`storage event` 不可靠，改為主 tab 重新可見時（且未登入）自動重新驗證
- `/auth/login` 頁面新增 `isAuthenticated` 監聽，認證成功後自動跳轉至目標頁面（配合 CCT 回調流程）

**變更位置：**
- `packages/shared/src/lib/storage.ts` — 新增 `AuthSignal` enum（localStorage）
- `packages/auth/src/hooks/use-redirect-after-login.ts` — 寫入 `AuthSignal` 通知其他 tab
- `packages/auth/src/lib/auth-provider.tsx` — 監聽 `AuthSignal` storage event 與 `visibilitychange`
- `apps/product/src/app/[locale]/auth/login/page.tsx` — 認證後自動跳轉

### 2. Reaction 系統完整實作

**功能說明：** 建立完整的 Reaction API 服務層，並在實踐卡片和留言中整合 Reaction 功能。

- 新增 `reaction.ts`：`getReactions`、`upsertReaction`、`removeReaction` API 函式，支援 `practice` 和 `comment` 兩種目標類型
- 新增 `reaction-hooks.ts`：`useReactions` SWR hook，取得目標的 Reaction 計數與當前使用者的 Reaction
- 新增 `ReactionSection` 元件：整合 `ReactionPickerButton` + `ReactionBar`，直接呼叫 API，可獨立用於任何支援 Reaction 的目標
- 新增 `ReactionAggregateLabel` 元件：顯示 Reaction 類型、計數與最新按讚者名稱
- 新增 `CommentInput` 元件：留言輸入框（含 Reaction 選取支援）
- `CommentSection` 整合留言 Reaction：每則留言可獨立查詢、切換 Reaction
- `PracticeDetailShell` 整合實踐頁 Reaction，從頁面傳入 `practiceId`
- `PracticeOverviewCard` 整合 `ReactionSection`，實踐總覽卡片底部顯示 Reaction 列
- 更新 `packages/api/src/types.ts`：新增 Reaction API OpenAPI 型別定義

**新增檔案：**
- `packages/api/src/services/reaction.ts` — Reaction API 服務函式
- `packages/api/src/services/reaction-hooks.ts` — Reaction SWR React Hook
- `apps/product/src/components/social/reaction-section.tsx` — 通用 Reaction 列元件
- `apps/product/src/components/social/comment-input.tsx` — 留言輸入元件
- `apps/product/src/components/social/index.ts` — social 模組導出
- `apps/product/src/components/practice/shared/reaction-aggregate-label.tsx` — Reaction 匯總標籤

**變更位置：**
- `packages/api/src/services/index.ts` — 新增 reactions 模組導出
- `packages/api/src/types.ts` — 新增 Reaction API OpenAPI 型別定義
- `apps/product/src/components/check-in/reactions/comment-section.tsx` — 整合留言 Reaction
- `apps/product/src/components/practice/detail/practice-detail-shell.tsx` — 整合實踐 Reaction
- `apps/product/src/components/practice/shared/practice-overview-card.tsx` — 新增 ReactionSection
- `apps/product/src/app/global-provider.tsx` — 加入 social 相關 provider

### 3. CI 部署驗證腳本重構

**功能說明：** 重構 `linode-cd.yml` 中的部署驗證腳本，改用本地變數取代內嵌環境變數，提升可讀性與維護性。

- 將環境變數引用（`${{ env.XXX }}`）提前賦值至本地變數
- 統一容器狀態檢查的 log 訊息格式

**變更位置：**
- `.github/workflows/linode-cd.yml` — 部署驗證腳本重構