### PR TITLE
fix(docker): 設定 KEEP_ALIVE_TIMEOUT 避免 nginx 複用過期連線導致 502

### DIFF
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
+      - KEEP_ALIVE_TIMEOUT=75000
     restart: unless-stopped
     # 如果需要環境變數文件，取消下面的註解
     # env_file:
@@ -32,6 +33,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
+      - KEEP_ALIVE_TIMEOUT=75000
     restart: unless-stopped
     # 如果需要環境變數文件，取消下面的註解
     # env_file:


### PR DESCRIPTION
## Why is this necessary?

- Next.js standalone server 預設 `keepAliveTimeout` 為 5 秒
- nginx 使用 HTTP/1.1 keepalive 複用連線，超過 5 秒閒置連線已被 Next.js 關閉
- nginx 不知道連線已失效，複用死連線導致偶發性 502，重新整理才恢復正常

## How does it address?

- `docker/production/docker-compose.yml` 的 website、product 服務加入 `KEEP_ALIVE_TIMEOUT=75000`
- Next.js standalone `server.js` 原生支援此環境變數，無需修改程式碼
- 確保連線存活 75 秒，遠大於一般請求間隔

🤖 Generated with [Claude Code](https://claude.com/claude-code)