### PR TITLE
[auto] #652 修改驗證完成頁按鈕文字

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4180,7 +4180,7 @@
         }
       },
       "actions": {
-        "goToHome": "Complete Profile Settings",
+        "goToHome": "Explore Dao Dao",
         "backToHome": "Back to Home"
       },
       "resend": {

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4180,7 +4180,7 @@
         }
       },
       "actions": {
-        "goToHome": "前往完成個人設定",
+        "goToHome": "前往島島阿學",
         "backToHome": "返回首頁"
       },
       "resend": {


### PR DESCRIPTION
## Summary
Implements #652: 修改驗證完成頁按鈕文字為「前往島島阿學」

- 更新 `auth.verifyEmail.actions.goToHome` i18n 鍵值：
  - zh-TW → `前往島島阿學`
  - en → `Explore Dao Dao`

## Test plan
- [ ] 完成 Email 驗證流程進入驗證完成頁，確認按鈕顯示「前往島島阿學」
- [ ] 切換英文語系，確認按鈕顯示「Explore Dao Dao」
- [ ] 點擊按鈕確認導向首頁

---
🤖 Auto-generated by daodao pipeline
Closes #652
