### PR TITLE
fix(notifications): 修正通知列表中 PracticeCreated 類型渲染空白的問題  

### DIFF
--- a/apps/product/src/components/notifications/notification-item.tsx
+++ b/apps/product/src/components/notifications/notification-item.tsx
@@ -164,6 +164,14 @@ function NotificationText({ notification }: { notification: INotificationData })
     );
   }
 
+  if (type === NotificationType.practiceCreated) {
+    return (
+      <p className="text-sm leading-5 line-clamp-2">
+        {name} 發起了新的主題實踐{practiceName}
+      </p>
+    );
+  }
+
   return null;
 }
 

--- a/apps/product/src/components/notifications/notification-list.tsx
+++ b/apps/product/src/components/notifications/notification-list.tsx
@@ -31,6 +31,7 @@ const BACKEND_TYPE_MAP: Record<string, INotificationData["type"]> = {
   ConnectAccepted: NotificationType.agreeConnect,
   PracticeCheckinActivity: NotificationType.updatePracticeCheckin,
   PartnerCheckinActivity: NotificationType.updatePracticeCheckin,
+  PracticeCreated: NotificationType.practiceCreated,
 };
 
 function normalizeNotificationType(backendType: string): INotificationData["type"] {

--- a/apps/product/src/constants/notification-type.ts
+++ b/apps/product/src/constants/notification-type.ts
@@ -9,6 +9,7 @@ export const NotificationType = {
   connectRejected: "connect-rejected",
   updatePracticeCheckin: "update-practice-checkin",
   updatePracticeFinish: "update-practice-finish",
+  practiceCreated: "practice-created",
 } as const;
 
 export type NotificationTypeType = (typeof NotificationType)[keyof typeof NotificationType];


### PR DESCRIPTION
---  
## Why is this necessary?  
- 通知列表中的 PracticeCreated 類型未正確顯示，導致用戶無法看到相關通知。  
- 空白渲染影響用戶體驗，可能造成混淆。  
- 修正此問題有助於提高應用程式的可靠性和可用性。  

## How does it address?  
- 針對通知列表的渲染邏輯進行了修正。  
- 確保 PracticeCreated 類型的通知能夠正確顯示在列表中。  
- 測試了修正後的功能以確認問題已解決。  