### PR TITLE
[auto] #651 修改註冊完成頁按鈕文字

### DIFF
--- a/apps/product/src/components/onboarding/success-section.tsx
+++ b/apps/product/src/components/onboarding/success-section.tsx
@@ -22,7 +22,7 @@ export const SuccessSection = ({ userName }: SuccessSectionProps) => {
   const t = useTranslations("onboarding");
   const router = useRouter();
 
-  const handleGoToPreferences = () => {
+  const handleGoToHome = () => {
     router.push("/");
   };
 
@@ -77,7 +77,7 @@ export const SuccessSection = ({ userName }: SuccessSectionProps) => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.6 }}
         >
-          <Button variant="ctaPrimary" className="w-full" onClick={handleGoToPreferences}>
+          <Button variant="ctaPrimary" className="w-full" onClick={handleGoToHome}>
             {t("steps.success.primaryButton")}
           </Button>
         </motion.div>

--- a/apps/product/src/components/onboarding/success-section.tsx
+++ b/apps/product/src/components/onboarding/success-section.tsx
@@ -26,10 +26,6 @@ export const SuccessSection = ({ userName }: SuccessSectionProps) => {
     router.push("/");
   };
 
-  const handleSkip = () => {
-    router.push("/");
-  };
-
   return (
     <>
       {/* Confetti 彩帶動畫 */}
@@ -76,16 +72,13 @@ export const SuccessSection = ({ userName }: SuccessSectionProps) => {
 
         {/* CTA 按鈕 */}
         <motion.div
-          className="w-full max-w-sm space-y-3"
+          className="w-full max-w-sm"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.6 }}
         >
           <Button variant="ctaPrimary" className="w-full" onClick={handleGoToPreferences}>
             {t("steps.success.primaryButton")}
-          </Button>
-          <Button variant="ghost" className="w-full" onClick={handleSkip}>
-            {t("steps.success.secondaryButton")}
           </Button>
         </motion.div>
       </div>

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4267,7 +4267,7 @@
       "success": {
         "title": "Welcome to Dao Dao!",
         "titleWithName": "{name}, Welcome to Dao Dao!",
-        "primaryButton": "Set up preferences for personalized recommendations",
+        "primaryButton": "Explore Dao Dao",
         "secondaryButton": "Set up later",
         "emailReminder": "Don't forget to check your inbox for our welcome email!"
       }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4268,7 +4268,6 @@
         "title": "Welcome to Dao Dao!",
         "titleWithName": "{name}, Welcome to Dao Dao!",
         "primaryButton": "Explore Dao Dao",
-        "secondaryButton": "Set up later",
         "emailReminder": "Don't forget to check your inbox for our welcome email!"
       }
     },

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4268,7 +4268,6 @@
         "title": "歡迎加入島島阿學！",
         "titleWithName": "{name}，歡迎加入島島阿學！",
         "primaryButton": "前往島島阿學",
-        "secondaryButton": "稍後設定",
         "emailReminder": "記得到信箱收我們的歡迎信哦!"
       }
     },

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4267,7 +4267,7 @@
       "success": {
         "title": "歡迎加入島島阿學！",
         "titleWithName": "{name}，歡迎加入島島阿學！",
-        "primaryButton": "前往完成偏好設定獲得個人化推薦",
+        "primaryButton": "前往島島阿學",
         "secondaryButton": "稍後設定",
         "emailReminder": "記得到信箱收我們的歡迎信哦!"
       }


### PR DESCRIPTION
## Summary
Implements #651: 修改註冊完成頁按鈕文字並移除「稍後設定」按鈕

- 移除 `SuccessSection` 中的「稍後設定」次要按鈕及其 `handleSkip` 函式
- 更新主要按鈕文字：zh-TW → `前往島島阿學`，en → `Explore Dao Dao`
- 移除 `space-y-3` 間距類別（只剩一個按鈕）

## Test plan
- [ ] 完成註冊流程進入 Step 4 成功頁，確認只顯示一個「前往島島阿學」按鈕
- [ ] 點擊按鈕導向首頁 `/`
- [ ] 切換英文語系，確認按鈕顯示「Explore Dao Dao」

---
🤖 Auto-generated by daodao pipeline
Closes #651
