### PR TITLE
fix(ui): 修復提及下拉消失及文件預覽圖片破圖問題  

### DIFF
--- a/apps/product/src/components/showcase/BrewingCard.tsx
+++ b/apps/product/src/components/showcase/BrewingCard.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import type { BatchReactionItem } from "@daodao/api";
-import {
-  followTarget,
-  unfollowTarget,
-  useComments,
-  usePracticeById,
-} from "@daodao/api";
+import { followTarget, unfollowTarget, useComments, usePracticeById } from "@daodao/api";
 import {
   ChartColumnIncreasingSvg,
   DefaultAvatarSvg,
@@ -113,21 +108,21 @@ export function BrewingCard({
 
   const handleOpenBrowseActivity = () => {
     setMenuOpen(false);
-    const followers: IBrowseActivityFollower[] = reactionItems.map(
-      (item) => ({
-        id: item.userId,
-        name: item.name,
-        photoURL: item.photoURL ?? undefined,
-        time: formatRelativeTime(item.reactedAt),
-        reaction: item.reactionType as ReactionTypeType,
-      })
-    );
+    const followers: IBrowseActivityFollower[] = reactionItems.map((item) => ({
+      id: item.userId,
+      name: item.name,
+      photoURL: item.photoURL ?? undefined,
+      time: formatRelativeTime(item.reactedAt),
+      reaction: item.reactionType as ReactionTypeType,
+    }));
     openSheet({
       title: "瀏覽活動",
       content: (
         <BrowseActivityContent
           viewCount={practiceData?.data?.stats?.viewCount ?? 0}
-          commentCount={commentsData?.data?.length ?? commentCount}
+          commentCount={
+            practiceData?.data?.stats?.commentCount ?? commentsData?.data?.length ?? commentCount
+          }
           followers={followers}
           onClose={() => closeSheet()}
         />
@@ -138,8 +133,14 @@ export function BrewingCard({
     });
   };
 
-  const { selectedReactions, totalCount, displayReactions, handleToggle, reactionItems, firstReactorName } =
-    useCardReactions("practice", id, batchReactionData, onReactionMutate);
+  const {
+    selectedReactions,
+    totalCount,
+    displayReactions,
+    handleToggle,
+    reactionItems,
+    firstReactorName,
+  } = useCardReactions("practice", id, batchReactionData, onReactionMutate);
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: card click for navigation
@@ -297,7 +298,8 @@ export function BrewingCard({
         >
           <DialogOutlineSvg className="size-6" />
           {(() => {
-            const count = commentsData?.data?.length ?? commentCount;
+            const count =
+              practiceData?.data?.stats?.commentCount ?? commentsData?.data?.length ?? commentCount;
             return count > 0 ? <span className="text-sm font-medium">{count}</span> : null;
           })()}
         </Link>

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import {
-  followTarget,
   type BatchReactionItem,
+  followTarget,
   unfollowTarget,
   useComments,
   usePracticeById,
@@ -132,7 +132,9 @@ export function PracticeShowcaseCard({
       content: (
         <BrowseActivityContent
           viewCount={practiceData?.data?.stats?.viewCount ?? 0}
-          commentCount={commentsData?.data?.length ?? commentCount}
+          commentCount={
+            practiceData?.data?.stats?.commentCount ?? commentsData?.data?.length ?? commentCount
+          }
           followers={followers}
           onClose={() => closeSheet()}
         />
@@ -299,7 +301,8 @@ export function PracticeShowcaseCard({
         >
           <DialogOutlineSvg className="size-6" />
           {(() => {
-            const count = commentsData?.data?.length ?? commentCount;
+            const count =
+              practiceData?.data?.stats?.commentCount ?? commentsData?.data?.length ?? commentCount;
             return count > 0 ? <span className="text-sm font-medium">{count}</span> : null;
           })()}
         </Link>

--- a/packages/features/mention/src/components/mention-input.tsx
+++ b/packages/features/mention/src/components/mention-input.tsx
@@ -123,7 +123,12 @@ export function MentionInput({
         autoFocus={autoFocus}
       />
       {mentionQuery !== null && filtered.length > 0 && (
-        <div className="absolute top-full left-0 mt-1 bg-white rounded-xl shadow-lg border border-[#E4EAE9] py-1 z-20 min-w-[160px] max-h-44 overflow-y-auto">
+        // biome-ignore lint/a11y/noStaticElementInteractions: prevent textarea blur when clicking anywhere in dropdown
+        // biome-ignore lint/a11y/useKeyWithClickEvents: dropdown navigation handled by keyboard in textarea
+        <div
+          className="absolute top-full left-0 mt-1 bg-white rounded-xl shadow-lg border border-[#E4EAE9] py-1 z-20 min-w-[160px] max-h-44 overflow-y-auto"
+          onMouseDown={(e) => e.preventDefault()}
+        >
           {filtered.map((p) => (
             <button
               key={p.userId}

--- a/packages/ui/src/components/file-upload.tsx
+++ b/packages/ui/src/components/file-upload.tsx
@@ -7,31 +7,26 @@ import * as React from "react";
 import { cn } from "../lib/utils";
 
 // Component to handle image preview with proper cleanup
-// 使用 ref 同步建立 blob URL，避免 React strict mode 下 effect 雙重執行導致 URL 被提前 revoke
+// 使用 useState + effect cleanup 先清除 src 再 revoke，避免 React Strict Mode 雙重 effect
+// 導致 URL 失效後 img 仍指向已 revoked blob URL 而破圖
 const FilePreviewImage = ({ file, index }: { file: File; index: number }) => {
-  const urlRef = React.useRef<string | null>(null);
-  const prevFileRef = React.useRef<File | null>(null);
-
-  if (prevFileRef.current !== file) {
-    if (urlRef.current) {
-      URL.revokeObjectURL(urlRef.current);
-    }
-    urlRef.current = URL.createObjectURL(file);
-    prevFileRef.current = file;
-  }
+  const [objectUrl, setObjectUrl] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+
     return () => {
-      if (urlRef.current) {
-        URL.revokeObjectURL(urlRef.current);
-        urlRef.current = null;
-      }
+      setObjectUrl(null);
+      URL.revokeObjectURL(url);
     };
-  }, []);
+  }, [file]);
+
+  if (!objectUrl) return null;
 
   return (
     <img
-      src={urlRef.current!}
+      src={objectUrl}
       alt={`Preview ${index + 1}`}
       className="w-full h-full object-cover"
     />


### PR DESCRIPTION
---  
## Why is this necessary?  
- 提及功能的下拉選單在某些情況下會消失，影響使用者體驗。  
- 靈感頁面留言數與實際不一致，可能導致使用者混淆。  
- 文件預覽圖片在合併後出現破圖問題，影響文件的可視性。  

## How does it address?  
- 修復了提及功能下拉選單的顯示邏輯，確保其正常顯示。  
- 調整了靈感頁面留言數的計算邏輯，確保數據一致性。  
- 修正了文件預覽圖片的 blob URL 處理，確保圖片正確顯示。  