### PR TITLE
fix(ci): 補上 codegen 前置步驟避免 CI build 失敗

### DIFF
--- a/.github/workflows/linode-ci.yml
+++ b/.github/workflows/linode-ci.yml
@@ -164,6 +164,15 @@ jobs:
           cp .env apps/website/.env
           cp .env apps/product/.env
 
+      # ===== 建置前置 packages（codegen） =====
+      - name: Build prerequisite packages
+        run: |
+          echo "⚙️ Generating config env (requires .env)..."
+          pnpm --filter @daodao/config generate:env
+
+          echo "⚙️ Building assets (SVG codegen)..."
+          pnpm --filter @daodao/assets build
+
       # ===== 構建驗證 =====
       - name: Build applications
         run: |


### PR DESCRIPTION
## Why is this necessary?

- CI build 失敗：@daodao/assets 和 packages/config/generated/env.ts 在 build apps 前未被產生
- 先前優化改用 --filter 選擇性 build 後，跳過了 turbo 原本自動處理的 packages 依賴順序

## How does it address?

- 在「Create environment files」之後、「Build applications」之前新增 Build prerequisite packages 步驟
- 先執行 pnpm --filter @daodao/config generate:env，讀取 .env 產生 packages/config/generated/env.ts
- 再執行 pnpm --filter @daodao/assets build，產生 packages/assets/generated/index.ts 等 SVG 相關檔案