### PR TITLE
fix(check-in): 修復 NULL 心情打卡記錄隱藏問題

### DIFF
--- a/apps/product/src/components/check-in/display/check-in-record-card.tsx
+++ b/apps/product/src/components/check-in/display/check-in-record-card.tsx
@@ -5,7 +5,7 @@ import { Button } from "@daodao/ui/components/button";
 import { cn } from "@daodao/ui/lib/utils";
 import { ChevronUp } from "lucide-react";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
-import { MOOD_OPTIONS, type MoodType, mapApiMoodToMoodType } from "@/constants/mood";
+import { MOOD_OPTIONS, MoodType, mapApiMoodToMoodType } from "@/constants/mood";
 import type { IMoodStat } from "../types";
 
 interface ICheckInRecordCardProps {
@@ -33,13 +33,11 @@ export const CheckInRecordCard = ({ checkInsData, isLoading = false }: ICheckInR
       moodCountMap.set(option.id, 0);
     });
 
-    // 統計每個心情的出現次數
+    // 統計每個心情的出現次數（NULL mood fallback 到 neutral，避免被排除在心情排行之外）
     checkInsData.data.forEach((checkIn) => {
-      const moodType = mapApiMoodToMoodType(checkIn.mood);
-      if (moodType) {
-        const currentCount = moodCountMap.get(moodType) ?? 0;
-        moodCountMap.set(moodType, currentCount + 1);
-      }
+      const moodType = mapApiMoodToMoodType(checkIn.mood) ?? MoodType.neutral;
+      const currentCount = moodCountMap.get(moodType) ?? 0;
+      moodCountMap.set(moodType, currentCount + 1);
     });
 
     // 轉換為陣列格式

--- a/apps/product/src/components/check-in/display/check-in-stack.tsx
+++ b/apps/product/src/components/check-in/display/check-in-stack.tsx
@@ -14,6 +14,7 @@ import * as decomp from "poly-decomp-es";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   MOOD_OPTIONS,
+  MoodType,
   type MoodType as MoodTypeType,
   mapApiMoodToMoodType,
 } from "@/constants/mood";
@@ -284,28 +285,18 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
   const animationFrameRef = useRef<number | undefined>(undefined);
   const [svgGeometries, setSvgGeometries] = useState<(ISvgGeometry | null)[]>([]);
 
-  // 將 API 資料轉換為 ICheckInItem[] 格式
+  // 將 API 資料轉換為 ICheckInItem[] 格式（NULL mood fallback 到 neutral，避免整筆被隱藏）
   const items: ICheckInItem[] = useMemo(() => {
     if (!checkInsData?.data) {
       return [];
     }
 
-    return checkInsData.data
-      .map((checkIn) => {
-        const moodType = mapApiMoodToMoodType(checkIn.mood);
-        // 如果沒有心情類型，跳過這個打卡記錄
-        if (!moodType) {
-          return null;
-        }
-
-        return {
-          id: String(checkIn.id),
-          date: formatCheckInDate(checkIn.checkinDate),
-          mood: moodType,
-          content: checkIn.note || "",
-        };
-      })
-      .filter((item): item is ICheckInItem => item !== null);
+    return checkInsData.data.map((checkIn) => ({
+      id: String(checkIn.id),
+      date: formatCheckInDate(checkIn.checkinDate),
+      mood: mapApiMoodToMoodType(checkIn.mood) ?? MoodType.neutral,
+      content: checkIn.note || "",
+    }));
   }, [checkInsData]);
 
   const count = items.length;
@@ -550,11 +541,6 @@ export const CheckInStack = ({ practiceId, checkInsData }: ICheckInStackProps) =
 
     return "";
   };
-
-  // 如果沒有資料（載入完成後），不顯示任何內容
-  if (count === 0) {
-    return null;
-  }
 
   return (
     <div


### PR DESCRIPTION
## Why is this necessary?

1. NULL 心情的打卡記錄在列表頁面中未正確顯示，影響用戶體驗。
2. 心情排行中缺少 NULL 心情的打卡記錄，導致數據不完整。
3. 確保所有打卡記錄都能被正確顯示，有助於用戶更好地了解自己的打卡狀態。

## How does it address?

1. 修正了打卡記錄中 NULL 心情的顯示邏輯。
2. 更新了列表頁面和心情排行的渲染方式，以包含 NULL 心情的記錄。
3. 測試了修復後的功能，確保所有打卡記錄均能正確顯示。