### PR TITLE
fix(showcase): 還原實踐卡片狀態 badge 樣式並新增資料驗證  

### DIFF
--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -181,6 +181,10 @@ export function PracticeShowcaseCard({
     >
       {/* Header row */}
       <div className="flex items-center gap-2 mb-2">
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#E8F8FF] text-logo-cyan text-xs font-medium">
+          <FlagOutlineSvg className="size-3" />
+          實踐
+        </span>
         <Badge variant={statusInfo.variant} size="sm" className="w-fit">
           {statusInfo.label}
         </Badge>

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -181,11 +181,7 @@ export function PracticeShowcaseCard({
     >
       {/* Header row */}
       <div className="flex items-center gap-2 mb-2">
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#E8F8FF] text-logo-cyan text-xs font-medium">
-          <FlagOutlineSvg className="size-3" />
-          實踐
-        </span>
-        <Badge variant={statusInfo.variant} size="sm" className="w-fit text-[10px] bg-primary-lightest">
+        <Badge variant={statusInfo.variant} size="sm" className="w-fit">
           {statusInfo.label}
         </Badge>
         {startFmt && endFmt && (

--- a/packages/api/src/services/feed-hooks.ts
+++ b/packages/api/src/services/feed-hooks.ts
@@ -111,13 +111,13 @@ export function useFeed(params: IFeedParams) {
 
   const feedItems: FeedItem[] = data
     ? data.flatMap((page) =>
-        (page.data ?? []).filter((item) => {
-          if (!item?.type || !item?.data) {
-            console.warn("[useFeed] Malformed feed item (missing type/data):", item);
-            return false;
-          }
-          return true;
-        }),
+(page.data ?? []).filter((item) => {
+  const isValid = !!(item?.type && item?.data);
+  if (!isValid && process.env.NODE_ENV !== "production") {
+    console.warn("[useFeed] Malformed feed item (missing type/data):", item);
+  }
+  return isValid;
+})
       )
     : [];
 

--- a/packages/api/src/services/feed-hooks.ts
+++ b/packages/api/src/services/feed-hooks.ts
@@ -110,7 +110,15 @@ export function useFeed(params: IFeedParams) {
     );
 
   const feedItems: FeedItem[] = data
-    ? data.flatMap((page) => page.data ?? [])
+    ? data.flatMap((page) =>
+        (page.data ?? []).filter((item) => {
+          if (!item?.type || !item?.data) {
+            console.warn("[useFeed] Malformed feed item (missing type/data):", item);
+            return false;
+          }
+          return true;
+        }),
+      )
     : [];
 
   const hasMore = data


### PR DESCRIPTION
---  
## Why is this necessary?  
- 實踐卡片的狀態 badge 樣式需要還原，以符合設計規範。  
- 需要確保 feed 資料的正確性，以避免顯示錯誤資訊。  
- 提升用戶體驗，確保使用者能夠正確理解卡片狀態。  

## How does it address?  
- 還原了實踐卡片狀態 badge 的樣式，確保其符合預期的視覺效果。  
- 新增了對 feed 資料的驗證機制，確保資料的完整性和正確性。  
- 進行了相關測試，以驗證樣式和資料驗證的有效性。  