### PR TITLE
fix(auth): 修復 prerender 時 useRouter context 不存在導致的 build 失敗  

### DIFF
--- a/apps/product/src/app/global-provider.tsx
+++ b/apps/product/src/app/global-provider.tsx
@@ -3,6 +3,7 @@
 import { AnalyticsScripts } from "@daodao/analytics";
 import { AuthProvider } from "@daodao/auth";
 import { type Locale, type Messages, NextIntlClientProvider } from "@daodao/i18n";
+import { useRouter } from "@daodao/i18n/navigation";
 import { type DeviceInfo, DeviceProvider, detectDeviceClient } from "@daodao/shared";
 import "@daodao/ui/globals.css";
 import { SwrConfigProvider } from "@daodao/api";
@@ -10,7 +11,6 @@ import { DialogManagerProvider } from "@daodao/ui/components/animate-ui/componen
 import { SheetManagerProvider } from "@daodao/ui/components/animate-ui/components/radix/sheet";
 import { Toaster } from "@daodao/ui/components/sonner";
 import { NavigationBlockerProvider } from "@daodao/ui/hooks/navigation-blocker";
-import { useRouter } from "@daodao/i18n/navigation";
 
 interface GlobalProviderProps {
   head?: React.ReactNode;
@@ -20,6 +20,43 @@ interface GlobalProviderProps {
   initialDevice?: DeviceInfo;
 }
 
+// useRouter from @daodao/i18n/navigation requires NextIntlClientProvider in the tree.
+// This inner component is rendered inside NextIntlClientProvider so the context is available.
+function AuthNavigator({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+
+  return (
+    <AuthProvider
+      defaultProtected
+      publicPattern={[
+        "^/auth/login",
+        "^/auth/callback",
+        "^/auth/error",
+        "^/auth/onboarding",
+        "^/auth/verify-email(/.*)?$",
+        "^/auth/error",
+        "^/users/",
+        "^/practices/[^/]+$",
+        "^/dev/",
+      ]}
+      onAuthRequired={(currentPath) => {
+        router.push(`/auth/login?redirect=${encodeURIComponent(currentPath)}`);
+      }}
+      onboardingPath="/auth/onboarding"
+      onTemporaryUser={() => {
+        router.push("/auth/onboarding");
+      }}
+      emailVerificationPath="/auth/verify-email"
+      onEmailUnverified={() => {
+        router.push("/auth/verify-email/pending");
+      }}
+    >
+      <Toaster />
+      {children}
+    </AuthProvider>
+  );
+}
+
 function GlobalProvider({
   head,
   locale,
@@ -27,8 +64,6 @@ function GlobalProvider({
   messages,
   initialDevice = detectDeviceClient(),
 }: GlobalProviderProps) {
-  const router = useRouter();
-
   return (
     <html
       lang={locale}
@@ -45,34 +80,7 @@ function GlobalProvider({
               <SwrConfigProvider>
                 <DialogManagerProvider>
                   <SheetManagerProvider>
-                    <AuthProvider
-                      defaultProtected
-                      publicPattern={[
-                        "^/auth/login",
-                        "^/auth/callback",
-                        "^/auth/error",
-                        "^/auth/onboarding",
-                        "^/auth/verify-email(/.*)?$",
-                        "^/auth/error",
-                        "^/users/",
-                        "^/practices/[^/]+$",
-                        "^/dev/",
-                      ]}
-                      onAuthRequired={(currentPath) => {
-                        router.push(`/auth/login?redirect=${encodeURIComponent(currentPath)}`);
-                      }}
-                      onboardingPath="/auth/onboarding"
-                      onTemporaryUser={() => {
-                        router.push("/auth/onboarding");
-                      }}
-                      emailVerificationPath="/auth/verify-email"
-                      onEmailUnverified={() => {
-                        router.push("/auth/verify-email/pending");
-                      }}
-                    >
-                      <Toaster />
-                      {children}
-                    </AuthProvider>
+                    <AuthNavigator>{children}</AuthNavigator>
                   </SheetManagerProvider>
                 </DialogManagerProvider>
               </SwrConfigProvider>

--- a/apps/product/src/app/global-provider.tsx
+++ b/apps/product/src/app/global-provider.tsx
@@ -34,7 +34,6 @@ function AuthNavigator({ children }: { children: React.ReactNode }) {
         "^/auth/error",
         "^/auth/onboarding",
         "^/auth/verify-email(/.*)?$",
-        "^/auth/error",
         "^/users/",
         "^/practices/[^/]+$",
         "^/dev/",


### PR DESCRIPTION
---  
## Why is this necessary?  
- 在進行 /_not-found 頁面的 prerender 時，useRouter context 不存在會導致應用程式無法正常構建。  
- 這個問題會影響到應用程式的穩定性和可用性。  
- 修復此問題能確保應用程式在 prerender 過程中不會中斷，提升用戶體驗。  

## How does it address?  
- 透過修正 useRouter context 的使用，確保在 prerender 過程中能正確獲取所需的上下文。  
- 修改了相關的程式碼以避免在缺少 context 的情況下進行操作。  
- 測試了修復後的功能，確保 build 過程不再出現錯誤。  