### PR TITLE
feat(reactions): enhance useReactions hook with refresh interval

### DIFF
--- a/packages/api/src/services/reaction-hooks.ts
+++ b/packages/api/src/services/reaction-hooks.ts
@@ -16,12 +16,19 @@ import type { IGetReactionsParams } from "./reaction";
  * 取得目標反應計數的 Hook
  */
 export const useReactions = (params: IGetReactionsParams) => {
-  return useQuery("/api/v1/reactions", {
-    params: {
-      query: {
-        targetType: params.targetType,
-        targetId: params.targetId,
+  return useQuery(
+    "/api/v1/reactions",
+    {
+      params: {
+        query: {
+          targetType: params.targetType,
+          targetId: params.targetId,
+        },
       },
     },
-  });
+    {
+      refreshInterval: 30_000,
+      revalidateOnFocus: true,
+    },
+  );
 };


### PR DESCRIPTION
## Why is this necessary?

- `useReactions` hook 預設使用 SWR 的被動快取，使用者長時間停留頁面或切換 tab 回來時，Reaction 計數不會自動更新，顯示的數字可能已過期

---

## How does it address?

### 1. 新增 refreshInterval 與 revalidateOnFocus

**功能說明：** 為 `useReactions` hook 加入 SWR 選項，讓 Reaction 資料定期自動刷新並在使用者切換回頁面時重新驗證。

- `refreshInterval: 30_000`：每 30 秒自動重新向 API 取得最新 Reaction 計數
- `revalidateOnFocus: true`：使用者切換 tab 或視窗焦點回到頁面時立即重新驗證，確保資料即時性

**變更位置：**
- `packages/api/src/services/reaction-hooks.ts` — 新增 SWR 選項