### PR TITLE
fix(ui): 修復 bottom/top sheet 在 iOS Safari 被工具列遮擋的問題

### DIFF
--- a/packages/ui/src/components/animate-ui/components/radix/sheet.tsx
+++ b/packages/ui/src/components/animate-ui/components/radix/sheet.tsx
@@ -62,8 +62,8 @@ function SheetContent({ className, children, side = "right", ...props }: SheetCo
           "bg-background fixed z-50 flex flex-col gap-4 shadow-lg",
           side === "right" && "h-full w-[400px] border-l rounded-l-3xl",
           side === "left" && "h-full w-[400px] border-r rounded-r-3xl",
-          side === "top" && "w-full h-[calc(100vh-64px)] border-b rounded-b-3xl",
-          side === "bottom" && "w-full h-[calc(100vh-64px)] border-t rounded-t-3xl",
+          side === "top" && "w-full h-[calc(100dvh-64px)] border-b rounded-b-3xl",
+          side === "bottom" && "w-full h-[calc(100dvh-64px)] border-t rounded-t-3xl",
           className
         )}
         side={side}


### PR DESCRIPTION
## Why is this necessary?

- 修復在 iOS Safari 中使用 bottom/top sheet 時被工具列遮擋的問題。
- 提升使用者在 iOS Safari 上的操作體驗。
- 確保應用在不同平台上的一致性和可用性。

## How does it address?

- 針對 iOS Safari 的特定問題進行了修復。
- 調整了底部和頂部彈出視窗的顯示邏輯。
- 測試了修復後的效果，確保不再受到工具列的影響。