### PR TITLE
feat(feed): 修正重複 key 渲染警告並新增多項功能

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -23,6 +23,7 @@ import type { CompletedTask } from "@/components/dashboard/completed-section";
 import { BackgroundAnimation, Banner } from "@/components/layout";
 import { RandomPracticesSection } from "@/components/practice/shared/random-practices-section";
 import {
+  ActivityCard,
   BrewingCard,
   CheckInShowcaseCard,
   FeedLabel,
@@ -108,6 +109,17 @@ export default function HomePage() {
   );
   const { data: batchReactionsData, mutate: mutateBatchReactions } =
     useReactionsBatch({ targetType: "practice", targetIds: practiceIds });
+
+  // Batch fetch reactions for all visible checkins (1 request for the whole page)
+  const checkinIds = useMemo(
+    () =>
+      feedItems
+        .filter((item): item is Extract<FeedItem, { type: "checkin" }> => item.type === "checkin")
+        .map((item) => item.data.id),
+    [feedItems],
+  );
+  const { data: batchCheckinReactionsData, mutate: mutateBatchCheckinReactions } =
+    useReactionsBatch({ targetType: "checkin", targetIds: checkinIds });
 
   // Infinite scroll observer
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -262,8 +274,21 @@ export default function HomePage() {
               ) : (
                 <div className="flex flex-col gap-3">
                   {feedItems.map((feedItem, index) => {
+                    if (feedItem.type === "activity") {
+                      return (
+                        <div key={`activity-${feedItem.event_text.slice(0, 20)}-${index}`}>
+                          <ActivityCard
+                            activity_type={feedItem.activity_type}
+                            event_text={feedItem.event_text}
+                            label={feedItem.label}
+                          />
+                        </div>
+                      );
+                    }
+
                     const isNewRelease = feedItem.feed_reason === "new_release";
-                    const prevIsNewRelease = index > 0 && feedItems[index - 1]?.feed_reason === "new_release";
+                    const prevItem = index > 0 ? feedItems[index - 1] : undefined;
+                    const prevIsNewRelease = prevItem?.type !== "activity" && prevItem?.feed_reason === "new_release";
                     const showFeedLabel = !isNewRelease || !prevIsNewRelease;
 
                     const latestActorName = feedItem.data.reactions
@@ -344,7 +369,11 @@ export default function HomePage() {
                               latestActorName={latestActorName}
                             />
                           )}
-                          <CheckInShowcaseCard {...checkin} />
+                          <CheckInShowcaseCard
+                            {...checkin}
+                            batchReactionData={batchCheckinReactionsData?.data?.[checkin.id]}
+                            onReactionMutate={() => mutateBatchCheckinReactions()}
+                          />
                         </div>
                       );
                     }

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -297,7 +297,7 @@ export default function HomePage() {
                     if (feedItem.type === "practice") {
                       const practice = feedItem.data;
                       return (
-                        <div key={practice.id}>
+                        <div key={`practice-${practice.id}-${feedItem.feed_reason}-${index}`}>
                           {showFeedLabel && (
                             <FeedLabel
                               feedReason={feedItem.feed_reason}
@@ -360,7 +360,7 @@ export default function HomePage() {
                     if (feedItem.type === "checkin") {
                       const checkin = feedItem.data;
                       return (
-                        <div key={checkin.id}>
+                        <div key={`checkin-${checkin.id}-${feedItem.feed_reason}-${index}`}>
                           {showFeedLabel && (
                             <FeedLabel
                               feedReason={feedItem.feed_reason}

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -24,6 +24,8 @@ import { BackgroundAnimation, Banner } from "@/components/layout";
 import { RandomPracticesSection } from "@/components/practice/shared/random-practices-section";
 import {
   BrewingCard,
+  CheckInShowcaseCard,
+  FeedLabel,
   PracticeShowcaseCard,
   type ShowcaseFilterState,
   ShowcaseSearchBar,
@@ -259,60 +261,94 @@ export default function HomePage() {
                 </div>
               ) : (
                 <div className="flex flex-col gap-3">
-                  {feedItems.map((feedItem) => {
+                  {feedItems.map((feedItem, index) => {
+                    const isNewRelease = feedItem.feed_reason === "new_release";
+                    const prevIsNewRelease = index > 0 && feedItems[index - 1]?.feed_reason === "new_release";
+                    const showFeedLabel = !isNewRelease || !prevIsNewRelease;
+
+                    const latestActorName = feedItem.data.reactions
+                      ?.find((r) => r.latestActorName)?.latestActorName;
+
                     if (feedItem.type === "practice") {
                       const practice = feedItem.data;
-                      return practice.is_brewing ? (
-                        <BrewingCard
-                          key={practice.id}
-                          id={practice.id}
-                          title={practice.title}
-                          startDate={practice.start_date}
-                          endDate={practice.end_date}
-                          user={
-                            practice.user
-                              ? {
-                                  id: practice.user.id,
-                                  name: practice.user.name,
-                                  photoUrl: practice.user.photo_url,
-                                }
-                              : undefined
-                          }
-                          actionDescription={practice.practice_action}
-                          frequencyMinDays={practice.frequency_min_days}
-                          frequencyMaxDays={practice.frequency_max_days}
-                          sessionDurationMinutes={practice.session_duration_minutes}
-                          commentCount={practice.comment_count}
-                          batchReactionData={batchReactionsData?.data?.[practice.id]}
-                          onReactionMutate={() => mutateBatchReactions()}
-                        />
-                      ) : (
-                        <PracticeShowcaseCard
-                          key={practice.id}
-                          id={practice.id}
-                          title={practice.title}
-                          status={practice.status}
-                          startDate={practice.start_date}
-                          endDate={practice.end_date}
-                          user={
-                            practice.user
-                              ? {
-                                  id: practice.user.id,
-                                  name: practice.user.name,
-                                  photoUrl: practice.user.photo_url,
-                                }
-                              : undefined
-                          }
-                          actionDescription={practice.practice_action}
-                          frequencyMinDays={practice.frequency_min_days}
-                          frequencyMaxDays={practice.frequency_max_days}
-                          sessionDurationMinutes={practice.session_duration_minutes}
-                          commentCount={practice.comment_count}
-                          batchReactionData={batchReactionsData?.data?.[practice.id]}
-                          onReactionMutate={() => mutateBatchReactions()}
-                        />
+                      return (
+                        <div key={practice.id}>
+                          {showFeedLabel && (
+                            <FeedLabel
+                              feedReason={feedItem.feed_reason}
+                              userName={practice.user?.name}
+                              latestActorName={latestActorName}
+                            />
+                          )}
+                          {practice.is_brewing ? (
+                            <BrewingCard
+                              id={practice.id}
+                              title={practice.title}
+                              startDate={practice.start_date}
+                              endDate={practice.end_date}
+                              user={
+                                practice.user
+                                  ? {
+                                      id: practice.user.id,
+                                      name: practice.user.name,
+                                      photoUrl: practice.user.photo_url,
+                                    }
+                                  : undefined
+                              }
+                              actionDescription={practice.practice_action}
+                              frequencyMinDays={practice.frequency_min_days}
+                              frequencyMaxDays={practice.frequency_max_days}
+                              sessionDurationMinutes={practice.session_duration_minutes}
+                              commentCount={practice.comment_count}
+                              batchReactionData={batchReactionsData?.data?.[practice.id]}
+                              onReactionMutate={() => mutateBatchReactions()}
+                            />
+                          ) : (
+                            <PracticeShowcaseCard
+                              id={practice.id}
+                              title={practice.title}
+                              status={practice.status}
+                              startDate={practice.start_date}
+                              endDate={practice.end_date}
+                              user={
+                                practice.user
+                                  ? {
+                                      id: practice.user.id,
+                                      name: practice.user.name,
+                                      photoUrl: practice.user.photo_url,
+                                    }
+                                  : undefined
+                              }
+                              actionDescription={practice.practice_action}
+                              frequencyMinDays={practice.frequency_min_days}
+                              frequencyMaxDays={practice.frequency_max_days}
+                              sessionDurationMinutes={practice.session_duration_minutes}
+                              commentCount={practice.comment_count}
+                              batchReactionData={batchReactionsData?.data?.[practice.id]}
+                              onReactionMutate={() => mutateBatchReactions()}
+                            />
+                          )}
+                        </div>
                       );
                     }
+
+                    if (feedItem.type === "checkin") {
+                      const checkin = feedItem.data;
+                      return (
+                        <div key={checkin.id}>
+                          {showFeedLabel && (
+                            <FeedLabel
+                              feedReason={feedItem.feed_reason}
+                              userName={checkin.user?.name}
+                              practiceTitle={checkin.practice?.title}
+                              latestActorName={latestActorName}
+                            />
+                          )}
+                          <CheckInShowcaseCard {...checkin} />
+                        </div>
+                      );
+                    }
+
                     return null;
                   })}
 

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -4,8 +4,8 @@ import {
   useMyPracticeStats,
   useMyPractices,
   useReactionsBatch,
-  useShowcaseFeed,
-  type IShowcasePractice,
+  useFeed,
+  type FeedItem,
 } from "@daodao/api";
 import { MessagesSvg } from "@daodao/assets";
 import { useRouter, useSearchParams } from "@daodao/i18n/navigation";
@@ -89,17 +89,20 @@ export default function HomePage() {
   );
 
   const {
-    practices,
+    feedItems,
     isLoading: isShowcaseLoading,
     hasMore,
     loadMore,
     isValidating,
-  } = useShowcaseFeed(showcaseParams);
+  } = useFeed(showcaseParams);
 
   // Batch fetch reactions for all visible practices
   const practiceIds = useMemo(
-    () => practices.map((p: IShowcasePractice) => p.id),
-    [practices],
+    () =>
+      feedItems
+        .filter((item): item is Extract<FeedItem, { type: "practice" }> => item.type === "practice")
+        .map((item) => item.data.id),
+    [feedItems],
   );
   const { data: batchReactionsData, mutate: mutateBatchReactions } =
     useReactionsBatch({ targetType: "practice", targetIds: practiceIds });
@@ -245,7 +248,7 @@ export default function HomePage() {
                 />
               </div>
 
-              {isShowcaseLoading && practices.length === 0 ? (
+              {isShowcaseLoading && feedItems.length === 0 ? (
                 <div className="flex flex-col gap-3">
                   {[1, 2, 3].map((i) => (
                     <div
@@ -256,58 +259,62 @@ export default function HomePage() {
                 </div>
               ) : (
                 <div className="flex flex-col gap-3">
-                  {practices.map((practice: IShowcasePractice) =>
-                    practice.is_brewing ? (
-                      <BrewingCard
-                        key={practice.id}
-                        id={practice.id}
-                        title={practice.title}
-                        startDate={practice.start_date}
-                        endDate={practice.end_date}
-                        user={
-                          practice.user
-                            ? {
-                                id: practice.user.id,
-                                name: practice.user.name,
-                                photoUrl: practice.user.photo_url,
-                              }
-                            : undefined
-                        }
-                        actionDescription={practice.practice_action}
-                        frequencyMinDays={practice.frequency_min_days}
-                        frequencyMaxDays={practice.frequency_max_days}
-                        sessionDurationMinutes={practice.session_duration_minutes}
-                        commentCount={practice.comment_count}
-                        batchReactionData={batchReactionsData?.data?.[practice.id]}
-                        onReactionMutate={() => mutateBatchReactions()}
-                      />
-                    ) : (
-                      <PracticeShowcaseCard
-                        key={practice.id}
-                        id={practice.id}
-                        title={practice.title}
-                        status={practice.status}
-                        startDate={practice.start_date}
-                        endDate={practice.end_date}
-                        user={
-                          practice.user
-                            ? {
-                                id: practice.user.id,
-                                name: practice.user.name,
-                                photoUrl: practice.user.photo_url,
-                              }
-                            : undefined
-                        }
-                        actionDescription={practice.practice_action}
-                        frequencyMinDays={practice.frequency_min_days}
-                        frequencyMaxDays={practice.frequency_max_days}
-                        sessionDurationMinutes={practice.session_duration_minutes}
-                        commentCount={practice.comment_count}
-                        batchReactionData={batchReactionsData?.data?.[practice.id]}
-                        onReactionMutate={() => mutateBatchReactions()}
-                      />
-                    )
-                  )}
+                  {feedItems.map((feedItem) => {
+                    if (feedItem.type === "practice") {
+                      const practice = feedItem.data;
+                      return practice.is_brewing ? (
+                        <BrewingCard
+                          key={practice.id}
+                          id={practice.id}
+                          title={practice.title}
+                          startDate={practice.start_date}
+                          endDate={practice.end_date}
+                          user={
+                            practice.user
+                              ? {
+                                  id: practice.user.id,
+                                  name: practice.user.name,
+                                  photoUrl: practice.user.photo_url,
+                                }
+                              : undefined
+                          }
+                          actionDescription={practice.practice_action}
+                          frequencyMinDays={practice.frequency_min_days}
+                          frequencyMaxDays={practice.frequency_max_days}
+                          sessionDurationMinutes={practice.session_duration_minutes}
+                          commentCount={practice.comment_count}
+                          batchReactionData={batchReactionsData?.data?.[practice.id]}
+                          onReactionMutate={() => mutateBatchReactions()}
+                        />
+                      ) : (
+                        <PracticeShowcaseCard
+                          key={practice.id}
+                          id={practice.id}
+                          title={practice.title}
+                          status={practice.status}
+                          startDate={practice.start_date}
+                          endDate={practice.end_date}
+                          user={
+                            practice.user
+                              ? {
+                                  id: practice.user.id,
+                                  name: practice.user.name,
+                                  photoUrl: practice.user.photo_url,
+                                }
+                              : undefined
+                          }
+                          actionDescription={practice.practice_action}
+                          frequencyMinDays={practice.frequency_min_days}
+                          frequencyMaxDays={practice.frequency_max_days}
+                          sessionDurationMinutes={practice.session_duration_minutes}
+                          commentCount={practice.comment_count}
+                          batchReactionData={batchReactionsData?.data?.[practice.id]}
+                          onReactionMutate={() => mutateBatchReactions()}
+                        />
+                      );
+                    }
+                    return null;
+                  })}
 
                   <div ref={sentinelRef} className="h-4" />
 

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -504,7 +504,6 @@ export default function CheckInDetailPage() {
       tags: checkInData.tags,
       description: checkInData.content,
       images: checkInData.images,
-      media: [],
     },
     onComplete: handleEditComplete,
   });

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -14,12 +14,16 @@ import {
   useUpdatePracticeCheckIn,
 } from "@daodao/api";
 import type { ReactionTypeValue } from "@daodao/api";
-import { Deco4Svg } from "@daodao/assets";
+import { ChartColumnIncreasingSvg, Deco4Svg, FlagOutlineSvg } from "@daodao/assets";
 import { useParams } from "@daodao/i18n/navigation";
+import { useSheetManager } from "@daodao/ui/components/animate-ui/components/radix/sheet";
+import { Button } from "@daodao/ui/components/button";
 import { toast } from "@daodao/ui/components/sonner";
+import { cn } from "@daodao/ui/lib/utils";
 import { addDays, format, formatDistanceToNow, isValid, parse, parseISO } from "date-fns";
 import { zhTW } from "date-fns/locale";
-import { useCallback, useMemo, useRef, useState, useTransition } from "react";
+import { MoreHorizontal, Pencil, Share2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import {
   CheckInButton,
   CheckInDateSelector,
@@ -31,6 +35,9 @@ import { CommentSection, ReactionBar } from "@/components/check-in/reactions";
 import type { IReactionCount } from "@/components/check-in/reactions";
 import type { ICheckInDisplayData, ICheckInFormData } from "@/components/check-in/types";
 import { PageHeader } from "@/components/layout";
+import { BrowseActivityContent } from "@/components/showcase";
+import { useEditCheckInSheet } from "@/hooks/use-edit-check-in-sheet";
+import { useShareCheckInSheet } from "@/hooks/use-share-check-in-sheet";
 import { mapApiMoodToMoodType, mapMoodTypeToApiMood } from "@/constants/mood";
 import { PICKER_REACTIONS } from "@/constants/reaction-type";
 import type { ReactionTypeType } from "@/constants/reaction-type";
@@ -193,6 +200,25 @@ export default function CheckInDetailPage() {
   });
   const commentInputRef = useRef<HTMLTextAreaElement>(null);
 
+  // Three-dot menu state
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
+  }, [menuOpen]);
+
   // 獲取所有 check-ins
   const { data: checkInsData, isLoading: isLoadingCheckIns } = usePracticeCheckIns(practiceId, {
     limit: 30,
@@ -338,6 +364,11 @@ export default function CheckInDetailPage() {
     (type: ReactionTypeType) => {
       const isSelected = currentUserReaction === type;
       setPendingReaction(isSelected ? null : type);
+      if (!isSelected) {
+        requestAnimationFrame(() => {
+          commentInputRef.current?.focus();
+        });
+      }
       startReactionTransition(async () => {
         if (isSelected) {
           await removeReaction({ targetType: "checkin", targetId: checkInId });
@@ -446,10 +477,7 @@ export default function CheckInDetailPage() {
   const isOwner =
     !!practiceData?.data?.user?.id && practiceData.data.user.id === currentUserData?.data?.id;
 
-  const handleCheckInComplete = (data: unknown) => {
-    // TODO: 處理打卡資料
-    console.log("打卡資料:", data);
-  };
+  const { open: openSheet, close: closeSheet } = useSheetManager();
 
   const handleEditComplete = async (data: ICheckInFormData) => {
     try {
@@ -467,6 +495,46 @@ export default function CheckInDetailPage() {
       toast.error("更新打卡失敗，請稍後再試");
       throw error;
     }
+  };
+
+  const { openEditCheckInSheet } = useEditCheckInSheet({
+    taskTitle: checkInData.practiceTitle,
+    checkInData: {
+      mood: checkInData.mood,
+      tags: checkInData.tags,
+      description: checkInData.content,
+      images: checkInData.images,
+      media: [],
+    },
+    onComplete: handleEditComplete,
+  });
+
+  const { openShareSheet } = useShareCheckInSheet({
+    taskTitle: checkInData.practiceTitle,
+    checkInData: {
+      mood: checkInData.mood,
+      tags: checkInData.tags,
+      description: checkInData.content,
+      media: [],
+      date: checkInData.date,
+      images: checkInData.images,
+    },
+  });
+
+  const handleOpenBrowseActivity = () => {
+    setMenuOpen(false);
+    openSheet({
+      title: "瀏覽活動",
+      content: <BrowseActivityContent targetId={checkInId} />,
+      dismissible: true,
+      closeOnEscape: true,
+      showCloseButton: true,
+    });
+  };
+
+  const handleCheckInComplete = (data: unknown) => {
+    // TODO: 處理打卡資料
+    console.log("打卡資料:", data);
   };
 
   return (
@@ -492,7 +560,6 @@ export default function CheckInDetailPage() {
       <main className="max-w-[448px] mx-auto pt-[150px] md:pt-10 px-5 pb-52">
         <CheckInDetail
           checkInData={checkInData}
-          onEditComplete={isOwner ? handleEditComplete : undefined}
           afterTitle={
             <SameDayCheckInNav
               sameDayCheckInIds={sameDayCheckInIds}
@@ -501,13 +568,78 @@ export default function CheckInDetailPage() {
             />
           }
           bottomActions={
-            <ReactionBar
-              reactions={reactionCounts}
-              selectedReactions={selectedReactions}
-              onReactionClick={handleReactionClick}
-              types={PICKER_REACTIONS}
-              className="flex-wrap"
-            />
+            <div className="flex items-center justify-between w-full">
+              <ReactionBar
+                reactions={reactionCounts}
+                selectedReactions={selectedReactions}
+                onReactionClick={handleReactionClick}
+                types={PICKER_REACTIONS}
+                className="flex-wrap"
+              />
+              {/* Three-dot menu */}
+              <div ref={menuRef} className="relative">
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setMenuOpen((v) => !v)}
+                  className={cn(
+                    "h-8 w-8 text-white/70 hover:text-white hover:bg-white/20",
+                    menuOpen && "bg-white/20 text-white"
+                  )}
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+                {menuOpen && (
+                  <div className="absolute right-0 top-full mt-1 bg-white rounded-2xl shadow-lg border border-[#E4EAE9] py-2 z-20 min-w-[140px]">
+                    {isOwner ? (
+                      <>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => { setMenuOpen(false); openEditCheckInSheet(); }}
+                          className="w-full h-auto justify-start rounded-none gap-3 px-4 py-3 text-sm text-[#295E5C] hover:bg-[#F0F9F8] transition-colors cursor-pointer"
+                        >
+                          <Pencil className="size-5 shrink-0" />
+                          <span>編輯打卡</span>
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => { setMenuOpen(false); openShareSheet(); }}
+                          className="w-full h-auto justify-start rounded-none gap-3 px-4 py-3 text-sm text-[#295E5C] hover:bg-[#F0F9F8] transition-colors cursor-pointer"
+                        >
+                          <Share2 className="size-5 shrink-0" />
+                          <span>分享打卡</span>
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => {
+                          setMenuOpen(false);
+                          toast.success("已檢舉");
+                        }}
+                        className="w-full h-auto justify-start rounded-none gap-3 px-4 py-3 text-sm text-[#295E5C] hover:bg-[#F0F9F8] transition-colors cursor-pointer"
+                      >
+                        <FlagOutlineSvg className="size-5 shrink-0" />
+                        <span>檢舉</span>
+                      </Button>
+                    )}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={handleOpenBrowseActivity}
+                      className="w-full h-auto justify-start rounded-none gap-3 px-4 py-3 text-sm text-[#295E5C] hover:bg-[#F0F9F8] transition-colors cursor-pointer"
+                    >
+                      <ChartColumnIncreasingSvg className="size-5 shrink-0" />
+                      <span>瀏覽活動</span>
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
           }
         />
 

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -1,25 +1,116 @@
 "use client";
 
 import {
+  createComment,
+  deleteComment,
+  removeReaction,
+  updateComment,
+  upsertReaction,
+  useComments,
   useCurrentUser,
   usePracticeById,
   usePracticeCheckIns,
+  useReactions,
   useUpdatePracticeCheckIn,
 } from "@daodao/api";
+import type { ReactionTypeValue } from "@daodao/api";
 import { Deco4Svg } from "@daodao/assets";
 import { useParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
-import { addDays, format, isValid, parse } from "date-fns";
-import { useMemo } from "react";
+import { addDays, format, formatDistanceToNow, isValid, parse, parseISO } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import { useCallback, useMemo, useRef, useState, useTransition } from "react";
 import {
   CheckInButton,
   CheckInDateSelector,
   CheckInDetail,
   SameDayCheckInNav,
 } from "@/components/check-in";
+import type { IComment, ICommentReply } from "@/components/check-in/reactions";
+import { CommentSection, ReactionBar } from "@/components/check-in/reactions";
+import type { IReactionCount } from "@/components/check-in/reactions";
 import type { ICheckInDisplayData, ICheckInFormData } from "@/components/check-in/types";
 import { PageHeader } from "@/components/layout";
 import { mapApiMoodToMoodType, mapMoodTypeToApiMood } from "@/constants/mood";
+import { PICKER_REACTIONS } from "@/constants/reaction-type";
+import type { ReactionTypeType } from "@/constants/reaction-type";
+
+// ============================================================================
+// Comment helpers (mirrors pattern from practices/[id]/page.tsx)
+// ============================================================================
+
+interface IApiCommentUser {
+  id?: string;
+  name?: string;
+  photoURL?: string | null;
+  customId?: string | null;
+}
+
+interface IApiCommentNode {
+  id: number | string;
+  content?: string;
+  createdAt?: string;
+  user?: IApiCommentUser;
+  userId?: number;
+  replies?: unknown[];
+}
+
+function getErrorMessage(error: unknown, fallbackMessage: string): string {
+  if (typeof error !== "object" || error === null) return fallbackMessage;
+  if ("details" in error && Array.isArray(error.details) && error.details.length > 0) {
+    const first = error.details[0];
+    if (typeof first === "object" && first !== null && "message" in first && typeof first.message === "string") {
+      return first.message;
+    }
+  }
+  if ("message" in error && typeof error.message === "string") return error.message;
+  return fallbackMessage;
+}
+
+function isApiCommentNode(comment: unknown): comment is IApiCommentNode {
+  return typeof comment === "object" && comment !== null && "id" in comment;
+}
+
+function formatCommentTime(createdAt?: string): string {
+  if (!createdAt) return "剛剛";
+  const d = parseISO(createdAt);
+  if (!isValid(d)) return "剛剛";
+  return formatDistanceToNow(d, { addSuffix: true, locale: zhTW });
+}
+
+function mapReply(reply: IApiCommentNode): ICommentReply {
+  return {
+    id: String(reply.id),
+    author: {
+      name: reply.user?.name || "匿名使用者",
+      photoURL: reply.user?.photoURL || undefined,
+      userId: reply.user?.id || undefined,
+      numericUserId: reply.userId ?? undefined,
+      customId: reply.user?.customId ?? undefined,
+    },
+    content: reply.content || "",
+    time: formatCommentTime(reply.createdAt),
+  };
+}
+
+function mapComment(comment: IApiCommentNode): IComment {
+  const rawReplies = Array.isArray(comment.replies) ? comment.replies : [];
+  return {
+    id: String(comment.id),
+    author: {
+      name: comment.user?.name || "匿名使用者",
+      photoURL: comment.user?.photoURL || undefined,
+      userId: comment.user?.id || undefined,
+      numericUserId: comment.userId ?? undefined,
+      customId: comment.user?.customId ?? undefined,
+    },
+    content: comment.content || "",
+    time: formatCommentTime(comment.createdAt),
+    replies: rawReplies.filter(isApiCommentNode).map(mapReply),
+  };
+}
+
+// ============================================================================
 
 /**
  * 將 API 的 checkinDate 格式轉換為顯示格式
@@ -84,6 +175,23 @@ export default function CheckInDetailPage() {
 
   // 更新打卡記錄
   const { updateCheckIn } = useUpdatePracticeCheckIn(practiceId, checkInId);
+
+  // Reactions
+  const { data: reactionsData, mutate: mutateReactions } = useReactions({
+    targetType: "checkin",
+    targetId: checkInId,
+  });
+  const [pendingReaction, setPendingReaction] = useState<ReactionTypeType | null | undefined>(
+    undefined
+  );
+  const [, startReactionTransition] = useTransition();
+
+  // Comments
+  const { data: commentsData, mutate: mutateComments } = useComments({
+    targetType: "checkin",
+    targetId: checkInId,
+  });
+  const commentInputRef = useRef<HTMLTextAreaElement>(null);
 
   // 獲取所有 check-ins
   const { data: checkInsData, isLoading: isLoadingCheckIns } = usePracticeCheckIns(practiceId, {
@@ -216,6 +324,88 @@ export default function CheckInDetailPage() {
     return record;
   }, [checkInsMap]);
 
+  // Derived reaction state (must be before early returns — hooks below depend on these values)
+  const currentUserReaction = (reactionsData?.data?.currentUserReaction ?? null) as ReactionTypeType | null;
+  const effectiveReaction = pendingReaction !== undefined ? pendingReaction : currentUserReaction;
+  const selectedReactions: ReactionTypeType[] = effectiveReaction ? [effectiveReaction] : [];
+  const reactionCounts: IReactionCount[] = (reactionsData?.data?.reactions ?? []).map((r) => ({
+    type: r.type as ReactionTypeType,
+    count: r.count,
+    latestActorName: r.latestActorName ?? undefined,
+  }));
+
+  const handleReactionClick = useCallback(
+    (type: ReactionTypeType) => {
+      const isSelected = currentUserReaction === type;
+      setPendingReaction(isSelected ? null : type);
+      startReactionTransition(async () => {
+        if (isSelected) {
+          await removeReaction({ targetType: "checkin", targetId: checkInId });
+        } else {
+          await upsertReaction({
+            targetType: "checkin",
+            targetId: checkInId,
+            reactionType: type as ReactionTypeValue,
+          });
+        }
+        await mutateReactions();
+        setPendingReaction(undefined);
+      });
+    },
+    [currentUserReaction, checkInId, mutateReactions]
+  );
+
+  // Derived comment state
+  const comments = useMemo(() => {
+    const raw = commentsData?.data;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter(isApiCommentNode).map(mapComment);
+  }, [commentsData]);
+
+  const handleCommentSubmit = useCallback(
+    async (content: string, _reactions: ReactionTypeType[], parentId?: string, mentionedUserIds?: number[]) => {
+      const response = await createComment({
+        targetType: "checkin",
+        targetId: checkInId,
+        content,
+        visibility: "public",
+        parentId: parentId ? Number(parentId) : undefined,
+        mentionedUserIds: mentionedUserIds?.length ? mentionedUserIds : undefined,
+      });
+      if (response.error) {
+        toast.error(getErrorMessage(response.error, "留言失敗"));
+        return;
+      }
+      toast.success("留言成功！");
+      await mutateComments();
+    },
+    [checkInId, mutateComments]
+  );
+
+  const handleCommentEdit = useCallback(
+    async (commentId: string, content: string) => {
+      const id = Number(commentId);
+      if (!Number.isFinite(id)) { toast.error("留言 ID 無效"); return false; }
+      const response = await updateComment(id, { content });
+      if (response.error) { toast.error(getErrorMessage(response.error, "更新留言失敗")); return false; }
+      await mutateComments();
+      return true;
+    },
+    [mutateComments]
+  );
+
+  const handleCommentDelete = useCallback(
+    async (commentId: string) => {
+      const id = Number(commentId);
+      if (!Number.isFinite(id)) { toast.error("留言 ID 無效"); return false; }
+      const response = await deleteComment(id);
+      if (response.error) { toast.error(getErrorMessage(response.error, "刪除留言失敗")); return false; }
+      await mutateComments();
+      return true;
+    },
+    [mutateComments]
+  );
+
   // Loading 狀態
   if (isLoadingPractice || isLoadingCheckIns || isLoadingCurrentUser) {
     return (
@@ -310,7 +500,36 @@ export default function CheckInDetailPage() {
               practiceId={practiceId}
             />
           }
+          bottomActions={
+            <ReactionBar
+              reactions={reactionCounts}
+              selectedReactions={selectedReactions}
+              onReactionClick={handleReactionClick}
+              types={PICKER_REACTIONS}
+              className="flex-wrap"
+            />
+          }
         />
+
+        {/* 留言區 */}
+        <div className="mt-4 bg-white rounded-2xl overflow-hidden">
+          <CommentSection
+            comments={comments}
+            selectedReactions={selectedReactions}
+            inputRef={commentInputRef}
+            onSubmit={handleCommentSubmit}
+            hasMoreComments={comments.length > 2}
+            currentUserName={currentUserData?.data?.name ?? undefined}
+            currentUserId={currentUserData?.data?.id ?? undefined}
+            currentUserPhotoURL={
+              typeof currentUserData?.data?.photoURL === "string"
+                ? currentUserData.data.photoURL
+                : undefined
+            }
+            onEditComment={handleCommentEdit}
+            onDeleteComment={handleCommentDelete}
+          />
+        </div>
       </main>
 
       {isOwner && (

--- a/apps/product/src/components/check-in/display/check-in-card.tsx
+++ b/apps/product/src/components/check-in/display/check-in-card.tsx
@@ -18,6 +18,8 @@ interface ICheckInCardProps {
   showTape?: boolean;
   /** 標題下方插入的額外內容（例如同日打卡切換導航） */
   afterTitle?: React.ReactNode;
+  /** 卡片底部注入的互動列（例如 Reaction 按鈕） */
+  bottomActions?: React.ReactNode;
 }
 
 /**
@@ -35,6 +37,7 @@ export const CheckInCard = ({
   onImageClick,
   showTape = true,
   afterTitle,
+  bottomActions,
 }: ICheckInCardProps) => {
   const moodOption = mood ? MOOD_OPTIONS.find((option) => option.id === mood) : null;
   const MoodEmoji = moodOption?.emoji;
@@ -173,6 +176,8 @@ export const CheckInCard = ({
           </div>
         </main>
       </div>
+
+      {bottomActions}
     </div>
   );
 };

--- a/apps/product/src/components/check-in/display/check-in-detail.tsx
+++ b/apps/product/src/components/check-in/display/check-in-detail.tsx
@@ -23,9 +23,11 @@ interface ICheckInDetailProps {
   onEditComplete?: (data: ICheckInFormData) => Promise<void> | void;
   /** 標題下方額外內容（如同日打卡切換導航） */
   afterTitle?: React.ReactNode;
+  /** 卡片底部注入的互動列（Reaction 按鈕等），不含硬編碼邏輯 */
+  bottomActions?: React.ReactNode;
 }
 
-export const CheckInDetail = ({ checkInData, onEditComplete, afterTitle }: ICheckInDetailProps) => {
+export const CheckInDetail = ({ checkInData, onEditComplete, afterTitle, bottomActions }: ICheckInDetailProps) => {
   const { date, mood, content, tags, images, practiceTitle } = checkInData;
 
   const [lightboxOpen, setLightboxOpen] = React.useState(false);
@@ -96,6 +98,7 @@ export const CheckInDetail = ({ checkInData, onEditComplete, afterTitle }: IChec
         onImageClick={handleImageClick}
         showTape={true}
         afterTitle={afterTitle}
+        bottomActions={bottomActions}
       />
 
       <div className="flex flex-col w-fit gap-4 mx-auto">

--- a/apps/product/src/components/check-in/reactions/reaction-bar.tsx
+++ b/apps/product/src/components/check-in/reactions/reaction-bar.tsx
@@ -25,6 +25,8 @@ interface ReactionBarProps {
   onReactionClick: (type: ReactionTypeType) => void;
   /** 覆蓋容器的 className，可用來控制 scroll / wrap 行為 */
   className?: string;
+  /** 限定顯示的 reaction 類型子集，預設顯示全部 */
+  types?: ReactionTypeType[];
 }
 
 // ============================================================================
@@ -36,10 +38,12 @@ export function ReactionBar({
   selectedReactions,
   onReactionClick,
   className,
+  types,
 }: ReactionBarProps) {
+  const displayTypes = types ?? REACTION_TYPE_LIST;
   return (
     <div className={cn("flex items-center gap-2 px-4 py-3", className ?? "flex-wrap")}>
-      {REACTION_TYPE_LIST.map((type) => {
+      {displayTypes.map((type) => {
         const config = REACTION_CONFIG[type];
         const reactionData = reactions.find((r) => r.type === type);
         const count = reactionData?.count ?? 0;

--- a/apps/product/src/components/showcase/ActivityCard.tsx
+++ b/apps/product/src/components/showcase/ActivityCard.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@daodao/ui/lib/utils";
+import { BookOpen } from "lucide-react";
+
+interface ActivityCardProps {
+  activity_type: "community_event" | "follow_summary";
+  event_text: string;
+  label: string;
+  className?: string;
+}
+
+export function ActivityCard({ event_text, label, className }: ActivityCardProps) {
+  return (
+    <div
+      className={cn(
+        "bg-white rounded-2xl p-4 border border-[#E8F8FF] flex items-start gap-3",
+        className
+      )}
+    >
+      <div className="flex-shrink-0 w-9 h-9 rounded-full bg-logo-cyan/10 flex items-center justify-center">
+        <BookOpen className="w-4 h-4 text-logo-cyan" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <span className="inline-block text-xs font-medium text-logo-cyan bg-logo-cyan/10 rounded-full px-2 py-0.5 mb-1">
+          {label}
+        </span>
+        <p className="text-sm text-text-dark leading-snug">{event_text}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/product/src/components/showcase/BrowseActivityContent.tsx
+++ b/apps/product/src/components/showcase/BrowseActivityContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReactionsList } from "@daodao/api";
+import { type ReactionListItemWithPrivacy, useReactionsList } from "@daodao/api";
 import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
 import { LottieEmoji } from "@/components/check-in/reactions/lottie-emoji";
 import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
@@ -16,9 +16,10 @@ export function BrowseActivityContent({ targetId }: BrowseActivityContentProps) 
     targetId,
   });
 
-  const items = [...(data?.data?.items ?? [])].sort(
-    (a, b) => new Date(b.reactedAt).getTime() - new Date(a.reactedAt).getTime(),
-  );
+  const items = [...(data?.data?.items ?? [])]
+    .map((item) => item as ReactionListItemWithPrivacy)
+    .filter((item) => item.isPublic === true || item.isConnection === true)
+    .sort((a, b) => new Date(b.reactedAt).getTime() - new Date(a.reactedAt).getTime());
 
   if (items.length === 0) {
     return (

--- a/apps/product/src/components/showcase/BrowseActivityContent.tsx
+++ b/apps/product/src/components/showcase/BrowseActivityContent.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useReactionsList } from "@daodao/api";
+import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
+import { LottieEmoji } from "@/components/check-in/reactions/lottie-emoji";
+import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
+import { formatRelativeTime } from "@/utils/format-time";
+
+interface BrowseActivityContentProps {
+  targetId: string;
+}
+
+export function BrowseActivityContent({ targetId }: BrowseActivityContentProps) {
+  const { data } = useReactionsList({
+    targetType: "checkin",
+    targetId,
+  });
+
+  const items = [...(data?.data?.items ?? [])].sort(
+    (a, b) => new Date(b.reactedAt).getTime() - new Date(a.reactedAt).getTime(),
+  );
+
+  if (items.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-[#9FB5B8]">還沒有人表達反應</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1 px-4">
+      {items.map((item) => {
+        const config = REACTION_CONFIG[item.reactionType as ReactionTypeType];
+        return (
+          <div
+            key={`${item.userId}-${item.reactedAt}`}
+            className="flex items-center gap-3 py-2"
+          >
+            <Avatar className="size-8 shrink-0">
+              {item.photoURL && <AvatarImage src={item.photoURL} alt={item.name} />}
+              <AvatarFallback className="text-[10px] font-medium text-text-dark bg-primary-palest">
+                {item.name.slice(0, 1)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-[#295E5C] truncate">{item.name}</p>
+              <p className="text-xs text-[#9FB5B8]">{formatRelativeTime(item.reactedAt)}</p>
+            </div>
+            {config && (
+              <LottieEmoji
+                url={config.lottieUrl}
+                fallback={config.emoji}
+                size={20}
+                play={false}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import { useCurrentUser } from "@daodao/api";
+import { FlagOutlineSvg } from "@daodao/assets";
 import { DialogOutlineSvg } from "@daodao/assets";
 import { useRouter } from "@daodao/i18n/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
-import { MapPin, Pencil } from "lucide-react";
+import { Button } from "@daodao/ui/components/button";
+import { toast } from "@daodao/ui/components/sonner";
+import { cn } from "@daodao/ui/lib/utils";
+import { MapPin, MoreHorizontal, Pencil } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { ReactionPickerButton } from "@/components/check-in/reactions";
 import { mapApiMoodToMoodType, MOOD_OPTIONS } from "@/constants/mood";
 import type { ApiMoodType } from "@/constants/mood";
@@ -41,6 +47,27 @@ export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
   const { selectedReactions, totalCount, displayReactions, handleToggle } =
     useCardReactions("checkin", id, batchReactionData, onReactionMutate);
 
+  const { data: currentUserData } = useCurrentUser();
+  const isOwnCard = !!currentUserData?.data?.id && user?.id === currentUserData.data.id;
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
+  }, [menuOpen]);
+
   const handleCardClick = () => {
     router.push(`/practices/${practice.id}/check-ins/${id}`);
   };
@@ -57,7 +84,7 @@ export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
       className="rounded-2xl bg-white p-4 shadow-sm border border-logo-orange/15 cursor-pointer"
       onClick={handleCardClick}
     >
-      {/* 1. Header: badge + mood */}
+      {/* 1. Header: badge + mood + more menu */}
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-logo-orange/10 text-logo-orange text-xs font-medium">
@@ -66,11 +93,44 @@ export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
           </span>
           <span className="text-xs text-text-dark/50">{checkin_date}</span>
         </div>
-        {moodOption && (
-          <div className="flex items-center justify-center size-7 rounded-full bg-logo-orange/10">
-            <moodOption.emoji className="size-4" />
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          {moodOption && (
+            <div className="flex items-center justify-center size-7 rounded-full bg-logo-orange/10">
+              <moodOption.emoji className="size-4" />
+            </div>
+          )}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: stop card click */}
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: stop card click */}
+          {!isOwnCard && (
+            <div ref={menuRef} className="relative" onClick={(e) => e.stopPropagation()}>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                onClick={() => setMenuOpen((v) => !v)}
+                className={cn("h-7 w-7", menuOpen ? "bg-[#E4EAE9]" : "hover:bg-[#E4EAE9]")}
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+              {menuOpen && (
+                <div className="absolute right-0 top-full mt-1 bg-white rounded-2xl shadow-lg border border-[#E4EAE9] py-2 z-20 min-w-[120px]">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      toast.success("已檢舉");
+                    }}
+                    className="w-full h-auto justify-start rounded-none gap-3 px-4 py-3 text-sm text-[#295E5C] hover:bg-[#F0F9F8] transition-colors cursor-pointer"
+                  >
+                    <FlagOutlineSvg className="size-5 shrink-0" />
+                    <span>檢舉</span>
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* 2. 實踐追溯連結 */}

--- a/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
@@ -99,9 +99,9 @@ export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
               <moodOption.emoji className="size-4" />
             </div>
           )}
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: stop card click */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: stop card click */}
           {!isOwnCard && (
+            // biome-ignore lint/a11y/useKeyWithClickEvents: stop card click
+            // biome-ignore lint/a11y/noStaticElementInteractions: stop card click
             <div ref={menuRef} className="relative" onClick={(e) => e.stopPropagation()}>
               <Button
                 type="button"

--- a/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
@@ -9,9 +9,14 @@ import { mapApiMoodToMoodType, MOOD_OPTIONS } from "@/constants/mood";
 import type { ApiMoodType } from "@/constants/mood";
 import { useCardReactions } from "@/hooks/use-card-reactions";
 import { formatRelativeTime } from "@/utils/format-time";
-import type { IShowcaseCheckIn } from "@daodao/api";
+import type { BatchReactionItem, IShowcaseCheckIn } from "@daodao/api";
 
-export function CheckInShowcaseCard(props: IShowcaseCheckIn) {
+type CheckInShowcaseCardProps = IShowcaseCheckIn & {
+  batchReactionData?: BatchReactionItem;
+  onReactionMutate?: () => void;
+};
+
+export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
   const {
     id,
     checkin_date,
@@ -23,6 +28,8 @@ export function CheckInShowcaseCard(props: IShowcaseCheckIn) {
     user,
     comment_count,
     comment_preview,
+    batchReactionData,
+    onReactionMutate,
   } = props;
 
   const router = useRouter();
@@ -32,7 +39,7 @@ export function CheckInShowcaseCard(props: IShowcaseCheckIn) {
     : null;
 
   const { selectedReactions, totalCount, displayReactions, handleToggle } =
-    useCardReactions("checkin", id);
+    useCardReactions("checkin", id, batchReactionData, onReactionMutate);
 
   const handleCardClick = () => {
     router.push(`/practices/${practice.id}/check-ins/${id}`);

--- a/apps/product/src/components/showcase/FeedLabel.tsx
+++ b/apps/product/src/components/showcase/FeedLabel.tsx
@@ -1,0 +1,51 @@
+import { CalendarCheck, Rss, ThumbsUp } from "lucide-react";
+import type { FeedReasonType } from "@daodao/api";
+
+interface FeedLabelProps {
+  feedReason: FeedReasonType;
+  userName?: string;
+  practiceTitle?: string;
+  latestActorName?: string;
+}
+
+export function FeedLabel({ feedReason, userName, practiceTitle, latestActorName }: FeedLabelProps) {
+  if (feedReason === "new_practice") {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-text-dark/60 mb-1.5 px-1">
+        <ThumbsUp className="size-3.5 shrink-0" />
+        <span>{userName ?? "某人"} 發布了新實踐</span>
+      </div>
+    );
+  }
+
+  if (feedReason === "new_release") {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-text-dark/60 mb-1.5 px-1">
+        <Rss className="size-3.5 shrink-0" />
+        <span>最新發布</span>
+      </div>
+    );
+  }
+
+  if (feedReason === "checked_in") {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-text-dark/60 mb-1.5 px-1">
+        <CalendarCheck className="size-3.5 shrink-0" />
+        <span>
+          {userName ?? "某人"} 在 {practiceTitle ?? "實踐"} 打卡
+        </span>
+      </div>
+    );
+  }
+
+  if (feedReason === "cheered") {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-text-dark/60 mb-1.5 px-1">
+        <ThumbsUp className="size-3.5 shrink-0" />
+        <span>{latestActorName ?? "某人"} 表達了加油</span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/product/src/components/showcase/index.ts
+++ b/apps/product/src/components/showcase/index.ts
@@ -1,3 +1,4 @@
+export * from "./ActivityCard";
 export * from "./BrewingCard";
 export * from "./CheckInShowcaseCard";
 export * from "./FeedLabel";

--- a/apps/product/src/components/showcase/index.ts
+++ b/apps/product/src/components/showcase/index.ts
@@ -1,4 +1,6 @@
 export * from "./BrewingCard";
+export * from "./CheckInShowcaseCard";
+export * from "./FeedLabel";
 export * from "./LottieEmoji";
 export * from "./PracticeShowcaseCard";
 export * from "./ShowcaseFilterBar";

--- a/apps/product/src/components/showcase/index.ts
+++ b/apps/product/src/components/showcase/index.ts
@@ -1,5 +1,6 @@
 export * from "./ActivityCard";
 export * from "./BrewingCard";
+export * from "./BrowseActivityContent";
 export * from "./CheckInShowcaseCard";
 export * from "./FeedLabel";
 export * from "./LottieEmoji";

--- a/packages/api/src/services/feed-hooks.ts
+++ b/packages/api/src/services/feed-hooks.ts
@@ -55,9 +55,17 @@ export interface IShowcaseCheckIn {
 
 export type FeedReasonType = "new_practice" | "new_release" | "checked_in" | "cheered";
 
+export interface ActivityCardItem {
+  type: "activity";
+  activity_type: "community_event" | "follow_summary";
+  event_text: string;
+  label: string;
+}
+
 export type FeedItem =
   | { type: "practice"; feed_reason: FeedReasonType; data: IShowcasePractice }
-  | { type: "checkin"; feed_reason: FeedReasonType; data: IShowcaseCheckIn };
+  | { type: "checkin"; feed_reason: FeedReasonType; data: IShowcaseCheckIn }
+  | ActivityCardItem;
 
 export interface IFeedParams {
   keyword?: string;
@@ -114,7 +122,7 @@ export function useFeed(params: IFeedParams) {
   const feedItems: FeedItem[] = data
     ? data.flatMap((page) =>
 (page.data ?? []).filter((item) => {
-  const isValid = !!(item?.type && item?.data);
+  const isValid = !!(item?.type && (item?.type === "activity" || item?.data));
   if (!isValid && process.env.NODE_ENV !== "production") {
     console.warn("[useFeed] Malformed feed item (missing type/data):", item);
   }

--- a/packages/api/src/services/feed-hooks.ts
+++ b/packages/api/src/services/feed-hooks.ts
@@ -53,9 +53,11 @@ export interface IShowcaseCheckIn {
   }[];
 }
 
+export type FeedReasonType = "new_practice" | "new_release" | "checked_in" | "cheered";
+
 export type FeedItem =
-  | { type: "practice"; data: IShowcasePractice }
-  | { type: "checkin"; data: IShowcaseCheckIn };
+  | { type: "practice"; feed_reason: FeedReasonType; data: IShowcasePractice }
+  | { type: "checkin"; feed_reason: FeedReasonType; data: IShowcaseCheckIn };
 
 export interface IFeedParams {
   keyword?: string;

--- a/packages/api/src/services/reaction.ts
+++ b/packages/api/src/services/reaction.ts
@@ -24,6 +24,12 @@ export type GetReactionsListResponse =
 
 export type ReactionListItem = components["schemas"]["ReactionListItem"];
 
+/** ReactionListItem 加入隱私欄位（後端尚未納入 openapi schema，透過此型別擴充） */
+export type ReactionListItemWithPrivacy = ReactionListItem & {
+  isPublic?: boolean;
+  isConnection?: boolean;
+};
+
 export type UpsertReactionRequest = components["schemas"]["UpsertReactionRequest"];
 export type RemoveReactionRequest = components["schemas"]["RemoveReactionRequest"];
 


### PR DESCRIPTION
## Why is this necessary?

1. 修正了 feed 列表中重複 key 導致的 React 渲染警告，提升了應用的穩定性。
2. 套用隱私規則以過濾 BrowseActivityContent 反應列表，確保用戶資料的安全性。
3. 實作了三點選單的差異化邏輯，增強了用戶互動的靈活性。
4. 新增了 BrowseActivityContent 元件，豐富了應用的功能性。
5. 更新了 FeedItem 型別並切換至 useFeed hook，提升了代碼的可維護性和效能。

## How does it address?

1. 透過修正重複 key 的問題，消除了 React 的警告訊息，改善了用戶體驗。
2. 實作了隱私規則過濾，確保用戶在使用 BrowseActivityContent 時的隱私得到保護。
3. 針對打卡詳情頁新增了快速反應按鈕與二層留言系統，提升了用戶的互動性。
4. 新增 ActivityCardItem 類型及 ActivityCard 元件，增強了 feed 的展示效果。
5. 將靈感頁面混合卡片渲染與 FeedLabel 動態化，提升了頁面的靈活性與美觀性。