### PR TITLE
fix(auth): 修復 OAuth 回調後頁面凍結無法跳轉問題  

### DIFF
--- a/packages/auth/src/hooks/use-redirect-after-login.ts
+++ b/packages/auth/src/hooks/use-redirect-after-login.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { getStorage, StorageEnum } from "@daodao/shared";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "@daodao/i18n/navigation";
+import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { decodeOAuthState, verifyAndConsumeOAuthState } from "../lib/auth-client";
 import { DEFAULT_REDIRECT_URL, ONBOARDING_URL } from "../lib/auth-constants";


### PR DESCRIPTION
---  
## Why is this necessary?  
- 使用者在 OAuth 認證後無法正常跳轉至下一頁，影響使用體驗。  
- 頁面凍結會導致使用者無法繼續操作，可能造成流失。  
- 修復此問題有助於提升應用的穩定性和可靠性。  

## How does it address?  
- 針對 OAuth 回調後的頁面跳轉邏輯進行修正。  
- 確保在認證成功後，頁面能夠正常響應並跳轉。  
- 測試修復後的功能，確保無其他影響。  