### PR TITLE
fix(home): 修正 PR 評論的型別與狀態同步問題

### DIFF
--- a/apps/mobile/components/home/filter-pills.tsx
+++ b/apps/mobile/components/home/filter-pills.tsx
@@ -17,6 +17,7 @@ interface FilterPillsProps {
 }
 
 export function FilterPills({ activeFilter, onFilterChange, counts }: FilterPillsProps) {
+  const safeCounts = counts ?? {};
   return (
     <ScrollView
       horizontal
@@ -26,7 +27,7 @@ export function FilterPills({ activeFilter, onFilterChange, counts }: FilterPill
     >
       {filterOptions.map((option) => {
         const isActive = activeFilter === option.value;
-        const count = counts?.[option.value];
+        const count = safeCounts[option.value];
         return (
           <Pressable
             key={option.value}

--- a/apps/mobile/components/home/showcase-card.tsx
+++ b/apps/mobile/components/home/showcase-card.tsx
@@ -1,5 +1,5 @@
 import { MessageCircle, MoreHorizontal } from "@tamagui/lucide-icons";
-import { useRouter } from "expo-router";
+import { type Href, useRouter } from "expo-router";
 import type { ReactNode } from "react";
 import { useCallback, useState } from "react";
 import { Image, Pressable, StyleSheet } from "react-native";
@@ -96,9 +96,7 @@ export function ShowcaseCard({
       style={styles.card}
       onPress={() =>
         router.push({
-          // biome-ignore lint: Expo Router dynamic route typing workaround
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          pathname: `/practices/${id}` as any,
+          pathname: `/practices/${id}` as Href,
           params: { showcaseData: JSON.stringify(practice) },
         })
       }

--- a/apps/mobile/tamagui.config.ts
+++ b/apps/mobile/tamagui.config.ts
@@ -56,22 +56,21 @@ const tokens = createTokens({
   ...defaultTokens,
   color: {
     ...defaultTokens.color,
-    // Primary
+    // Base palettes
     primaryPalest: colors.primary.palest,
     primaryPale: colors.primary.pale,
     primaryLightest: colors.primary.lightest,
     primaryLighter: colors.primary.lighter,
     primaryBase: colors.primary.base,
     primaryDarker: colors.primary.darker,
-    // Gray
     grayDark: colors.gray.dark,
     grayMid: colors.gray.mid,
     grayLight: colors.gray.light,
     grayVeryLight: colors.gray.veryLight,
     grayWhite: colors.gray.white,
-    // Tips
-    tips: "#FFA10B",
-    // Mascot
+
+    // Semantic colors
+    accentTips: "#FFA10B",
     mascotAqua: colors.mascot.aqua,
     mascotBrightBlue: colors.mascot.brightBlue,
   },

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -104,10 +104,17 @@ export default function HomePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const activeTab = (searchParams.get("tab") as TabType) === "mine" ? "mine" : "inspire";
+  const [activeTab, setActiveTab] = useState<TabType>(
+    (searchParams.get("tab") as TabType) === "mine" ? "mine" : "inspire"
+  );
+
+  useEffect(() => {
+    setActiveTab((searchParams.get("tab") as TabType) === "mine" ? "mine" : "inspire");
+  }, [searchParams]);
 
   const handleTabChange = useCallback(
     (tab: TabType) => {
+      setActiveTab(tab);
       const params = new URLSearchParams(searchParams.toString());
       if (tab === "inspire") {
         params.delete("tab");

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -104,13 +104,10 @@ export default function HomePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [activeTab, setActiveTab] = useState<TabType>(
-    (searchParams.get("tab") as TabType) === "mine" ? "mine" : "inspire"
-  );
+  const activeTab = (searchParams.get("tab") as TabType) === "mine" ? "mine" : "inspire";
 
   const handleTabChange = useCallback(
     (tab: TabType) => {
-      setActiveTab(tab);
       const params = new URLSearchParams(searchParams.toString());
       if (tab === "inspire") {
         params.delete("tab");

--- a/apps/product/src/components/notifications/notification-list.tsx
+++ b/apps/product/src/components/notifications/notification-list.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "@daodao/i18n/navigation";
 import { Button } from "@daodao/ui/components/button";
 import { toast } from "@daodao/ui/components/sonner";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { mutate as globalMutate } from "swr";
 import { NotificationType } from "@/constants/notification-type";
 import type { ReactionTypeType } from "@/constants/reaction-type";
@@ -149,10 +149,13 @@ export function NotificationList() {
     {}
   );
 
-  const rawItems = data?.data?.notifications ?? [];
-  const apiItems = (rawItems as unknown as NotificationApiItem[])
-    .slice()
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const apiItems = useMemo(
+    () =>
+      ((data?.data?.notifications ?? []) as unknown as NotificationApiItem[])
+        .slice()
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+    [data?.data?.notifications]
+  );
   const notifications: INotificationData[] = apiItems.map((item) => {
     const base = apiItemToDisplay(item);
     return { ...base, ...(localOverrides[base.id] ?? {}) };

--- a/apps/product/src/components/notifications/notification-list.tsx
+++ b/apps/product/src/components/notifications/notification-list.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "@daodao/i18n/navigation";
 import { Button } from "@daodao/ui/components/button";
 import { toast } from "@daodao/ui/components/sonner";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { mutate as globalMutate } from "swr";
 import { NotificationType } from "@/constants/notification-type";
 import type { ReactionTypeType } from "@/constants/reaction-type";
@@ -150,13 +150,9 @@ export function NotificationList() {
   );
 
   const rawItems = data?.data?.notifications ?? [];
-  const apiItems = useMemo(
-    () =>
-      (rawItems as unknown as NotificationApiItem[])
-        .slice()
-        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-    [rawItems]
-  );
+  const apiItems = (rawItems as unknown as NotificationApiItem[])
+    .slice()
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   const notifications: INotificationData[] = apiItems.map((item) => {
     const base = apiItemToDisplay(item);
     return { ...base, ...(localOverrides[base.id] ?? {}) };

--- a/apps/product/src/components/notifications/notification-list.tsx
+++ b/apps/product/src/components/notifications/notification-list.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "@daodao/i18n/navigation";
 import { Button } from "@daodao/ui/components/button";
 import { toast } from "@daodao/ui/components/sonner";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { mutate as globalMutate } from "swr";
 import { NotificationType } from "@/constants/notification-type";
 import type { ReactionTypeType } from "@/constants/reaction-type";
@@ -150,9 +150,13 @@ export function NotificationList() {
   );
 
   const rawItems = data?.data?.notifications ?? [];
-  const apiItems = (rawItems as unknown as NotificationApiItem[])
-    .slice()
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const apiItems = useMemo(
+    () =>
+      (rawItems as unknown as NotificationApiItem[])
+        .slice()
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    [rawItems]
+  );
   const notifications: INotificationData[] = apiItems.map((item) => {
     const base = apiItemToDisplay(item);
     return { ...base, ...(localOverrides[base.id] ?? {}) };

--- a/packages/features/mention/src/components/mention-input.tsx
+++ b/packages/features/mention/src/components/mention-input.tsx
@@ -70,7 +70,8 @@ export function MentionInput({
     const textarea = ref.current;
     if (!textarea) return;
     resizeTextarea(textarea);
-  }, [resizeTextarea]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: include value for external prop updates
+  }, [resizeTextarea, value]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;

--- a/packages/features/mention/src/components/mention-input.tsx
+++ b/packages/features/mention/src/components/mention-input.tsx
@@ -70,7 +70,7 @@ export function MentionInput({
     const textarea = ref.current;
     if (!textarea) return;
     resizeTextarea(textarea);
-  });
+  }, [resizeTextarea]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;


### PR DESCRIPTION
## Why is this necessary?

1. PR 評論的型別與狀態不一致可能導致使用者混淆。
2. 確保 PR 評論的準確性對於團隊協作至關重要。
3. 修正此問題可以提升使用者體驗，減少錯誤操作。

## How does it address?

1. 針對 PR review 的型別與狀態進行了檢查與修正。
2. 更新了相關的邏輯以確保型別與狀態的正確同步。
3. 測試了修正後的功能以確保其正常運作。