### PR TITLE
fix(notification): 修正通知設定頁面事件類型及總開關持久性問題  

### DIFF
--- a/apps/product/src/components/settings/notifications/notification-settings.tsx
+++ b/apps/product/src/components/settings/notifications/notification-settings.tsx
@@ -25,17 +25,17 @@ type PreferencesMap = Record<string, PreferenceState>;
 const NOTIFICATION_TYPES = [
   { type: "reaction", label: "反應", description: "有人對你的內容按了反應" },
   { type: "comment", label: "留言與 @", description: "有人留言或 @ 提及了你" },
-  { type: "follow-user", label: "關注", description: "有人關注了你" },
-  { type: "connect", label: "連結請求", description: "有人向你發出連結請求" },
-  { type: "agree-connect", label: "連結確認", description: "對方同意了你的連結請求" },
+  { type: "UserFollowed", label: "關注", description: "有人關注了你" },
+  { type: "Connect", label: "連結請求", description: "有人向你發出連結請求" },
+  { type: "ConnectAccepted", label: "連結確認", description: "對方同意了你的連結請求" },
   { type: "update-practice-checkin", label: "關注的實踐更新", description: "你關注的實踐有新打卡" },
   {
-    type: "practice-started",
+    type: "PracticeCreated",
     label: "關注的人開始實踐",
     description: "你關注的人開始了新主題實踐",
   },
-  { type: "buddy-request", label: "Buddy 請求", description: "有人邀請你成為實踐夥伴" },
-  { type: "weekly", label: "週報", description: "每週一的島嶼探索摘要" },
+  { type: "BuddyRequest", label: "Buddy 請求", description: "有人邀請你成為實踐夥伴" },
+  { type: "WeeklyDigest", label: "週報", description: "每週一的島嶼探索摘要" },
 ];
 
 const DEFAULT_PREFS: PreferencesMap = Object.fromEntries(

--- a/apps/product/src/components/settings/notifications/notification-settings.tsx
+++ b/apps/product/src/components/settings/notifications/notification-settings.tsx
@@ -92,6 +92,9 @@ export const NotificationSettings = () => {
   // Sync from API response
   useEffect(() => {
     if (!data) return;
+    const n01Prefs = (data.data ?? []).filter((p) => p.channel === "N01");
+    // 從所有 N01 項目推導總開關狀態：至少有一個 enabled 就是開
+    setGlobalEnabled(n01Prefs.length === 0 || n01Prefs.some((p) => p.isEnabled));
     const newPrefs: PreferencesMap = { ...DEFAULT_PREFS };
     for (const p of data.data ?? []) {
       if (p.channel === "N01" && newPrefs[p.type]) {


### PR DESCRIPTION
---  
## Why is this necessary?  
- 通知設定頁面中的事件類型與實際使用的事件類型不一致，可能導致用戶混淆。  
- 通知總開關在重新進入頁面後無法保持關閉狀態，影響用戶體驗。  
- 確保通知功能的正確性和穩定性對於用戶的使用至關重要。  

## How does it address?  
- 修正了通知設定頁面中 type key 與實際 event type 不符的問題，確保顯示正確的事件類型。  
- 修復了通知總開關在重新進入頁面後無法保持關閉狀態的問題，確保用戶的設定能夠持久保存。  
- 進行了相關測試以驗證修正的有效性，提升了整體系統的可靠性。  