### PR TITLE
fix(product): 統一關閉按鈕行為以改善導航體驗  

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -58,6 +58,12 @@ interface IApiCommentNode {
   replies?: unknown[];
 }
 
+
+const canNavigateBack = () => {
+  if (typeof window === "undefined") return false;
+  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
+};
+
 interface IPracticeDetailData {
   title: string;
   actionDescription: string;
@@ -466,7 +472,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/?tab=mine")}
+            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -487,7 +493,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/?tab=mine")}
+            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -517,7 +523,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => router.replace("/?tab=mine")}
+          onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -469,7 +469,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={() => router.replace("/")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -490,7 +490,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.back()}
+            onClick={() => router.replace("/")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -520,7 +520,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => (fromCopy ? router.push("/?tab=mine") : router.back())}
+          onClick={() => (fromCopy ? router.replace("/?tab=mine") : router.replace("/"))}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -22,7 +22,6 @@ import { toast } from "@daodao/ui/components/sonner";
 import { format, formatDistanceToNow, isValid, parseISO } from "date-fns";
 import { zhTW } from "date-fns/locale";
 import { X } from "lucide-react";
-import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo } from "react";
 import { CheckInButton } from "@/components/check-in";
 import type { IComment, ICommentReply } from "@/components/check-in/reactions";
