### PR TITLE
feat(reactions): 整合批次反應 API 以提升性能和降低重複邏輯  

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -3,6 +3,7 @@
 import {
   useMyPracticeStats,
   useMyPractices,
+  useReactionsBatch,
   useShowcaseFeed,
   type IShowcasePractice,
 } from "@daodao/api";
@@ -94,6 +95,14 @@ export default function HomePage() {
     loadMore,
     isValidating,
   } = useShowcaseFeed(showcaseParams);
+
+  // Batch fetch reactions for all visible practices
+  const practiceIds = useMemo(
+    () => practices.map((p: IShowcasePractice) => p.id),
+    [practices],
+  );
+  const { data: batchReactionsData, mutate: mutateBatchReactions } =
+    useReactionsBatch({ targetType: "practice", targetIds: practiceIds });
 
   // Infinite scroll observer
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -269,6 +278,8 @@ export default function HomePage() {
                         frequencyMaxDays={practice.frequency_max_days}
                         sessionDurationMinutes={practice.session_duration_minutes}
                         commentCount={practice.comment_count}
+                        batchReactionData={batchReactionsData?.data?.[practice.id]}
+                        onReactionMutate={() => mutateBatchReactions()}
                       />
                     ) : (
                       <PracticeShowcaseCard
@@ -292,6 +303,8 @@ export default function HomePage() {
                         frequencyMaxDays={practice.frequency_max_days}
                         sessionDurationMinutes={practice.session_duration_minutes}
                         commentCount={practice.comment_count}
+                        batchReactionData={batchReactionsData?.data?.[practice.id]}
+                        onReactionMutate={() => mutateBatchReactions()}
                       />
                     )
                   )}

--- a/apps/product/src/components/showcase/BrewingCard.tsx
+++ b/apps/product/src/components/showcase/BrewingCard.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import type { BatchReactionItem, ReactionTypeValue } from "@daodao/api";
+import type { BatchReactionItem } from "@daodao/api";
 import {
   followTarget,
-  removeReaction,
   unfollowTarget,
-  upsertReaction,
   useComments,
   usePracticeById,
-  useReactions,
   useReactionsList,
 } from "@daodao/api";
 import {
@@ -26,7 +23,7 @@ import { Button } from "@daodao/ui/components/button";
 import { toast } from "@daodao/ui/components/sonner";
 import { cn } from "@daodao/ui/lib/utils";
 import { MoreHorizontal } from "lucide-react";
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ReactionPickerButton } from "@/components/check-in/reactions";
 import {
   BrowseActivityContent,
@@ -34,6 +31,7 @@ import {
 } from "@/components/practice/shared/browse-activity-content";
 import type { ReactionTypeType } from "@/constants/reaction-type";
 import { getStatusConfig, TaskStatus } from "@/constants/task-status";
+import { useCardReactions } from "@/hooks/use-card-reactions";
 import { formatRelativeTime } from "@/utils/format-time";
 import { formatShowcaseDate } from "./utils";
 
@@ -146,44 +144,8 @@ export function BrewingCard({
     });
   };
 
-  const { data: reactionsData, mutate } = useReactions(
-    { targetType: "practice", targetId: id },
-    { enabled: !batchReactionData },
-  );
-  const [, startTransition] = useTransition();
-
-  const reactionSource = batchReactionData ?? reactionsData?.data;
-  const currentUserReaction = (reactionSource?.currentUserReaction ??
-    null) as ReactionTypeType | null;
-  const selectedReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
-  const allReactions = reactionSource?.reactions ?? [];
-  const totalCount = allReactions.reduce((sum, r) => sum + r.count, 0);
-  const displayReactions = allReactions
-    .filter((r) => r.count > 0)
-    .map((r) => r.type as ReactionTypeType);
-
-  const handleToggle = useCallback(
-    (type: ReactionTypeType) => {
-      const isSelected = currentUserReaction === type;
-      startTransition(async () => {
-        if (isSelected) {
-          await removeReaction({ targetType: "practice", targetId: id });
-        } else {
-          await upsertReaction({
-            targetType: "practice",
-            targetId: id,
-            reactionType: type as ReactionTypeValue,
-          });
-        }
-        if (onReactionMutate) {
-          onReactionMutate();
-        } else {
-          await mutate();
-        }
-      });
-    },
-    [currentUserReaction, id, mutate]
-  );
+  const { selectedReactions, totalCount, displayReactions, handleToggle } =
+    useCardReactions("practice", id, batchReactionData, onReactionMutate);
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: card click for navigation

