### PR TITLE
feat(reactions): 新增迴響列表 API 串接並修正 reaction 顯示

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   useMyPractices,
   usePracticeById,
   usePracticeCheckIns,
+  useReactionsList,
 } from "@daodao/api";
 import { useParams, useRouter } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
@@ -178,6 +179,10 @@ export default function PracticeDetailPage() {
   });
   const { data: practicesListData } = useMyPractices({ limit: 100 });
   const { data: currentUserData } = useCurrentUser();
+  const { data: reactionsListData } = useReactionsList({
+    targetType: "practice",
+    targetId: practiceId,
+  });
 
   const isOwner = practiceData?.data?.user?.id === currentUserData?.data?.id;
   const { openArchiveDialog } = useArchivePracticeDialog();
@@ -470,6 +475,16 @@ export default function PracticeDetailPage() {
         }}
         onEditComment={handleCommentEdit}
         onDeleteComment={handleCommentDelete}
+        browseActivity={{
+          followers: (reactionsListData?.data?.items ?? []).map((item) => ({
+            id: item.userId,
+            name: item.name,
+            photoURL: item.photoURL ?? undefined,
+            time: formatCommentTime(item.reactedAt),
+            following: false,
+            reaction: item.reactionType as "useful" | "fire" | "touched" | "curious",
+          })),
+        }}
         footer={
           isOwner ? (
             <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-6 p-6 border-t border-light-gray bg-very-light-gray z-20">

--- a/apps/product/src/components/check-in/reactions/comment-section.tsx
+++ b/apps/product/src/components/check-in/reactions/comment-section.tsx
@@ -97,6 +97,18 @@ function CommentBubble({
   const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
     null) as ReactionTypeType | null;
   const commentReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
+  const totalReactionCount = (reactionsData?.data?.reactions ?? []).reduce(
+    (sum, r) => sum + r.count,
+    0,
+  );
+  // 所有有人按過的 reaction 類型，按數量排序，當前用戶的排第一（參考 practice-detail-shell 作法）
+  const activeReactionTypes = (reactionsData?.data?.reactions ?? [])
+    .filter((r) => r.count > 0)
+    .sort((a, b) => b.count - a.count)
+    .map((r) => r.type as ReactionTypeType);
+  const displayReactions = currentUserReaction
+    ? [currentUserReaction, ...activeReactionTypes.filter((t) => t !== currentUserReaction)].slice(0, 3)
+    : activeReactionTypes.slice(0, 3);
 
   const handleCommentReactionToggle = useCallback(
     (type: ReactionTypeType) => {
@@ -289,6 +301,8 @@ function CommentBubble({
               selectedReactions={commentReactions}
               onToggle={handleCommentReactionToggle}
               variant="comment"
+              totalCount={totalReactionCount > 0 ? totalReactionCount : undefined}
+              displayReactions={displayReactions.length > 0 ? displayReactions : undefined}
             />
             {!isReply && onReply && (
               <Button

--- a/apps/product/src/components/check-in/reactions/reaction-picker-button.tsx
+++ b/apps/product/src/components/check-in/reactions/reaction-picker-button.tsx
@@ -18,6 +18,10 @@ export interface ReactionPickerButtonProps {
    * "comment" — 留言層級，較小按鈕（size-7 / emoji 18），顯示計數
    */
   variant?: "card" | "comment";
+  /** comment variant 的總反應計數（所有用戶，非僅當前用戶） */
+  totalCount?: number;
+  /** 要疊加顯示的 reaction 類型（aggregate，最多 3 個），參考主題實踐的 browseActivity 作法 */
+  displayReactions?: ReactionTypeType[];
 }
 
 const PICKER_REACTIONS: ReactionTypeType[] = ["useful", "fire", "touched", "curious"];
@@ -32,6 +36,8 @@ export function ReactionPickerButton({
   selectedReactions,
   onToggle,
   variant = "comment",
+  totalCount,
+  displayReactions,
 }: ReactionPickerButtonProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -164,27 +170,52 @@ export function ReactionPickerButton({
               )
         )}
       >
-        {hasSelection ? (
-          <>
+        {isCard ? (
+          /* card variant：顯示當前用戶的 reaction emoji，或預設 👍 */
+          hasSelection ? (
             <div className="flex items-center">
               {selectedReactions.slice(-2).map((type, i) => (
-                <div
-                  key={type}
-                  className={cn(isCard ? "size-[22px]" : "size-4", i > 0 && "-ml-1")}
-                >
+                <div key={type} className={cn("size-[22px]", i > 0 && "-ml-1")}>
                   <LottieEmoji
                     url={REACTION_CONFIG[type].lottieUrl}
                     fallback={REACTION_CONFIG[type].emoji}
-                    size={isCard ? 22 : 16}
+                    size={22}
                     play={true}
                   />
                 </div>
               ))}
             </div>
-            {!isCard && <span>{selectedReactions.length}</span>}
-          </>
+          ) : (
+            <LikeOutlineSvg className="size-[22px]" />
+          )
         ) : (
-          <LikeOutlineSvg className={isCard ? "size-[22px]" : "size-5"} />
+          /* comment variant：Facebook 疊加圓圈（displayReactions）+ 總數 */
+          <>
+            {displayReactions && displayReactions.length > 0 ? (
+              <div className="flex items-center">
+                {displayReactions.slice(0, 3).map((type, i) => (
+                  <div
+                    key={type}
+                    className={cn(
+                      "size-5 rounded-full flex items-center justify-center ring-1 ring-white",
+                      selectedReactions.includes(type) ? "bg-[#E8FAF9]" : "bg-[#F0F4F4]",
+                      i > 0 && "-ml-1"
+                    )}
+                  >
+                    <LottieEmoji
+                      url={REACTION_CONFIG[type].lottieUrl}
+                      fallback={REACTION_CONFIG[type].emoji}
+                      size={14}
+                      play={selectedReactions.includes(type)}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <LikeOutlineSvg className="size-5" />
+            )}
+            {totalCount != null && totalCount > 0 && <span>{totalCount}</span>}
+          </>
         )}
       </button>
     </div>

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -698,23 +698,42 @@ export function PracticeDetailShell({
 
             {(() => {
               const followers = browseActivity?.followers ?? [];
-              // 優先用 API followers；沒有時若使用者已按讚，用 headerReactions
+              // 從 reactions API 取出有人按的類型（所有人共享的 aggregate）
+              const activeReactions = (reactionsData?.data?.reactions ?? [])
+                .filter((r) => r.count > 0)
+                .slice(0, 2);
+              const totalReactionCount = (reactionsData?.data?.reactions ?? []).reduce(
+                (sum, r) => sum + r.count,
+                0,
+              );
+              const latestActorName =
+                (reactionsData?.data?.reactions ?? []).find((r) => r.count > 0)?.latestActorName ??
+                null;
+              // 優先用 API followers；沒有時用 aggregate reactions（所有人共享）
               const displayReactions =
                 followers.length > 0
                   ? ([...new Set(followers.map((f) => f.reaction))].slice(
                       0,
                       2
                     ) as ReactionTypeType[])
-                  : headerReactions.slice(0, 2);
+                  : activeReactions.map((r) => r.type as ReactionTypeType);
               const firstName = followers[0]?.name;
               const text =
                 followers.length > 1
                   ? `${firstName} 與其他 ${followers.length - 1} 人`
                   : followers.length === 1
                     ? firstName
-                    : headerReactions.length > 0
-                      ? "你"
-                      : "觀看瀏覽活動";
+                    : currentUserReaction
+                      ? totalReactionCount > 1
+                        ? `你 與其他 ${totalReactionCount - 1} 人`
+                        : "你"
+                      : totalReactionCount > 0
+                        ? latestActorName
+                          ? totalReactionCount > 1
+                            ? `${latestActorName} 與其他 ${totalReactionCount - 1} 人`
+                            : latestActorName
+                          : `${totalReactionCount} 人`
+                        : "觀看瀏覽活動";
               return (
                 <button
                   type="button"

--- a/packages/api/src/services/reaction-hooks.ts
+++ b/packages/api/src/services/reaction-hooks.ts
@@ -32,3 +32,24 @@ export const useReactions = (params: IGetReactionsParams) => {
     },
   );
 };
+
+/**
+ * 取得目標個別用戶反應列表的 Hook
+ */
+export const useReactionsList = (params: IGetReactionsParams) => {
+  return useQuery(
+    "/api/v1/reactions/list",
+    {
+      params: {
+        query: {
+          targetType: params.targetType,
+          targetId: params.targetId,
+        },
+      },
+    },
+    {
+      refreshInterval: 30_000,
+      revalidateOnFocus: true,
+    },
+  );
+};

--- a/packages/api/src/services/reaction.ts
+++ b/packages/api/src/services/reaction.ts
@@ -19,6 +19,11 @@ export type ReactionTypeValue = components["schemas"]["UpsertReactionRequest"]["
 export type GetReactionsResponse =
   paths["/api/v1/reactions"]["get"]["responses"]["200"]["content"]["application/json"];
 
+export type GetReactionsListResponse =
+  paths["/api/v1/reactions/list"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type ReactionListItem = components["schemas"]["ReactionListItem"];
+
 export type UpsertReactionRequest = components["schemas"]["UpsertReactionRequest"];
 export type RemoveReactionRequest = components["schemas"]["RemoveReactionRequest"];
 
@@ -57,4 +62,18 @@ export const upsertReaction = async (data: UpsertReactionRequest) => {
  */
 export const removeReaction = async (data: RemoveReactionRequest) => {
   return client.DELETE("/api/v1/reactions", { body: data });
+};
+
+/**
+ * 取得目標的個別用戶反應列表
+ */
+export const getReactionsList = async (params: IGetReactionsParams) => {
+  return client.GET("/api/v1/reactions/list", {
+    params: {
+      query: {
+        targetType: params.targetType,
+        targetId: params.targetId,
+      },
+    },
+  });
 };

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -11405,6 +11405,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/reactions/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 取得個別用戶反應列表
+         * @description 取得指定目標的每位反應用戶詳細資料（含名稱、頭像、反應類型、時間）
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description 反應目標類型 */
+                    targetType: "practice" | "comment";
+                    /** @description 目標外部 ID（UUID） */
+                    targetId: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功取得反應列表 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description Indicates successful API response
+                             * @enum {boolean}
+                             */
+                            success: true;
+                            data: components["schemas"]["GetReactionsListResponse"] & unknown;
+                            /**
+                             * Format: date-time
+                             * @description ISO 8601 timestamp of the response
+                             */
+                            timestamp: string;
+                            meta?: {
+                                [key: string]: unknown;
+                            };
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/images/{filename}": {
         parameters: {
             query?: never;
@@ -27134,6 +27195,27 @@ export interface components {
              * @example fire
              */
             currentUserReaction: string | null;
+        };
+        /** @description 單筆用戶反應資料 */
+        ReactionListItem: {
+            /** @description 用戶外部 ID（UUID） */
+            userId: string;
+            /** @description 用戶名稱 */
+            name: string;
+            /** @description 用戶頭像 URL */
+            photoURL: string | null;
+            /**
+             * @description 反應類型
+             * @example fire
+             */
+            reactionType: string;
+            /** @description 反應時間（ISO 8601） */
+            reactedAt: string;
+        };
+        /** @description 個別用戶反應列表回應 */
+        GetReactionsListResponse: {
+            /** @description 反應列表 */
+            items: components["schemas"]["ReactionListItem"][];
         };
         /** @description 新增或更換反應的請求資料 */
         UpsertReactionRequest: {


### PR DESCRIPTION
## Why is this necessary?

- 迴響 tab 需要顯示每位按過 reaction 的用戶資料（名稱、頭像、反應類型、時間）
- 舊版在 followers 為空時，只顯示當前用戶的 reaction，不反映所有人的 aggregate 狀態，導致不同帳號觀看時顯示不一致
- comment variant 的 `ReactionPickerButton` 缺少疊加表情圖示與總計數，與設計稿不符

## How does it address?

- 新增 `/api/v1/reactions/list` API 串接，包含 `getReactionsList` 函式、`useReactionsList` hook 及對應 TypeScript 型別
- 在 `practice-detail-shell.tsx` 改用 aggregate reactions 資料顯示「latestActorName 與其他 N 人」文字
- 重構 `ReactionPickerButton`，card variant 維持原有行為，comment variant 改為 Facebook 風格疊加圓圈 emoji + 總計數
- 在 `comment-section.tsx` 計算 `totalReactionCount` 與 `displayReactions` 並傳入 `ReactionPickerButton`
- 在 `page.tsx` 透過 `useReactionsList` 取得 `browseActivity.followers` 資料

🤖 Generated with [Claude Code](https://claude.ai/code)