@@ -194,8 +193,6 @@ export default function PracticeDetailPage() {
   const router = useRouter();
   const params = useParams();
   const practiceId = params.id as string;
-  const searchParams = useSearchParams();
-  const fromCopy = searchParams.get("from") === "copy";
   const {
     data: practiceData,
     isLoading,
@@ -469,7 +466,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/")}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -490,7 +487,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace("/")}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -520,7 +517,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => (fromCopy ? router.replace("/?tab=mine") : router.replace("/"))}
+          onClick={() => router.replace("/?tab=mine")}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -59,11 +59,6 @@ interface IApiCommentNode {
 }
 
 
-const canNavigateBack = () => {
-  if (typeof window === "undefined") return false;
-  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
-};
-
 interface IPracticeDetailData {
   title: string;
   actionDescription: string;
@@ -472,7 +467,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -493,7 +488,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
+            onClick={() => router.replace("/?tab=mine")}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label="關閉"
           >
@@ -523,7 +518,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => (canNavigateBack() ? router.back() : router.replace("/?tab=mine"))}
+          onClick={() => router.replace("/?tab=mine")}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label="關閉"
         >

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -8,6 +8,11 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { CheckInDateButton } from "./check-in-date-button";
 import type { ICheckInDateSelectorProps } from "./types";
 
+const canNavigateBack = () => {
+  if (typeof window === "undefined") return false;
+  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
+};
+
 export const MobileCheckInDateSelector = ({
   checkInDates,
   checkIns,
@@ -137,9 +142,15 @@ export const MobileCheckInDateSelector = ({
   const handleClose = () => {
     if (closeActionTo) {
       router.replace(closeActionTo);
-    } else {
-      router.replace("/");
+      return;
     }
+
+    if (canNavigateBack()) {
+      router.back();
+      return;
+    }
+
+    router.replace("/");
   };
 
   return (

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -8,10 +8,6 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { CheckInDateButton } from "./check-in-date-button";
 import type { ICheckInDateSelectorProps } from "./types";
 
-const canNavigateBack = () => {
-  if (typeof window === "undefined") return false;
-  return window.history.length > 1 && document.referrer.startsWith(window.location.origin);
-};
 
 export const MobileCheckInDateSelector = ({
   checkInDates,
@@ -142,11 +138,6 @@ export const MobileCheckInDateSelector = ({
   const handleClose = () => {
     if (closeActionTo) {
       router.replace(closeActionTo);
-      return;
-    }
-
-    if (canNavigateBack()) {
-      router.back();
       return;
     }
 

--- a/apps/product/src/components/check-in/date-selector/mobile.tsx
+++ b/apps/product/src/components/check-in/date-selector/mobile.tsx
@@ -136,9 +136,9 @@ export const MobileCheckInDateSelector = ({
   // 處理關閉按鈕點擊
   const handleClose = () => {
     if (closeActionTo) {
-      router.push(closeActionTo);
+      router.replace(closeActionTo);
     } else {
-      router.back();
+      router.replace("/");
     }
   };
 

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -18,7 +18,7 @@ import {
   FlagOutlineSvg,
   TelescopeSvg,
 } from "@daodao/assets";
-import { usePathname, useRouter } from "@daodao/i18n/navigation";
+import { usePathname, useRouter, useSearchParams } from "@daodao/i18n/navigation";
 import { useSheetManager } from "@daodao/ui/components/animate-ui/components/radix/sheet";
 import { Badge } from "@daodao/ui/components/badge";
 import { Button } from "@daodao/ui/components/button";
@@ -309,6 +309,7 @@ export function PracticeDetailShell({
 }: IPracticeDetailShellProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { copyPractice } = useCopyPractice();
   const [isCopying, setIsCopying] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>("comments");
@@ -342,6 +343,16 @@ export function PracticeDetailShell({
   const [pendingReaction, setPendingReaction] = useState<ReactionTypeType | null | undefined>(
     undefined
   );
+
+  useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam !== "comments") return;
+
+    setActiveTab("comments");
+    requestAnimationFrame(() => {
+      commentsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }, [searchParams]);
 
   const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
     null) as ReactionTypeType | null;

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -343,16 +343,30 @@ export function PracticeDetailShell({
   const [pendingReaction, setPendingReaction] = useState<ReactionTypeType | null | undefined>(
     undefined
   );
+  const tabParam = searchParams.get("tab");
+
+  const isValidTab = useCallback((tab: string | null): tab is TabType => {
+    if (!tab) {
+      return false;
+    }
+
+    return TABS.some((item) => item.id === tab);
+  }, []);
 
   useEffect(() => {
-    const tabParam = searchParams.get("tab");
-    if (tabParam !== "comments") return;
+    if (!isValidTab(tabParam)) {
+      return;
+    }
 
-    setActiveTab("comments");
+    setActiveTab(tabParam);
+    if (tabParam !== "comments") {
+      return;
+    }
+
     requestAnimationFrame(() => {
       commentsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
     });
-  }, [searchParams]);
+  }, [isValidTab, tabParam]);
 
   const currentUserReaction = (reactionsData?.data?.currentUserReaction ??
     null) as ReactionTypeType | null;

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -352,6 +352,7 @@ export function PracticeShowcaseCard({
                   {commentUserIslandHref ? (
                     <Link
                       href={commentUserIslandHref}
+                      // 預先載入使用者小島頁，降低點擊頭像後的等待體感
                       prefetch
                       aria-label={`前往 ${commentUserName} 的小島`}
                       className="shrink-0"
@@ -365,6 +366,7 @@ export function PracticeShowcaseCard({
                     {commentUserIslandHref ? (
                       <Link
                         href={commentUserIslandHref}
+                        // 預先載入使用者小島頁，降低點擊名稱後的等待體感
                         prefetch
                         className="text-xs font-semibold text-[#295E5C] mr-1.5 hover:underline"
                       >

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -253,7 +253,7 @@ export function PracticeShowcaseCard({
             // biome-ignore lint/a11y/useKeyWithClickEvents: stop card click
             // biome-ignore lint/a11y/noStaticElementInteractions: stop card click
             <span onClick={(e) => e.stopPropagation()}>
-              <Link href={`/users/${user.id}`} className="shrink-0">
+              <Link href={`/users/${user.id}`} prefetch className="shrink-0">
                 <Avatar className="size-16">
                   {user.photoUrl && <AvatarImage src={user.photoUrl} />}
                   <AvatarFallback>
@@ -308,7 +308,7 @@ export function PracticeShowcaseCard({
         />
 
         <Link
-          href={`/practices/${id}`}
+          href={`/practices/${id}?tab=comments`}
           className="flex items-center gap-1.5 text-[#9FB5B8] hover:text-text-dark transition-colors"
         >
           <DialogOutlineSvg className="size-6" />
@@ -352,6 +352,7 @@ export function PracticeShowcaseCard({
                   {commentUserIslandHref ? (
                     <Link
                       href={commentUserIslandHref}
+                      prefetch
                       aria-label={`前往 ${commentUserName} 的小島`}
                       className="shrink-0"
                     >
@@ -364,6 +365,7 @@ export function PracticeShowcaseCard({
                     {commentUserIslandHref ? (
                       <Link
                         href={commentUserIslandHref}
+                        prefetch
                         className="text-xs font-semibold text-[#295E5C] mr-1.5 hover:underline"
                       >
                         {commentUserName}


### PR DESCRIPTION
---  

## Why is this necessary?  
- 關閉按鈕的行為不一致可能導致使用者在頁面之間的導航不穩定。  
- 需要避免歷史堆疊的回跳循環，以提升使用者體驗。  
- 關閉行為應該根據當前頁面的上下文提供合適的導向，而非僅僅返回首頁。  

## How does it address?  
- 將所有關閉按鈕的行為統一為使用 `replace` 方法，以確保不依賴歷史堆疊。  
- 增加判斷邏輯，根據歷史紀錄決定是否使用 `back` 或 `replace`。  
- 調整實踐詳情頁的關閉按鈕導向為 `mine` 分頁，提供更符合情境的導航選擇。  