### PR TITLE
fix(auth): 修復 /auth/error 路由保護與登入後跳轉問題

### DIFF
--- a/apps/product/src/app/global-provider.tsx
+++ b/apps/product/src/app/global-provider.tsx
@@ -50,6 +50,7 @@ function GlobalProvider({
                       publicPattern={[
                         "^/auth/login",
                         "^/auth/callback",
+                        "^/auth/error",
                         "^/auth/onboarding",
                         "^/auth/verify-email(/.*)?$",
                         "^/users/",

--- a/packages/auth/src/hooks/use-redirect-after-login.ts
+++ b/packages/auth/src/hooks/use-redirect-after-login.ts
@@ -70,7 +70,9 @@ export const useRedirectAfterLogin = () => {
       router.push(ONBOARDING_URL);
     } else {
       // 舊用戶跳轉到原目標頁面
-      router.push(state.redirectUrl);
+      // 過濾掉 /auth/error 路徑，避免成功登入後仍被導向錯誤頁面
+      const isSafeRedirect = !state.redirectUrl.includes("/auth/error");
+      router.push(isSafeRedirect ? state.redirectUrl : DEFAULT_REDIRECT_URL);
     }
   }, [searchParams, router]);
 };


### PR DESCRIPTION
## Why is this necessary?

- /auth/error 未列入 publicPattern，未登入用戶被 AuthProvider 踢到 /auth/login?redirect=/auth/error
- 形成無法脫離的 redirect loop：錯誤頁面 → login（錯誤 redirect）→ OAuth → 再回錯誤頁面
- 成功登入後仍被導向 /auth/error，用戶無法正常使用

## How does it address?

- global-provider.tsx 的 publicPattern 加入 "^/auth/error"，使錯誤頁面可公開訪問
- use-redirect-after-login.ts 加入 isSafeRedirect 檢查，/auth/error 路徑不作為登入後 redirect 目標
- 若 redirectUrl 被污染為 /auth/error，改 fallback 到 DEFAULT_REDIRECT_URL