### PR TITLE
fix(check-in): 強制打卡表單第一階段 mood 為必填欄位

### DIFF
--- a/apps/mobile/components/check-in/form/schema.ts
+++ b/apps/mobile/components/check-in/form/schema.ts
@@ -9,7 +9,8 @@ export const checkInFormSchema = z.object({
   mood: z
     .enum(MOOD_OPTIONS.map((option) => option.id) as [MoodType, ...MoodType[]])
     .nullable()
-    .default(null),
+    .default(null)
+    .refine((val) => val !== null, { message: "請選擇心情" }),
   tags: z.array(z.string()).default([]),
   description: z.string().max(300, "最多300字").default(""),
   mediaUris: z.array(z.string()).max(3, "最多只能上傳3張圖片").default([]),

--- a/apps/product/src/components/check-in/form/schema.ts
+++ b/apps/product/src/components/check-in/form/schema.ts
@@ -9,7 +9,8 @@ export const checkInFormSchema = z.object({
   mood: z
     .enum(MOOD_OPTIONS.map((option) => option.id) as [MoodType, ...MoodType[]])
     .nullable()
-    .default(null),
+    .default(null)
+    .refine((val) => val !== null, { message: "請選擇心情" }),
   tags: z.array(z.string()).default([]),
   description: z.string().max(300, "最多300字").default(""),
   media: z.array(z.instanceof(File)).max(3, "最多只能上傳3張圖片").default([]),


### PR DESCRIPTION
## Why is this necessary?

1. 避免使用者在打卡時未填寫 mood，導致資料不完整。
2. 防止 NULL 值寫入資料庫，確保資料的一致性和完整性。
3. 提升使用者體驗，明確告知使用者必填欄位。

## How does it address?

1. 將打卡表單第一階段的 mood 欄位設為必填。
2. 在表單提交時進行驗證，確保 mood 欄位不為空。
3. 提供即時回饋，提示使用者填寫必要的欄位。