--- a/apps/product/src/components/showcase/BrewingCard.tsx
+++ b/apps/product/src/components/showcase/BrewingCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactionTypeValue } from "@daodao/api";
+import type { BatchReactionItem, ReactionTypeValue } from "@daodao/api";
 import {
   followTarget,
   removeReaction,
@@ -52,6 +52,8 @@ interface BrewingCardProps {
   frequencyMaxDays?: number | null;
   sessionDurationMinutes?: number | null;
   commentCount?: number;
+  batchReactionData?: BatchReactionItem;
+  onReactionMutate?: () => void;
 }
 
 export function BrewingCard({
@@ -65,6 +67,8 @@ export function BrewingCard({
   frequencyMaxDays,
   sessionDurationMinutes,
   commentCount = 0,
+  batchReactionData,
+  onReactionMutate,
 }: BrewingCardProps) {
   const startFmt = formatShowcaseDate(startDate);
   const endFmt = formatShowcaseDate(endDate);
@@ -76,7 +80,10 @@ export function BrewingCard({
   const router = useRouter();
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { data: practiceData } = usePracticeById(id);
-  const { data: reactionsListData } = useReactionsList({ targetType: "practice", targetId: id });
+  const { data: reactionsListData } = useReactionsList(
+    { targetType: "practice", targetId: id },
+    { enabled: !batchReactionData },
+  );
   const { data: commentsData } = useComments({ targetType: "practice", targetId: id });
 
   useEffect(() => {
@@ -113,7 +120,8 @@ export function BrewingCard({
 
   const handleOpenBrowseActivity = () => {
     setMenuOpen(false);
-    const followers: IBrowseActivityFollower[] = (reactionsListData?.data?.items ?? []).map(
+    const reactionItems = batchReactionData?.items ?? reactionsListData?.data?.items ?? [];
+    const followers: IBrowseActivityFollower[] = reactionItems.map(
       (item) => ({
         id: item.userId,
         name: item.name,
@@ -138,13 +146,17 @@ export function BrewingCard({
     });
   };
 
-  const { data: reactionsData, mutate } = useReactions({ targetType: "practice", targetId: id });
+  const { data: reactionsData, mutate } = useReactions(
+    { targetType: "practice", targetId: id },
+    { enabled: !batchReactionData },
+  );
   const [, startTransition] = useTransition();
 
-  const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
+  const reactionSource = batchReactionData ?? reactionsData?.data;
+  const currentUserReaction = (reactionSource?.currentUserReaction ??
     null) as ReactionTypeType | null;
   const selectedReactions: ReactionTypeType[] = currentUserReaction ? [currentUserReaction] : [];
-  const allReactions = reactionsData?.data?.reactions ?? [];
+  const allReactions = reactionSource?.reactions ?? [];
   const totalCount = allReactions.reduce((sum, r) => sum + r.count, 0);
   const displayReactions = allReactions
     .filter((r) => r.count > 0)
@@ -163,7 +175,11 @@ export function BrewingCard({
             reactionType: type as ReactionTypeValue,
           });
         }
-        await mutate();
+        if (onReactionMutate) {
+          onReactionMutate();
+        } else {
+          await mutate();
+        }
       });
     },
     [currentUserReaction, id, mutate]
@@ -316,7 +332,7 @@ export function BrewingCard({
           variant="summary"
           totalCount={totalCount}
           displayReactions={displayReactions}
-          firstReactorName={reactionsListData?.data?.items[0]?.name}
+          firstReactorName={batchReactionData?.items[0]?.name ?? reactionsListData?.data?.items[0]?.name}
         />
 
         <Link

--- a/apps/product/src/components/showcase/BrewingCard.tsx
+++ b/apps/product/src/components/showcase/BrewingCard.tsx
@@ -6,7 +6,6 @@ import {
   unfollowTarget,
   useComments,
   usePracticeById,
-  useReactionsList,
 } from "@daodao/api";
 import {
   ChartColumnIncreasingSvg,
@@ -78,10 +77,6 @@ export function BrewingCard({
   const router = useRouter();
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { data: practiceData } = usePracticeById(id);
-  const { data: reactionsListData } = useReactionsList(
-    { targetType: "practice", targetId: id },
-    { enabled: !batchReactionData },
-  );
   const { data: commentsData } = useComments({ targetType: "practice", targetId: id });
 
   useEffect(() => {
@@ -118,7 +113,6 @@ export function BrewingCard({
 
   const handleOpenBrowseActivity = () => {
     setMenuOpen(false);
-    const reactionItems = batchReactionData?.items ?? reactionsListData?.data?.items ?? [];
     const followers: IBrowseActivityFollower[] = reactionItems.map(
       (item) => ({
         id: item.userId,
@@ -144,7 +138,7 @@ export function BrewingCard({
     });
   };
 
-  const { selectedReactions, totalCount, displayReactions, handleToggle } =
+  const { selectedReactions, totalCount, displayReactions, handleToggle, reactionItems, firstReactorName } =
     useCardReactions("practice", id, batchReactionData, onReactionMutate);
 
   return (
@@ -294,7 +288,7 @@ export function BrewingCard({
           variant="summary"
           totalCount={totalCount}
           displayReactions={displayReactions}
-          firstReactorName={batchReactionData?.items[0]?.name ?? reactionsListData?.data?.items[0]?.name}
+          firstReactorName={firstReactorName}
         />
 
         <Link

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/practice/shared/browse-activity-content";
 import type { ReactionTypeType } from "@/constants/reaction-type";
 import { getStatusConfig, TaskStatus } from "@/constants/task-status";
+import type { BatchReactionItem } from "@daodao/api";
 import { useCardReactions } from "@/hooks/use-card-reactions";
 import { formatRelativeTime } from "@/utils/format-time";
 import { formatShowcaseDate } from "./utils";
@@ -50,6 +51,8 @@ interface PracticeShowcaseCardProps {
   frequencyMaxDays?: number | null;
   sessionDurationMinutes?: number | null;
   commentCount?: number;
+  batchReactionData?: BatchReactionItem;
+  onReactionMutate?: () => void;
 }
 
 export function PracticeShowcaseCard({
@@ -64,6 +67,8 @@ export function PracticeShowcaseCard({
   frequencyMaxDays,
   sessionDurationMinutes,
   commentCount = 0,
+  batchReactionData,
+  onReactionMutate,
 }: PracticeShowcaseCardProps) {
   const startFmt = formatShowcaseDate(startDate);
   const endFmt = formatShowcaseDate(endDate);
@@ -76,7 +81,10 @@ export function PracticeShowcaseCard({
   const router = useRouter();
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { data: practiceData } = usePracticeById(id);
-  const { data: reactionsListData } = useReactionsList({ targetType: "practice", targetId: id });
+  const { data: reactionsListData } = useReactionsList(
+    { targetType: "practice", targetId: id },
+    { enabled: !batchReactionData },
+  );
   const { data: commentsData } = useComments({ targetType: "practice", targetId: id });
 
   useEffect(() => {
@@ -113,7 +121,8 @@ export function PracticeShowcaseCard({
 
   const handleOpenBrowseActivity = () => {
     setMenuOpen(false);
-    const followers: IBrowseActivityFollower[] = (reactionsListData?.data?.items ?? []).map(
+    const reactionItems = batchReactionData?.items ?? reactionsListData?.data?.items ?? [];
+    const followers: IBrowseActivityFollower[] = reactionItems.map(
       (item) => ({
         id: item.userId,
         name: item.name,
@@ -139,7 +148,7 @@ export function PracticeShowcaseCard({
   };
 
   const { selectedReactions, totalCount, displayReactions, handleToggle } =
-    useCardReactions("practice", id);
+    useCardReactions("practice", id, batchReactionData, onReactionMutate);
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: card click for navigation
@@ -283,7 +292,7 @@ export function PracticeShowcaseCard({
           variant="summary"
           totalCount={totalCount}
           displayReactions={displayReactions}
-          firstReactorName={reactionsListData?.data?.items[0]?.name}
+          firstReactorName={batchReactionData?.items[0]?.name ?? reactionsListData?.data?.items[0]?.name}
         />
 
         <Link

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -5,7 +5,6 @@ import {
   unfollowTarget,
   useComments,
   usePracticeById,
-  useReactionsList,
 } from "@daodao/api";
 import {
   ChartColumnIncreasingSvg,
@@ -81,10 +80,6 @@ export function PracticeShowcaseCard({
   const router = useRouter();
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { data: practiceData } = usePracticeById(id);
-  const { data: reactionsListData } = useReactionsList(
-    { targetType: "practice", targetId: id },
-    { enabled: !batchReactionData },
-  );
   const { data: commentsData } = useComments({ targetType: "practice", targetId: id });
 
   useEffect(() => {
@@ -121,7 +116,6 @@ export function PracticeShowcaseCard({
 
   const handleOpenBrowseActivity = () => {
     setMenuOpen(false);
-    const reactionItems = batchReactionData?.items ?? reactionsListData?.data?.items ?? [];
     const followers: IBrowseActivityFollower[] = reactionItems.map(
       (item) => ({
         id: item.userId,
@@ -147,7 +141,7 @@ export function PracticeShowcaseCard({
     });
   };
 
-  const { selectedReactions, totalCount, displayReactions, handleToggle } =
+  const { selectedReactions, totalCount, displayReactions, handleToggle, reactionItems, firstReactorName } =
     useCardReactions("practice", id, batchReactionData, onReactionMutate);
 
   return (
@@ -292,7 +286,7 @@ export function PracticeShowcaseCard({
           variant="summary"
           totalCount={totalCount}
           displayReactions={displayReactions}
-          firstReactorName={batchReactionData?.items[0]?.name ?? reactionsListData?.data?.items[0]?.name}
+          firstReactorName={firstReactorName}
         />
 
         <Link

--- a/apps/product/src/hooks/use-card-reactions.ts
+++ b/apps/product/src/hooks/use-card-reactions.ts
@@ -2,10 +2,16 @@
 
 import type {
   BatchReactionItem,
+  ReactionListItem,
   ReactionTargetType,
   ReactionTypeValue,
 } from "@daodao/api";
-import { removeReaction, upsertReaction, useReactions } from "@daodao/api";
+import {
+  removeReaction,
+  upsertReaction,
+  useReactions,
+  useReactionsList,
+} from "@daodao/api";
 import { useCallback, useTransition } from "react";
 import type { ReactionTypeType } from "@/constants/reaction-type";
 
@@ -15,9 +21,15 @@ export function useCardReactions(
   prefetchedData?: BatchReactionItem,
   onMutate?: () => void,
 ) {
+  const hasBatch = !!prefetchedData;
+
   const { data: reactionsData, mutate } = useReactions(
     { targetType, targetId },
-    { enabled: !prefetchedData },
+    { enabled: !hasBatch },
+  );
+  const { data: reactionsListData } = useReactionsList(
+    { targetType, targetId },
+    { enabled: !hasBatch },
   );
   const [, startTransition] = useTransition();
 
@@ -33,6 +45,11 @@ export function useCardReactions(
     .filter((r) => r.count > 0)
     .map((r) => r.type as ReactionTypeType);
 
+  // Reaction list items（用於瀏覽活動等）
+  const reactionItems: ReactionListItem[] =
+    prefetchedData?.items ?? reactionsListData?.data?.items ?? [];
+  const firstReactorName = reactionItems[0]?.name ?? undefined;
+
   const handleToggle = useCallback(
     (type: ReactionTypeType) => {
       const isSelected = currentUserReaction === type;
@@ -46,7 +63,6 @@ export function useCardReactions(
             reactionType: type as ReactionTypeValue,
           });
         }
-        // 同時 revalidate 獨立 SWR cache 和 batch cache
         await mutate();
         onMutate?.();
       });
@@ -59,5 +75,7 @@ export function useCardReactions(
     totalCount,
     displayReactions,
     handleToggle,
+    reactionItems,
+    firstReactorName,
   };
 }

--- a/apps/product/src/hooks/use-card-reactions.ts
+++ b/apps/product/src/hooks/use-card-reactions.ts
@@ -1,23 +1,33 @@
 "use client";
 
-import type { ReactionTargetType, ReactionTypeValue } from "@daodao/api";
+import type {
+  BatchReactionItem,
+  ReactionTargetType,
+  ReactionTypeValue,
+} from "@daodao/api";
 import { removeReaction, upsertReaction, useReactions } from "@daodao/api";
 import { useCallback, useTransition } from "react";
 import type { ReactionTypeType } from "@/constants/reaction-type";
 
-export function useCardReactions(targetType: ReactionTargetType, targetId: string) {
-  const { data: reactionsData, mutate } = useReactions({
-    targetType,
-    targetId,
-  });
+export function useCardReactions(
+  targetType: ReactionTargetType,
+  targetId: string,
+  prefetchedData?: BatchReactionItem,
+  onMutate?: () => void,
+) {
+  const { data: reactionsData, mutate } = useReactions(
+    { targetType, targetId },
+    { enabled: !prefetchedData },
+  );
   const [, startTransition] = useTransition();
 
-  const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
-    null) as ReactionTypeType | null;
+  const source = prefetchedData ?? reactionsData?.data;
+
+  const currentUserReaction = (source?.currentUserReaction ?? null) as ReactionTypeType | null;
   const selectedReactions: ReactionTypeType[] = currentUserReaction
     ? [currentUserReaction]
     : [];
-  const allReactions = reactionsData?.data?.reactions ?? [];
+  const allReactions = source?.reactions ?? [];
   const totalCount = allReactions.reduce((sum, r) => sum + r.count, 0);
   const displayReactions = allReactions
     .filter((r) => r.count > 0)
@@ -36,10 +46,14 @@ export function useCardReactions(targetType: ReactionTargetType, targetId: strin
             reactionType: type as ReactionTypeValue,
           });
         }
-        await mutate();
+        if (onMutate) {
+          onMutate();
+        } else {
+          await mutate();
+        }
       });
     },
-    [currentUserReaction, targetType, targetId, mutate],
+    [currentUserReaction, targetType, targetId, mutate, onMutate],
   );
 
   return {

--- a/apps/product/src/hooks/use-card-reactions.ts
+++ b/apps/product/src/hooks/use-card-reactions.ts
@@ -46,11 +46,9 @@ export function useCardReactions(
             reactionType: type as ReactionTypeValue,
           });
         }
-        if (onMutate) {
-          onMutate();
-        } else {
-          await mutate();
-        }
+        // 同時 revalidate 獨立 SWR cache 和 batch cache
+        await mutate();
+        onMutate?.();
       });
     },
     [currentUserReaction, targetType, targetId, mutate, onMutate],

--- a/packages/api/src/services/reaction-hooks.ts
+++ b/packages/api/src/services/reaction-hooks.ts
@@ -5,8 +5,10 @@
  * 提供快速反應相關的 React Hooks（用於 Client Components）
  */
 
+import useSWR from "swr";
 import { useQuery } from "../hooks";
-import type { IGetReactionsParams } from "./reaction";
+import type { IGetReactionsParams, IGetReactionsBatchParams } from "./reaction";
+import { getReactionsBatch } from "./reaction";
 
 // ============================================================================
 // Query Hooks
@@ -14,42 +16,77 @@ import type { IGetReactionsParams } from "./reaction";
 
 /**
  * 取得目標反應計數的 Hook
+ * @param enabled - 設為 false 時不發請求（用於有預取資料的場景）
  */
-export const useReactions = (params: IGetReactionsParams) => {
+export const useReactions = (
+  params: IGetReactionsParams,
+  options?: { enabled?: boolean },
+) => {
+  const enabled = options?.enabled ?? true;
   return useQuery(
     "/api/v1/reactions",
-    {
-      params: {
-        query: {
-          targetType: params.targetType,
-          targetId: params.targetId,
-        },
-      },
-    },
+    enabled
+      ? {
+          params: {
+            query: {
+              targetType: params.targetType,
+              targetId: params.targetId,
+            },
+          },
+        }
+      : null,
     {
       refreshInterval: 30_000,
       revalidateOnFocus: true,
-    }
+    },
   );
 };
 
 /**
  * 取得目標個別用戶反應列表的 Hook
  */
-export const useReactionsList = (params: IGetReactionsParams) => {
+/**
+ * 取得目標個別用戶反應列表的 Hook
+ * @param enabled - 設為 false 時不發請求（用於有預取資料的場景）
+ */
+export const useReactionsList = (
+  params: IGetReactionsParams,
+  options?: { enabled?: boolean },
+) => {
+  const enabled = options?.enabled ?? true;
   return useQuery(
     "/api/v1/reactions/list",
-    {
-      params: {
-        query: {
-          targetType: params.targetType,
-          targetId: params.targetId,
-        },
-      },
-    },
+    enabled
+      ? {
+          params: {
+            query: {
+              targetType: params.targetType,
+              targetId: params.targetId,
+            },
+          },
+        }
+      : null,
     {
       refreshInterval: 30_000,
       revalidateOnFocus: true,
-    }
+    },
+  );
+};
+
+/**
+ * 批次取得多個目標的反應計數 + 用戶反應列表
+ */
+export const useReactionsBatch = (params: IGetReactionsBatchParams) => {
+  const sortedIds = [...params.targetIds].sort().join(",");
+
+  return useSWR(
+    params.targetIds.length > 0
+      ? ["/api/v1/reactions/batch", params.targetType, sortedIds]
+      : null,
+    () => getReactionsBatch(params),
+    {
+      refreshInterval: 30_000,
+      revalidateOnFocus: true,
+    },
   );
 };

--- a/packages/api/src/services/reaction.ts
+++ b/packages/api/src/services/reaction.ts
@@ -32,6 +32,28 @@ export interface IGetReactionsParams {
   targetId: string;
 }
 
+export interface IGetReactionsBatchParams {
+  targetType: ReactionTargetType;
+  targetIds: string[];
+}
+
+/** 單一目標的批次反應資料 */
+export interface BatchReactionItem {
+  reactions: Array<{
+    type: string;
+    count: number;
+    latestActorName: string | null;
+  }>;
+  currentUserReaction: string | null;
+  items: ReactionListItem[];
+}
+
+/** 批次反應回傳（key 為 targetId） */
+export interface GetReactionsBatchResponse {
+  success: true;
+  data: Record<string, BatchReactionItem>;
+}
+
 // ============================================================================
 // Client Functions
 // ============================================================================
@@ -76,4 +98,28 @@ export const getReactionsList = async (params: IGetReactionsParams) => {
       },
     },
   });
+};
+
+/**
+ * 批次取得多個目標的反應計數 + 用戶反應列表
+ */
+export const getReactionsBatch = async (
+  params: IGetReactionsBatchParams,
+): Promise<GetReactionsBatchResponse> => {
+  const { getRequiredEnv } = await import("@daodao/config");
+  const baseUrl = getRequiredEnv("NEXT_PUBLIC_API_URL");
+  const qs = new URLSearchParams({
+    targetType: params.targetType,
+    targetIds: params.targetIds.join(","),
+  });
+
+  const res = await fetch(`${baseUrl}/api/v1/reactions/batch?${qs}`, {
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Batch reactions fetch failed: ${res.status}`);
+  }
+
+  return res.json() as Promise<GetReactionsBatchResponse>;
 };


### PR DESCRIPTION
---  
## Why is this necessary?  
- 現有的反應請求數量過多，影響性能。  
- 卡片元件中存在重複的邏輯，增加了維護成本。  
- 需要統一處理反應列表的 fallback，以簡化代碼。  

## How does it address?  
- 整合批次反應的 hook，將多個請求合併為一個請求，顯著提升性能。  
- 重構卡片元件，使用統一的 useCardReactions hook，消除重複邏輯。  
- 統一管理 useReactionsList 的 fallback，減少代碼重複，提高可讀性。  