### PR TITLE
[auto] #646 打卡上傳圖片預覽失敗

### DIFF
--- a/apps/mobile/components/check-in/form/components/media-upload-field.tsx
+++ b/apps/mobile/components/check-in/form/components/media-upload-field.tsx
@@ -3,9 +3,8 @@ import * as ImagePicker from "expo-image-picker";
 import { useCallback } from "react";
 import { Pressable, StyleSheet } from "react-native";
 import { Image, Text, View, XStack, YStack } from "tamagui";
+import { CHECK_IN_MAX_IMAGES } from "@daodao/shared/lib/check-in-image";
 import { colors } from "@/generated/design-tokens";
-
-const MAX_FILES = 3;
 
 interface IMediaUploadFieldProps {
   value: string[];
@@ -17,18 +16,19 @@ interface IMediaUploadFieldProps {
  */
 export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) => {
   const handlePickImage = useCallback(async () => {
-    if (value.length >= MAX_FILES) return;
+    if (value.length >= CHECK_IN_MAX_IMAGES) return;
 
     const result = await ImagePicker.launchImageLibraryAsync({
+      // Images only: videos cannot be previewed with the Image component
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsMultipleSelection: true,
-      selectionLimit: MAX_FILES - value.length,
+      selectionLimit: CHECK_IN_MAX_IMAGES - value.length,
       quality: 0.8,
     });
 
     if (!result.canceled) {
       const newMedia = result.assets.map((asset) => asset.uri);
-      onChange([...value, ...newMedia].slice(0, MAX_FILES));
+      onChange([...value, ...newMedia].slice(0, CHECK_IN_MAX_IMAGES));
     }
   }, [value, onChange]);
 
@@ -43,15 +43,15 @@ export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) =>
     <YStack marginBottom="$8">
       <XStack justifyContent="space-between" alignItems="center" marginBottom="$3">
         <Text fontSize={16} fontWeight="500" color={colors.text.dark}>
-          上傳照片
+          上傳圖片
         </Text>
         <Text fontSize={14} color={colors.basic["400"]}>
-          已上傳 {value.length}/{MAX_FILES} 張
+          已上傳 {value.length}/{CHECK_IN_MAX_IMAGES} 張
         </Text>
       </XStack>
 
       <XStack gap="$3" flexWrap="wrap">
-        {/* 已上傳的媒體預覽 */}
+        {/* 已上傳的圖片預覽 */}
         {value.map((uri, index) => (
           <View key={uri} style={styles.mediaPreview}>
             <View
@@ -61,12 +61,18 @@ export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) =>
               overflow="hidden"
               backgroundColor={colors.basic["200"]}
             >
-              <Image source={{ uri }} width={80} height={80} resizeMode="cover" />
+              <Image
+                source={{ uri }}
+                width={80}
+                height={80}
+                resizeMode="cover"
+                alt={`圖片預覽 ${index + 1}`}
+              />
             </View>
             <Pressable
               style={styles.removeButton}
               onPress={() => handleRemoveMedia(index)}
-              accessibilityLabel="移除媒體"
+              accessibilityLabel="移除圖片"
               accessibilityRole="button"
             >
               <X size={12} color={colors.basic.white} />
@@ -75,7 +81,7 @@ export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) =>
         ))}
 
         {/* 上傳按鈕 */}
-        {value.length < MAX_FILES && (
+        {value.length < CHECK_IN_MAX_IMAGES && (
           <Pressable style={styles.uploadButton} onPress={handlePickImage}>
             <Camera size={24} color={colors.basic["400"]} />
             <Text fontSize={12} color={colors.basic["400"]}>

--- a/apps/mobile/components/check-in/form/components/media-upload-field.tsx
+++ b/apps/mobile/components/check-in/form/components/media-upload-field.tsx
@@ -20,7 +20,7 @@ export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) =>
     if (value.length >= MAX_FILES) return;
 
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsMultipleSelection: true,
       selectionLimit: MAX_FILES - value.length,
       quality: 0.8,
@@ -43,7 +43,7 @@ export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) =>
     <YStack marginBottom="$8">
       <XStack justifyContent="space-between" alignItems="center" marginBottom="$3">
         <Text fontSize={16} fontWeight="500" color={colors.text.dark}>
-          上傳照片或影片
+          上傳照片
         </Text>
         <Text fontSize={14} color={colors.basic["400"]}>
           已上傳 {value.length}/{MAX_FILES} 張
@@ -61,7 +61,7 @@ export const MediaUploadField = ({ value, onChange }: IMediaUploadFieldProps) =>
               overflow="hidden"
               backgroundColor={colors.basic["200"]}
             >
-              <Image source={{ uri }} width="100%" height="100%" resizeMode="cover" />
+              <Image source={{ uri }} width={80} height={80} resizeMode="cover" />
             </View>
             <Pressable
               style={styles.removeButton}

--- a/packages/shared/src/lib/__tests__/check-in-image.test.ts
+++ b/packages/shared/src/lib/__tests__/check-in-image.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { CHECK_IN_IMAGE_ACCEPTED_TYPES, CHECK_IN_MAX_IMAGES } from "../check-in-image";
+
+describe("check-in image constants", () => {
+  it("only accepts image MIME types, not video", () => {
+    const hasVideo = CHECK_IN_IMAGE_ACCEPTED_TYPES.some((t) => t.startsWith("video/"));
+    expect(hasVideo).toBe(false);
+  });
+
+  it("all accepted types are image MIME types", () => {
+    for (const type of CHECK_IN_IMAGE_ACCEPTED_TYPES) {
+      expect(type.startsWith("image/")).toBe(true);
+    }
+  });
+
+  it("limits to 3 images maximum", () => {
+    expect(CHECK_IN_MAX_IMAGES).toBe(3);
+  });
+});

--- a/packages/shared/src/lib/check-in-image.ts
+++ b/packages/shared/src/lib/check-in-image.ts
@@ -1,0 +1,10 @@
+export const CHECK_IN_MAX_IMAGES = 3;
+
+export const CHECK_IN_IMAGE_ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export type CheckInImageType = (typeof CHECK_IN_IMAGE_ACCEPTED_TYPES)[number];


### PR DESCRIPTION
## Summary
Implements #646: 打卡上傳圖片預覽失敗

- `MediaTypeOptions.All` 允許選擇影片，但 `<Image>` 無法顯示影片縮圖 → 改為 `MediaTypeOptions.Images` 只允許選擇圖片
- `Image` 元件使用 `width="100%"` 在部分 React Native/Tamagui 版本中無法正確渲染 → 改為明確的 `width={80} height={80}` 尺寸
- 更新標籤文字從「上傳照片或影片」改為「上傳照片」

## Test plan
- [ ] pnpm test passes (shared package)
- [ ] pnpm lint passes (mobile app)
- [ ] 打卡時選擇圖片，縮圖正確顯示
- [ ] 影片不再出現在圖片選擇器中

---
🤖 Auto-generated by daodao pipeline
Closes #646

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJWg9iMY7eNfs7SfBkfuVk)_