### PR TITLE
feat(ui): 更新首頁與個人頁面顯示及修正導航問題  

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/users/[identifier]/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/users/[identifier]/page.tsx
@@ -136,6 +136,7 @@ export default async function UserProfilePage({
         {/* 用戶個人資訊卡片 */}
         <UserInfoCard
           name={userData.name || "未命名用戶"}
+          customId={userData.customId || undefined}
           location={
             (locale === "en" ? userData.locationNameEn : userData.locationNameZh) || undefined
           }

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -22,7 +22,9 @@ import { zhTW } from "date-fns/locale";
 import { useCallback, useEffect, useMemo } from "react";
 import { CheckInButton } from "@/components/check-in";
 import type { IComment, ICommentReply } from "@/components/check-in/reactions";
-import { BackgroundAnimation, PageHeader } from "@/components/layout";
+import { BackgroundAnimation } from "@/components/layout";
+import Link from "next/link";
+import { X } from "lucide-react";
 import { PracticeDetailShell } from "@/components/practice";
 import {
   type DurationDays,
@@ -416,7 +418,15 @@ export default function PracticeDetailPage() {
   if (isLoading) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-gray-100">
-        <PageHeader leftAction="back" leftLabel="" title="主題實踐" rightActionTo="/" />
+        <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
+          <Link
+            href="/"
+            className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
+            aria-label="關閉"
+          >
+            <X className="size-6" />
+          </Link>
+        </div>
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">載入中...</div>
@@ -428,7 +438,15 @@ export default function PracticeDetailPage() {
   if (error || !practice) {
     return (
       <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-gray-100">
-        <PageHeader leftAction="back" leftLabel="" title="主題實踐" rightActionTo="/" />
+        <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
+          <Link
+            href="/"
+            className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
+            aria-label="關閉"
+          >
+            <X className="size-6" />
+          </Link>
+        </div>
         <BackgroundAnimation />
         <main className="max-w-[448px] mx-auto px-5 pb-6 pt-4">
           <div className="text-center text-text-dark">
@@ -449,7 +467,15 @@ export default function PracticeDetailPage() {
 
   return (
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-gray-100">
-      <PageHeader leftAction="back" leftLabel="" title="主題實踐" rightActionTo="/" />
+      <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
+        <Link
+          href="/"
+          className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
+          aria-label="關閉"
+        >
+          <X className="size-6" />
+        </Link>
+      </div>
       <BackgroundAnimation />
 
       <PracticeDetailShell

--- a/apps/product/src/components/layout/banner.tsx
+++ b/apps/product/src/components/layout/banner.tsx
@@ -152,11 +152,11 @@ export function Banner() {
         <DesktopBannerSvg className="hidden md:block w-full" />
         <h2
           className={cn(
-            "absolute left-1/2 -translate-x-1/2 max-w-[540px] min-w-44 w-1/2",
+            "absolute left-1/2 -translate-x-1/2 max-w-[80%] md:max-w-[540px]",
             "flex items-center justify-center pointer-events-auto",
-            "bg-white/70 rounded-full text-text-dark border border-white",
-            "bottom-[70%] -translate-y-full h-7 text-sm",
-            "md:top-[42%] md:-translate-y-full md:h-10 md:text-[1.125rem]"
+            "bg-white/70 rounded-full text-text-dark border border-white px-4 py-1",
+            "bottom-[70%] -translate-y-full text-sm",
+            "md:top-[42%] md:-translate-y-full md:py-2 md:text-[1.125rem]"
           )}
         >
           {slogan}

--- a/apps/product/src/components/settings/connections/connections-settings.tsx
+++ b/apps/product/src/components/settings/connections/connections-settings.tsx
@@ -107,43 +107,36 @@ export const ConnectionsSettings = () => {
           {/* 收到的 */}
           {incomingRequests.length > 0 && (
             <div className="flex flex-col gap-2">
-              {incomingRequests.map((req, index) => {
-                const reqAny = req as any;
-                const user = req.requester;
-                const name = reqAny.requesterNickname || user?.name || "用戶";
-                const userId = reqAny.requesterExternalId || user?.identifier || user?.id || req.requesterId;
-                const requestId = reqAny.requestId || req.id;
+              {incomingRequests.map((req) => {
+                const name = req.requesterNickname || "用戶";
                 return (
-                  <div key={requestId || `incoming-${index}`} className="bg-white rounded-lg p-3 flex flex-col gap-3">
+                  <div key={req.requestId} className="bg-white rounded-lg p-3 flex flex-col gap-3">
                     <div className="flex items-center gap-3">
-                      <CustomLink href={`/users/${userId}`} className="shrink-0">
+                      <CustomLink href={`/users/${req.requesterExternalId}`} className="shrink-0">
                         <Avatar className="size-10">
-                          <AvatarImage src={user?.photoURL} alt={name} />
+                          <AvatarImage src={req.requesterPhotoUrl ?? undefined} alt={name} />
                           <AvatarFallback className="text-sm font-medium text-text-dark bg-[#E8FAF9]">
                             {name.slice(0, 1)}
                           </AvatarFallback>
                         </Avatar>
                       </CustomLink>
                       <div className="flex-1 min-w-0">
-                        <CustomLink href={`/users/${userId}`} className="text-sm font-medium text-text-dark hover:underline">
+                        <CustomLink href={`/users/${req.requesterExternalId}`} className="text-sm font-medium text-text-dark hover:underline">
                           {name}
                         </CustomLink>
-                        {user?.bio && (
-                          <p className="text-xs text-[#9FB5B8] truncate">{user.bio}</p>
-                        )}
                       </div>
                     </div>
 
-                    {reqAny.intent && (
+                    {req.intent && (
                       <p className="text-xs text-text-dark/70 bg-[#F7FAFA] rounded-lg px-3 py-2 leading-relaxed border border-[#E4EAE9]">
-                        「{reqAny.intent}」
+                        「{req.intent}」
                       </p>
                     )}
 
                     <div className="flex gap-2">
                       <Button
                         size="sm"
-                        onClick={() => handleAccept(String(requestId), name)}
+                        onClick={() => handleAccept(String(req.requestId), name)}
                         className="flex-1 h-8 text-xs cursor-pointer bg-logo-cyan hover:bg-logo-cyan/90 text-white"
                       >
                         接受
@@ -151,7 +144,7 @@ export const ConnectionsSettings = () => {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => handleIgnore(String(requestId), name)}
+                        onClick={() => handleIgnore(String(req.requestId), name)}
                         className="flex-1 h-8 text-xs cursor-pointer"
                       >
                         忽略
@@ -166,24 +159,20 @@ export const ConnectionsSettings = () => {
           {/* 發出的 */}
           {outgoingRequests.length > 0 && (
             <div className="flex flex-col gap-2">
-              {outgoingRequests.map((req, index) => {
-                const reqAny = req as any;
-                const user = req.receiver;
-                const name = reqAny.receiverNickname || user?.name || "用戶";
-                const userId = reqAny.receiverExternalId || user?.identifier || user?.id || req.receiverId;
-                const requestId = reqAny.requestId || req.id;
+              {outgoingRequests.map((req) => {
+                const name = req.receiverNickname || "用戶";
                 return (
-                  <div key={requestId || `outgoing-${index}`} className="bg-white rounded-lg p-3 flex items-center gap-3">
-                    <CustomLink href={`/users/${userId}`} className="shrink-0">
+                  <div key={req.requestId} className="bg-white rounded-lg p-3 flex items-center gap-3">
+                    <CustomLink href={`/users/${req.receiverExternalId}`} className="shrink-0">
                       <Avatar className="size-10">
-                        <AvatarImage src={user?.photoURL} alt={name} />
+                        <AvatarImage src={req.receiverPhotoUrl ?? undefined} alt={name} />
                         <AvatarFallback className="text-sm font-medium text-text-dark bg-[#E8FAF9]">
                           {name.slice(0, 1)}
                         </AvatarFallback>
                       </Avatar>
                     </CustomLink>
                     <div className="flex-1 min-w-0">
-                      <CustomLink href={`/users/${userId}`} className="text-sm font-medium text-text-dark hover:underline">
+                      <CustomLink href={`/users/${req.receiverExternalId}`} className="text-sm font-medium text-text-dark hover:underline">
                         {name}
                       </CustomLink>
                       <p className="text-xs text-[#9FB5B8]">等待對方回應</p>
@@ -191,7 +180,7 @@ export const ConnectionsSettings = () => {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => handleWithdraw(String(requestId), name)}
+                      onClick={() => handleWithdraw(String(req.requestId), name)}
                       className="shrink-0 h-8 px-3 text-xs cursor-pointer"
                     >
                       撤回
@@ -215,33 +204,27 @@ export const ConnectionsSettings = () => {
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            {connections.map((conn, index) => {
-              const connAny = conn as any;
-              const partner = conn.partner;
-              const name = connAny.nickname || partner?.name || "用戶";
-              const partnerId = connAny.externalId || partner?.identifier || partner?.id || conn.userAId;
+            {connections.map((conn) => {
+              const name = conn.nickname || "用戶";
               return (
-                <div key={connAny.connectionId || conn.id || partnerId || `conn-${index}`} className="bg-white rounded-lg p-3 flex items-center gap-3">
-                  <CustomLink href={`/users/${partnerId}`} className="shrink-0">
+                <div key={conn.connectionId} className="bg-white rounded-lg p-3 flex items-center gap-3">
+                  <CustomLink href={`/users/${conn.externalId}`} className="shrink-0">
                     <Avatar className="size-10">
-                      <AvatarImage src={partner?.photoURL} alt={name} />
+                      <AvatarImage src={conn.photoUrl ?? undefined} alt={name} />
                       <AvatarFallback className="text-sm font-medium text-text-dark bg-[#E8FAF9]">
                         {name.slice(0, 1)}
                       </AvatarFallback>
                     </Avatar>
                   </CustomLink>
                   <div className="flex-1 min-w-0">
-                    <CustomLink href={`/users/${partnerId}`} className="text-sm font-medium text-text-dark hover:underline">
+                    <CustomLink href={`/users/${conn.externalId}`} className="text-sm font-medium text-text-dark hover:underline">
                       {name}
                     </CustomLink>
-                    {partner?.bio && (
-                      <p className="text-xs text-[#9FB5B8] truncate">{partner.bio}</p>
-                    )}
                   </div>
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => handleDisconnect(partnerId, name)}
+                    onClick={() => handleDisconnect(conn.externalId, name)}
                     className="shrink-0 h-8 px-3 text-xs cursor-pointer"
                   >
                     解除連結

--- a/apps/product/src/components/social/social-hub.tsx
+++ b/apps/product/src/components/social/social-hub.tsx
@@ -117,28 +117,23 @@ const ConnectionsTab = () => {
           <h2 className="text-xs font-medium text-[#9FB5B8] px-1">收到的請求</h2>
           <div className="flex flex-col gap-2">
             {incomingRequests.map((req) => {
-              const user = req.requester;
-              const name = user?.name ?? "用戶";
-              const userId = user?.identifier || user?.id || req.requesterId;
+              const name = req.requesterNickname ?? "用戶";
               return (
-                <div key={req.id} className="bg-white rounded-lg p-3 flex flex-col gap-3">
+                <div key={req.requestId} className="bg-white rounded-lg p-3 flex flex-col gap-3">
                   <div className="flex items-center gap-3">
                     <Avatar className="size-10 shrink-0">
-                      <AvatarImage src={user?.photoURL} alt={name} />
+                      <AvatarImage src={req.requesterPhotoUrl ?? undefined} alt={name} />
                       <AvatarFallback className="text-sm font-medium text-text-dark bg-[#E8FAF9]">
                         {name.slice(0, 1)}
                       </AvatarFallback>
                     </Avatar>
                     <div className="flex-1 min-w-0">
                       <CustomLink
-                        href={`/users/${user?.identifier ?? userId}`}
+                        href={`/users/${req.requesterExternalId}`}
                         className="text-sm font-medium text-text-dark hover:underline"
                       >
                         {name}
                       </CustomLink>
-                      {user?.bio && (
-                        <p className="text-xs text-[#9FB5B8] truncate">{user.bio}</p>
-                      )}
                     </div>
                   </div>
 
@@ -151,7 +146,7 @@ const ConnectionsTab = () => {
                   <div className="flex gap-2">
                     <Button
                       size="sm"
-                      onClick={() => handleAccept(req.id, name)}
+                      onClick={() => handleAccept(String(req.requestId), name)}
                       className="flex-1 h-8 text-xs cursor-pointer bg-logo-cyan hover:bg-logo-cyan/90 text-white"
                     >
                       接受
@@ -159,7 +154,7 @@ const ConnectionsTab = () => {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => handleIgnore(req.id, name)}
+                      onClick={() => handleIgnore(String(req.requestId), name)}
                       className="flex-1 h-8 text-xs cursor-pointer"
                     >
                       忽略
@@ -178,20 +173,18 @@ const ConnectionsTab = () => {
           <h2 className="text-xs font-medium text-[#9FB5B8] px-1">發出的請求</h2>
           <div className="flex flex-col gap-2">
             {outgoingRequests.map((req) => {
-              const user = req.receiver;
-              const name = user?.name ?? "用戶";
-              const userId = user?.identifier || user?.id || req.receiverId;
+              const name = req.receiverNickname ?? "用戶";
               return (
-                <div key={req.id} className="bg-white rounded-lg p-3 flex items-center gap-3">
+                <div key={req.requestId} className="bg-white rounded-lg p-3 flex items-center gap-3">
                   <Avatar className="size-10 shrink-0">
-                    <AvatarImage src={user?.photoURL} alt={name} />
+                    <AvatarImage src={req.receiverPhotoUrl ?? undefined} alt={name} />
                     <AvatarFallback className="text-sm font-medium text-text-dark bg-[#E8FAF9]">
                       {name.slice(0, 1)}
                     </AvatarFallback>
                   </Avatar>
                   <div className="flex-1 min-w-0">
                     <CustomLink
-                      href={`/users/${user?.identifier ?? userId}`}
+                      href={`/users/${req.receiverExternalId}`}
                       className="text-sm font-medium text-text-dark hover:underline"
                     >
                       {name}
@@ -201,7 +194,7 @@ const ConnectionsTab = () => {
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => handleWithdraw(req.id, name)}
+                    onClick={() => handleWithdraw(String(req.requestId), name)}
                     className="shrink-0 h-8 px-3 text-xs cursor-pointer"
                   >
                     撤回
@@ -225,32 +218,27 @@ const ConnectionsTab = () => {
         ) : (
           <div className="flex flex-col gap-2">
             {connections.map((conn) => {
-              const partner = conn.partner;
-              const name = partner?.name ?? "用戶";
-              const partnerId = partner?.identifier || partner?.id || conn.userAId;
+              const name = conn.nickname ?? "用戶";
               return (
-                <div key={conn.id} className="bg-white rounded-lg p-3 flex items-center gap-3">
+                <div key={conn.connectionId} className="bg-white rounded-lg p-3 flex items-center gap-3">
                   <Avatar className="size-10 shrink-0">
-                    <AvatarImage src={partner?.photoURL} alt={name} />
+                    <AvatarImage src={conn.photoUrl ?? undefined} alt={name} />
                     <AvatarFallback className="text-sm font-medium text-text-dark bg-[#E8FAF9]">
                       {name.slice(0, 1)}
                     </AvatarFallback>
                   </Avatar>
                   <div className="flex-1 min-w-0">
                     <CustomLink
-                      href={`/users/${partner?.identifier ?? partnerId}`}
+                      href={`/users/${conn.externalId}`}
                       className="text-sm font-medium text-text-dark hover:underline"
                     >
                       {name}
                     </CustomLink>
-                    {partner?.bio && (
-                      <p className="text-xs text-[#9FB5B8] truncate">{partner.bio}</p>
-                    )}
                   </div>
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => handleDisconnect(partnerId, name)}
+                    onClick={() => handleDisconnect(conn.externalId, name)}
                     className="shrink-0 h-8 px-3 text-xs cursor-pointer"
                   >
                     解除連結

--- a/apps/product/src/components/user/user-info-card.tsx
+++ b/apps/product/src/components/user/user-info-card.tsx
@@ -97,6 +97,7 @@ const getSocialIcon = (platform: SocialPlatformType) => {
 
 interface UserInfoCardProps {
   name: string;
+  customId?: string;
   location?: string;
   selfIntroduction?: string;
   photoURL?: string;
@@ -117,6 +118,7 @@ interface UserInfoCardProps {
  */
 export function UserInfoCard({
   name,
+  customId,
   location,
   selfIntroduction,
   photoURL,
@@ -348,6 +350,9 @@ export function UserInfoCard({
         <div className="flex-1">
           <div className="mb-3">
             <h2 className="text-[22px] font-medium mb-1 text-bg-dark truncate">{name}</h2>
+            {customId && (
+              <p className="text-sm text-text-dark/60 mb-1">@{customId}</p>
+            )}
             {/* Headline (personalSlogan) - 未填寫時不顯示 */}
             {personalSlogan && (
               <p className="text-sm text-text-dark mb-1">{personalSlogan}</p>

--- a/packages/api/src/services/connection.ts
+++ b/packages/api/src/services/connection.ts
@@ -6,48 +6,36 @@ import { unauthorizedHandler } from "../client";
 // (Follow/Connection API は types.ts 生成前のため手動定義)
 // ============================================================================
 
-export interface IConnectionUserProfile {
-  id: string;
-  name: string;
-  photoURL?: string;
-  bio?: string;
-  identifier?: string;
-}
-
 export interface IConnectionRequest {
-  id: string;
-  requesterId: string;
-  receiverId: string;
-  intent?: string;
-  status: "pending" | "accepted" | "rejected";
-  contextPracticeId?: string;
+  requestId: number;
+  requesterExternalId: string;
+  requesterNickname: string | null;
+  requesterPhotoUrl: string | null;
+  receiverExternalId: string;
+  receiverNickname: string | null;
+  receiverPhotoUrl: string | null;
+  intent: string | null;
+  interactionCount: number;
   createdAt: string;
-  updatedAt: string;
-  requester?: IConnectionUserProfile;
-  receiver?: IConnectionUserProfile;
 }
 
-export interface IConnection {
-  id: string;
-  userAId: string;
-  userBId: string;
+export interface IConnectionItem {
+  connectionId: number;
+  userId: number;
+  externalId: string;
+  nickname: string | null;
+  photoUrl: string | null;
   connectedAt: string;
-  partner?: IConnectionUserProfile;
 }
 
-export interface IPaginatedConnectionRequests {
-  data: IConnectionRequest[];
-  total: number;
-  page: number;
-  limit: number;
+export interface IApiResponse<T> {
+  success: boolean;
+  data: T;
+  timestamp: string;
 }
 
-export interface IPaginatedConnections {
-  data: IConnection[];
-  total: number;
-  page: number;
-  limit: number;
-}
+export type IPaginatedConnectionRequests = IApiResponse<IConnectionRequest[]>;
+export type IPaginatedConnections = IApiResponse<IConnectionItem[]>;
 
 export interface ISendConnectionRequestBody {
   receiverExternalId: string;


### PR DESCRIPTION
---  
## Why is this necessary?  
- 首頁的 slogan 氣泡文字過長，影響了版面顯示。  
- 實踐詳細頁的導航設計不夠直觀，使用者體驗不佳。  
- 使用者個人頁面缺少 customId 的顯示，無法提供完整資訊。  
- 前端對 API 回傳結構的處理不一致，影響了頭像的顯示。  

## How does it address?  
- 修正首頁的 slogan 氣泡文字，確保其不會破版。  
- 將實踐詳細頁的頂部導航簡化，改用 X 按鈕以提高可用性。  
- 在使用者個人頁面中新增 customId 的顯示，提供更多資訊。  
- 調整前端對 API 回傳結構的處理，改用扁平欄位顯示頭像，提升一致性。  