### PR TITLE
feat(auth): add error handling page for OAuth failures

### DIFF
--- a/apps/product/src/app/[locale]/auth/error.tsx
+++ b/apps/product/src/app/[locale]/auth/error.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Button } from "@daodao/ui/components/button";
+import { XCircle } from "lucide-react";
+import Link from "next/link";
+import { BackgroundAnimation, PageHeader } from "@/components/layout";
+
+interface AuthErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AuthError({ reset }: AuthErrorProps) {
+  return (
+    <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto">
+      <PageHeader leftAction={null} rightActionTo="/" />
+
+      <BackgroundAnimation />
+
+      <main className="max-w-[448px] mx-auto px-5 pb-[128px] pt-12 md:pt-24">
+        <div className="flex flex-col items-center text-center space-y-6">
+          <div className="w-20 h-20 rounded-full bg-red-100 flex items-center justify-center">
+            <XCircle className="w-10 h-10 text-red-600" />
+          </div>
+
+          <h1 className="text-2xl font-bold text-text-dark">發生錯誤</h1>
+
+          <p className="text-text-gray">請稍後再試，或透過以下方式聯繫我們：</p>
+
+          <div className="flex gap-4 text-sm text-[--logo-cyan]">
+            <Link
+              href="https://discord.com/invite/8GnqSZZxp7"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2"
+            >
+              Discord
+            </Link>
+            <Link
+              href="https://www.instagram.com/daodao_learn/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2"
+            >
+              Instagram
+            </Link>
+            <Link href="mailto:contact@daodao.so" className="underline underline-offset-2">
+              Email
+            </Link>
+          </div>
+
+          <div className="flex flex-col gap-3 w-full mt-8">
+            <Button variant="orange" className="w-full" onClick={reset}>
+              重試
+            </Button>
+
+            <Button variant="ghost" className="w-full" asChild>
+              <Link href="/">返回首頁</Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/product/src/components/check-in/reactions/comment-section.tsx
+++ b/apps/product/src/components/check-in/reactions/comment-section.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactionTypeValue } from "@daodao/api";
+import { removeReaction, upsertReaction, useReactions } from "@daodao/api";
 import { DialogOutlineSvg } from "@daodao/assets";
 import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
 import { Button } from "@daodao/ui/components/button";
@@ -9,8 +11,6 @@ import { cn } from "@daodao/ui/lib/utils";
 import { MoreHorizontal, Pencil, Send, Trash2 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
-import { upsertReaction, removeReaction, useReactions } from "@daodao/api";
-import type { ReactionTypeValue } from "@daodao/api";
 import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
 import { ReactionPickerButton } from "./reaction-picker-button";
 
@@ -88,14 +88,14 @@ function CommentBubble({
   const [editValue, setEditValue] = useState(comment.content);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const commentNumericId = Number(comment.id);
   const { data: reactionsData, mutate: mutateReactions } = useReactions({
     targetType: "comment",
-    targetId: commentNumericId,
+    targetId: comment.id,
   });
   const [, startReactionTransition] = useTransition();
 
-  const currentUserReaction = (reactionsData?.data?.currentUserReaction ?? null) as ReactionTypeType | null;
+  const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
+    null) as ReactionTypeType | null;
   const commentReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
 
   const handleCommentReactionToggle = useCallback(
@@ -103,18 +103,18 @@ function CommentBubble({
       const isSelected = currentUserReaction === type;
       startReactionTransition(async () => {
         if (isSelected) {
-          await removeReaction({ targetType: "comment", targetId: commentNumericId });
+          await removeReaction({ targetType: "comment", targetId: comment.id });
         } else {
           await upsertReaction({
             targetType: "comment",
-            targetId: commentNumericId,
+            targetId: comment.id,
             reactionType: type as ReactionTypeValue,
           });
         }
         await mutateReactions();
       });
     },
-    [currentUserReaction, commentNumericId, mutateReactions],
+    [currentUserReaction, comment.id, mutateReactions]
   );
   const { openWarningDialog } = useDialog();
 

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useExtractOgImage, useReactions, upsertReaction, removeReaction } from "@daodao/api";
 import type { ReactionTypeValue } from "@daodao/api";
+import { removeReaction, upsertReaction, useExtractOgImage, useReactions } from "@daodao/api";
 import {
   BookSvg,
   ChartColumnIncreasingSvg,
@@ -21,7 +21,11 @@ import { Archive, ChevronDown, ChevronUp, MoreHorizontal, Pencil, Trash2 } from 
 import type React from "react";
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { CheckInRecordCard, CheckInStack } from "@/components/check-in";
-import { CommentSection, ReactionPickerButton, type IComment } from "@/components/check-in/reactions";
+import {
+  CommentSection,
+  type IComment,
+  ReactionPickerButton,
+} from "@/components/check-in/reactions";
 import { LottieEmoji } from "@/components/check-in/reactions/lottie-emoji";
 import {
   ExecutionDurationCard,
@@ -128,9 +132,7 @@ function BrowseActivityContent({
   }, {});
   const uniqueReactions = [...new Set(followers.map((f) => f.reaction))] as ReactionTypeType[];
   const filteredFollowers =
-    reactionFilter === "all"
-      ? followers
-      : followers.filter((f) => f.reaction === reactionFilter);
+    reactionFilter === "all" ? followers : followers.filter((f) => f.reaction === reactionFilter);
   const followCount = followers.filter((f) => f.following).length;
 
   return (
@@ -208,7 +210,12 @@ function BrowseActivityContent({
                       isActive ? "text-logo-cyan" : "text-[#9FB5B8]"
                     )}
                   >
-                    <LottieEmoji url={config.lottieUrl} fallback={config.emoji} size={18} play={false} />
+                    <LottieEmoji
+                      url={config.lottieUrl}
+                      fallback={config.emoji}
+                      size={18}
+                      play={false}
+                    />
                     {count}
                     {isActive && (
                       <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-logo-cyan rounded-full" />
@@ -282,7 +289,11 @@ interface IPracticeResourceListCardProps {
   onEditPractice: () => void;
 }
 
-function PracticeResourceListCard({ resource, isOwner, onEditPractice }: IPracticeResourceListCardProps) {
+function PracticeResourceListCard({
+  resource,
+  isOwner,
+  onEditPractice,
+}: IPracticeResourceListCardProps) {
   const [imageError, setImageError] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -437,14 +448,14 @@ export function PracticeDetailShell({
   const [practiceMenuOpen, setPracticeMenuOpen] = useState(false);
   const commentsRef = useRef<HTMLDivElement>(null);
 
-  const numericPracticeId = Number(practiceId);
   const { data: reactionsData, mutate: mutateReactions } = useReactions({
     targetType: "practice",
-    targetId: numericPracticeId,
+    targetId: practiceId,
   });
   const [, startReactionTransition] = useTransition();
 
-  const currentUserReaction = (reactionsData?.data?.currentUserReaction ?? null) as ReactionTypeType | null;
+  const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
+    null) as ReactionTypeType | null;
   const headerReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
 
   const handleHeaderReactionToggle = useCallback(
@@ -452,18 +463,18 @@ export function PracticeDetailShell({
       const isSelected = currentUserReaction === type;
       startReactionTransition(async () => {
         if (isSelected) {
-          await removeReaction({ targetType: "practice", targetId: numericPracticeId });
+          await removeReaction({ targetType: "practice", targetId: practiceId });
         } else {
           await upsertReaction({
             targetType: "practice",
-            targetId: numericPracticeId,
+            targetId: practiceId,
             reactionType: type as ReactionTypeValue,
           });
         }
         await mutateReactions();
       });
     },
-    [currentUserReaction, numericPracticeId, mutateReactions],
+    [currentUserReaction, practiceId, mutateReactions]
   );
   const { open: openSheet } = useSheetManager();
   const { openWarningDialog } = useDialog();
@@ -481,7 +492,7 @@ export function PracticeDetailShell({
           viewCount={browseActivity?.viewCount ?? 0}
           commentCount={commentCount ?? comments.length}
           followers={followers}
-          onToggleFollow={(id) => {
+          onToggleFollow={(_id) => {
             if (!followers.length) {
               toast("功能開發中");
               return;
@@ -672,7 +683,10 @@ export function PracticeDetailShell({
             >
               <div className="overflow-hidden">
                 <div className="grid grid-cols-2 gap-3 pb-3">
-                  <ExecutionTimingCard executionTiming={practice.executionTiming} customTiming={practice.customTiming} />
+                  <ExecutionTimingCard
+                    executionTiming={practice.executionTiming}
+                    customTiming={practice.customTiming}
+                  />
                   <ExecutionDurationCard
                     durationDays={practice.durationDays}
                     startDate={practice.startDate || ""}
@@ -687,7 +701,10 @@ export function PracticeDetailShell({
               // 優先用 API followers；沒有時若使用者已按讚，用 headerReactions
               const displayReactions =
                 followers.length > 0
-                  ? ([...new Set(followers.map((f) => f.reaction))].slice(0, 2) as ReactionTypeType[])
+                  ? ([...new Set(followers.map((f) => f.reaction))].slice(
+                      0,
+                      2
+                    ) as ReactionTypeType[])
                   : headerReactions.slice(0, 2);
               const firstName = followers[0]?.name;
               const text =

--- a/apps/product/src/components/practice/shared/practice-overview-card.tsx
+++ b/apps/product/src/components/practice/shared/practice-overview-card.tsx
@@ -4,9 +4,9 @@ import { DefaultAvatarSvg, TagSolidSvg } from "@daodao/assets";
 import { Link } from "@daodao/i18n/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
 import { Badge } from "@daodao/ui/components/badge";
+import { ReactionSection } from "@/components/social";
 import type { ManualPracticeFormValues } from "../create/manual/schema";
 import { CircularProgress } from "./circular-progress";
-import { ReactionSection } from "@/components/social";
 
 interface CreatorInfo {
   id: string;
@@ -26,7 +26,7 @@ interface PracticeOverviewCardProps {
   // 公開頁面顯示建立者資訊
   creator?: CreatorInfo;
   // 快速反應 + 留言（提供 practiceId 時顯示）
-  practiceId?: number;
+  practiceId?: string;
 }
 
 export const PracticeOverviewCard = ({
@@ -58,9 +58,7 @@ export const PracticeOverviewCard = ({
           >
             {creator.name}
           </Link>
-          {creator.date && (
-            <span className="text-sm text-text-dark/60">{creator.date}</span>
-          )}
+          {creator.date && <span className="text-sm text-text-dark/60">{creator.date}</span>}
         </div>
       )}
       <div className="relative flex items-start gap-4">
@@ -113,12 +111,7 @@ export const PracticeOverviewCard = ({
       </div>
 
       {/* 反應列 */}
-      {practiceId !== undefined && (
-        <ReactionSection
-          targetType="practice"
-          targetId={practiceId}
-        />
-      )}
+      {practiceId !== undefined && <ReactionSection targetType="practice" targetId={practiceId} />}
     </div>
   );
 };

--- a/apps/product/src/components/social/reaction-section.tsx
+++ b/apps/product/src/components/social/reaction-section.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { useCallback, useTransition } from "react";
-import { upsertReaction, removeReaction, useReactions } from "@daodao/api";
 import type { ReactionTypeValue } from "@daodao/api";
-import { ReactionBar, ReactionPickerButton } from "@/components/check-in/reactions";
+import { removeReaction, upsertReaction, useReactions } from "@daodao/api";
+import { useCallback, useTransition } from "react";
 import type { IReactionCount } from "@/components/check-in/reactions";
+import { ReactionBar, ReactionPickerButton } from "@/components/check-in/reactions";
 import type { ReactionTypeType } from "@/constants/reaction-type";
 
 export interface ReactionSectionProps {
   /** 目標類型，目前支援 'practice' */
   targetType: "practice";
-  /** 目標的內部 ID */
-  targetId: number;
+  /** 目標的外部 ID（UUID） */
+  targetId: string;
   /** 反應變更回調（可選） */
   onReactionChange?: (type: ReactionTypeType | null) => void;
 }
@@ -54,7 +54,7 @@ export function ReactionSection({ targetType, targetId, onReactionChange }: Reac
         await mutate();
       });
     },
-    [currentUserReaction, targetType, targetId, mutate, onReactionChange],
+    [currentUserReaction, targetType, targetId, mutate, onReactionChange]
   );
 
   return (

--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,8 @@
       "!!**/.turbo",
       "!!**/out",
       "!!**/.vercel",
-      "!!**/packages/assets"
+      "!!**/packages/assets",
+      "!!**/packages/api/src/types.ts"
     ]
   },
   "formatter": {

--- a/packages/api/src/services/reaction.ts
+++ b/packages/api/src/services/reaction.ts
@@ -10,9 +10,7 @@ import type { components, paths } from "../types";
 // Types
 // ============================================================================
 
-type GetReactionsQuery = NonNullable<
-  paths["/api/v1/reactions"]["get"]["parameters"]["query"]
->;
+type GetReactionsQuery = NonNullable<paths["/api/v1/reactions"]["get"]["parameters"]["query"]>;
 
 export type ReactionTargetType = GetReactionsQuery["targetType"];
 
@@ -26,7 +24,7 @@ export type RemoveReactionRequest = components["schemas"]["RemoveReactionRequest
 
 export interface IGetReactionsParams {
   targetType: ReactionTargetType;
-  targetId: number;
+  targetId: string;
 }
 
 // ============================================================================

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -11138,8 +11138,8 @@ export interface paths {
                 query: {
                     /** @description 反應目標類型 */
                     targetType: "practice" | "comment";
-                    /** @description 目標內部 ID */
-                    targetId: number;
+                    /** @description 目標外部 ID（UUID） */
+                    targetId: string;
                 };
                 header?: never;
                 path?: never;
@@ -27144,10 +27144,10 @@ export interface components {
              */
             targetType: "practice" | "comment";
             /**
-             * @description 目標內部 ID
-             * @example 1
+             * @description 目標外部 ID（UUID）
+             * @example 32859587-f159-43fd-93e7-fcc890661781
              */
-            targetId: number;
+            targetId: string;
             /**
              * @description 反應類型
              * @example fire
@@ -27168,10 +27168,10 @@ export interface components {
              */
             targetType: "practice" | "comment";
             /**
-             * @description 目標內部 ID
-             * @example 1
+             * @description 目標外部 ID（UUID）
+             * @example 32859587-f159-43fd-93e7-fcc890661781
              */
-            targetId: number;
+            targetId: string;
         };
         AdminUserListQuery: {
             /**


### PR DESCRIPTION
## Why is this necessary?

- Android Chrome Custom Tab（CCT）完成 OAuth 後，主 tab 不一定能透過 `storage event` 得知登入完成，導致主 tab 停留在未登入狀態、需要手動重新整理
- 實踐卡片和留言只有 Reaction Picker 按鈕，但缺少完整的 Reaction 系統：沒有計數顯示、無法查詢/儲存/刪除 Reaction、留言也不支援 Reaction
- CI 部署驗證腳本（`linode-cd.yml`）中大量使用內嵌環境變數，可讀性差，維護困難

---

## How does it address?

### 1. OAuth 跨 Tab 認證改進（Android Chrome Custom Tab）

**功能說明：** 透過雙重機制解決 Android CCT OAuth 回調後主 tab 停留在未登入狀態的問題。

- 新增 `StorageEnum.AuthSignal`（存入 `localStorage`），OAuth 回調完成時由 `useRedirectAfterLogin` 寫入當前時間戳
- `AuthProvider` 的 `storage` event 監聽器新增對 `AuthSignal` 的處理：偵測到變化後立即呼叫 `checkAuth()`
- 新增 `visibilitychange` 監聽器作為補充機制：CCT 是獨立 renderer process，`storage event` 不可靠，改為主 tab 重新可見時（且未登入）自動重新驗證
- `/auth/login` 頁面新增 `isAuthenticated` 監聽，認證成功後自動跳轉至目標頁面（配合 CCT 回調流程）

**變更位置：**
- `packages/shared/src/lib/storage.ts` — 新增 `AuthSignal` enum（localStorage）
- `packages/auth/src/hooks/use-redirect-after-login.ts` — 寫入 `AuthSignal` 通知其他 tab
- `packages/auth/src/lib/auth-provider.tsx` — 監聽 `AuthSignal` storage event 與 `visibilitychange`
- `apps/product/src/app/[locale]/auth/login/page.tsx` — 認證後自動跳轉

### 2. Reaction 系統完整實作

**功能說明：** 建立完整的 Reaction API 服務層，並在實踐卡片和留言中整合 Reaction 功能。

- 新增 `reaction.ts`：`getReactions`、`upsertReaction`、`removeReaction` API 函式，支援 `practice` 和 `comment` 兩種目標類型
- 新增 `reaction-hooks.ts`：`useReactions` SWR hook，取得目標的 Reaction 計數與當前使用者的 Reaction
- 新增 `ReactionSection` 元件：整合 `ReactionPickerButton` + `ReactionBar`，直接呼叫 API，可獨立用於任何支援 Reaction 的目標
- 新增 `ReactionAggregateLabel` 元件：顯示 Reaction 類型、計數與最新按讚者名稱
- 新增 `CommentInput` 元件：留言輸入框（含 Reaction 選取支援）
- `CommentSection` 整合留言 Reaction：每則留言可獨立查詢、切換 Reaction
- `PracticeDetailShell` 整合實踐頁 Reaction，從頁面傳入 `practiceId`
- `PracticeOverviewCard` 整合 `ReactionSection`，實踐總覽卡片底部顯示 Reaction 列
- 更新 `packages/api/src/types.ts`：新增 Reaction API OpenAPI 型別定義

**新增檔案：**
- `packages/api/src/services/reaction.ts` — Reaction API 服務函式
- `packages/api/src/services/reaction-hooks.ts` — Reaction SWR React Hook
- `apps/product/src/components/social/reaction-section.tsx` — 通用 Reaction 列元件
- `apps/product/src/components/social/comment-input.tsx` — 留言輸入元件
- `apps/product/src/components/social/index.ts` — social 模組導出
- `apps/product/src/components/practice/shared/reaction-aggregate-label.tsx` — Reaction 匯總標籤

**變更位置：**
- `packages/api/src/services/index.ts` — 新增 reactions 模組導出
- `packages/api/src/types.ts` — 新增 Reaction API OpenAPI 型別定義
- `apps/product/src/components/check-in/reactions/comment-section.tsx` — 整合留言 Reaction
- `apps/product/src/components/practice/detail/practice-detail-shell.tsx` — 整合實踐 Reaction
- `apps/product/src/components/practice/shared/practice-overview-card.tsx` — 新增 ReactionSection
- `apps/product/src/app/global-provider.tsx` — 加入 social 相關 provider

### 3. CI 部署驗證腳本重構

**功能說明：** 重構 `linode-cd.yml` 中的部署驗證腳本，改用本地變數取代內嵌環境變數，提升可讀性與維護性。

- 將環境變數引用（`${{ env.XXX }}`）提前賦值至本地變數
- 統一容器狀態檢查的 log 訊息格式

**變更位置：**
- `.github/workflows/linode-cd.yml` — 部署驗證腳本重構
