### PR TITLE
feat(product): 統一實踐詳情頁關閉按鈕為 replace 導頁

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -58,6 +58,12 @@ interface IApiCommentNode {
   replies?: unknown[];
 }
 
+
+const canNavigateBack = () => {
+  if (typeof window === "undefined") return false;
+  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
+};
+
 interface IPracticeDetailData {
   title: string;
   actionDescription: string;
@@ -466,7 +472,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/?tab=mine")}
+            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -487,7 +493,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/?tab=mine")}
+            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -517,7 +523,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => router.replace("/?tab=mine")}
+          onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -469,7 +469,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={() => router.replace("/")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -490,7 +490,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={() => router.replace("/")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -520,7 +520,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => (fromCopy ? router.push("/?tab=mine") : router.back())}
+          onClick={() => (fromCopy ? router.replace("/?tab=mine") : router.replace("/"))}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -22,7 +22,6 @@ import { toast } from "@daodao/ui/components/sonner";
 import { format, formatDistanceToNow, isValid, parseISO } from "date-fns";
 import { zhTW } from "date-fns/locale";
 import { X } from "lucide-react";
-import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo } from "react";
 import { CheckInButton } from "@/components/check-in";
 import type { IComment, ICommentReply } from "@/components/check-in/reactions";
@@ -194,8 +193,6 @@ export default function PracticeDetailPage() {
   const router = useRouter();
   const params = useParams();
   const practiceId = params.id as string;
-  const searchParams = useSearchParams();
-  const fromCopy = searchParams.get("from") === "copy";
   const {
     data: practiceData,
     isLoading,
@@ -469,7 +466,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/")}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -490,7 +487,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/")}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -520,7 +517,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => (fromCopy ? router.replace("/?tab=mine") : router.replace("/"))}
+          onClick={() => router.replace("/?tab=mine")}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -59,11 +59,6 @@ interface IApiCommentNode {
 }
 
 
-const canNavigateBack = () => {
-  if (typeof window === "undefined") return false;
-  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
-};
-
 interface IPracticeDetailData {
   title: string;
   actionDescription: string;
@@ -472,7 +467,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -493,7 +488,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -523,7 +518,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
+          onClick={() => router.replace("/?tab=mine")}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -8,6 +8,11 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { CheckInDateButton } from "./check-in-date-button";
 import type { ICheckInDateSelectorProps } from "./types";
 
+const canNavigateBack = () => {
+  if (typeof window === "undefined") return false;
+  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
+};
+
 export const MobileCheckInDateSelector = ({
   checkInDates,
   checkIns,
@@ -137,9 +142,15 @@ export const MobileCheckInDateSelector = ({
   const handleClose = () => {
     if (closeActionTo) {
       router.replace(closeActionTo);
-    } else {
-      router.replace("/");
+      return;
     }
+
+    if (canNavigateBack()) {
+      router.back();
+      return;
+    }
+
+    router.replace("/");
   };
 
   return (

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -8,10 +8,6 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { CheckInDateButton } from "./check-in-date-button";
 import type { ICheckInDateSelectorProps } from "./types";
 
-const canNavigateBack = () => {
-  if (typeof window === "undefined") return false;
-  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
-};
 
 export const MobileCheckInDateSelector = ({
   checkInDates,
@@ -142,11 +138,6 @@ export const MobileCheckInDateSelector = ({
   const handleClose = () => {
     if (closeActionTo) {
       router.replace(closeActionTo);
-      return;
-    }
-
-    if (canNavigateBack()) {
-      router.back();
       return;
     }
 

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -136,9 +136,9 @@ export const MobileCheckInDateSelector = ({
   // 處理關閉按鈕點擊
   const handleClose = () => {
     if (closeActionTo) {
-      router.push(closeActionTo);
+      router.replace(closeActionTo);
     } else {
-      router.back();
+      router.replace("/");
     }
   };
 


### PR DESCRIPTION
## Why is this necessary?

- 實踐詳情頁多個關閉按鈕仍使用 router.back，會依賴歷史堆疊導致回跳不穩定。
- 已調整的 check-in 關閉策略是 replace，詳情頁需一致以避免 A/B 循環問題再現。

## How does it address?

- 將載入中與錯誤狀態的關閉按鈕從 router.back 改為 router.replace('/')。
- 將一般狀態關閉按鈕改為 fromCopy 時 replace('/?tab=mine')，其餘 replace('/')。