### PR TITLE
fix(check-in): 修復無 mood 打卡記錄顯示找不到的問題  

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -99,7 +99,7 @@ export default function CheckInDetailPage() {
     }
 
     checkInsData.data.forEach((checkIn) => {
-      const moodType = mapApiMoodToMoodType(checkIn.mood) ?? null;
+      const moodType = mapApiMoodToMoodType(checkIn.mood);
 
       const displayData: ICheckInDisplayData = {
         id: String(checkIn.id),

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -99,10 +99,7 @@ export default function CheckInDetailPage() {
     }
 
     checkInsData.data.forEach((checkIn) => {
-      const moodType = mapApiMoodToMoodType(checkIn.mood);
-      if (!moodType) {
-        return;
-      }
+      const moodType = mapApiMoodToMoodType(checkIn.mood) ?? null;
 
       const displayData: ICheckInDisplayData = {
         id: String(checkIn.id),

--- a/apps/product/src/components/check-in/types.ts
+++ b/apps/product/src/components/check-in/types.ts
@@ -20,7 +20,7 @@ export interface ICheckInFormData {
 export interface ICheckInDisplayData {
   id: string;
   date: string;
-  mood: MoodType;
+  mood: MoodType | null;
   content: string;
   tags: string[];
   images?: string[];


### PR DESCRIPTION
---  
## Why is this necessary?  
- 使用者在無 mood 打卡時，系統無法正確顯示打卡記錄。  
- 這會影響使用者的打卡體驗，導致混淆和不便。  
- 需要確保所有打卡記錄都能正確顯示，以維持系統的可靠性。  

## How does it address?  
- 修正了查詢邏輯，以正確處理無 mood 的打卡記錄。  
- 增加了相應的錯誤處理，避免顯示找不到的錯誤訊息。  
- 測試了修復後的功能，確保無 mood 打卡記錄能正常顯示。  