### PR TITLE
feat(website): 修復 CD Docker build 失敗的問題

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -9,6 +9,7 @@ loadEnvConfig(path.resolve(process.cwd(), "../.."));
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  output: "export",
   reactStrictMode: true,
   typedRoutes: true,
   transpilePackages: [


### PR DESCRIPTION
## Why is this necessary?

1. CD Docker build 失敗會導致自動化部署無法進行，影響開發流程。
2. 確保網站能夠正常運行並且能夠順利部署到生產環境。
3. 維持代碼庫的穩定性，避免因為構建失敗而造成的時間浪費。

## How does it address?

1. 加回 `output: "export"` 設定，修復了 Docker build 的問題。
2. 確保構建過程中的所有依賴和配置正確無誤。
3. 測試並驗證修復後的構建流程，確保不再出現相同的問題。