### PR TITLE
fix(api): 還原 admin user-stats 路徑型別定義

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1856,6 +1856,749 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/user-stats/overview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取總覽儀表板
+         * @description 返回使用者統計的關鍵指標摘要，包括總使用者數、本月新增、增長率、活躍使用者等
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回總覽統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                /** @description 總使用者數 */
+                                totalUsers: number;
+                                /** @description 本月新增使用者數 */
+                                newUsersThisMonth: number;
+                                /** @description 上月新增使用者數 */
+                                newUsersLastMonth: number;
+                                /** @description 增長率（百分比） */
+                                growthRate: number;
+                                /** @description 活躍使用者數（最近30天） */
+                                activeUsers: number;
+                                /** @description 活躍率（百分比） */
+                                activeRate: number;
+                            };
+                            metadata: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足（需要管理員權限） */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/registrations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取註冊統計
+         * @description 根據不同維度（時間、地區、角色、教育階段）獲取使用者註冊統計資料
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description 統計分組方式（必選） */
+                    groupBy: "day" | "week" | "month" | "year" | "location" | "role" | "education_stage";
+                    /** @description 開始日期（YYYY-MM-DD） */
+                    startDate?: string;
+                    /** @description 結束日期（YYYY-MM-DD） */
+                    endDate?: string;
+                    /** @description 地區 ID 篩選 */
+                    locationId?: string;
+                    /** @description 角色 ID 篩選 */
+                    roleId?: string;
+                    /** @description 教育階段篩選 */
+                    educationStage?: string;
+                    /** @description 分頁限制（最大 1000） */
+                    limit?: string;
+                    /** @description 分頁偏移 */
+                    offset?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回註冊統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data?: unknown;
+                            metadata?: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 參數錯誤 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取活躍度統計
+         * @description 分析使用者活躍度，可選擇按角色、地區或教育階段分組
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 活躍度時間範圍（天數，最大 365） */
+                    activeWithinDays?: string;
+                    /** @description 統計分組方式 */
+                    groupBy?: "role" | "location" | "education_stage";
+                    /** @description 分頁限制（最大 1000） */
+                    limit?: string;
+                    /** @description 分頁偏移 */
+                    offset?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回活躍度統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                /** @description 活躍使用者數 */
+                                activeUsers: number;
+                                /** @description 非活躍使用者數 */
+                                inactiveUsers: number;
+                                /** @description 總使用者數 */
+                                totalUsers: number;
+                                /** @description 活躍率（百分比） */
+                                activeRate: number;
+                                /** @description 分組統計（按角色/地區/教育階段） */
+                                groups?: {
+                                    group: string;
+                                    activeUsers: number;
+                                    inactiveUsers: number;
+                                }[];
+                            };
+                            metadata: {
+                                activeWithinDays?: number;
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 參數錯誤 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 匯出統計資料
+         * @description 將統計資料匯出為 CSV 或 Excel 格式
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description 匯出格式（必選） */
+                    format: "csv" | "excel";
+                    /** @description 匯出類型（必選） */
+                    type: "registrations" | "activity" | "full";
+                    /** @description 開始日期（YYYY-MM-DD） */
+                    startDate?: string;
+                    /** @description 結束日期（YYYY-MM-DD） */
+                    endDate?: string;
+                    /** @description 統計分組方式（type=registrations 時必選） */
+                    groupBy?: "day" | "week" | "month" | "year" | "location" | "role" | "education_stage";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功匯出檔案 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/csv": string;
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": string;
+                    };
+                };
+                /** @description 參數錯誤 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/active-users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取 DAU/WAU/MAU 統計
+         * @description 返回日活躍、週活躍、月活躍用戶統計及趨勢變化
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回活躍用戶統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                /** @description 日活躍用戶數 */
+                                dau: number;
+                                /** @description 週活躍用戶數 */
+                                wau: number;
+                                /** @description 月活躍用戶數 */
+                                mau: number;
+                                /** @description DAU 佔總用戶比例 */
+                                dauRate: number;
+                                /** @description WAU 佔總用戶比例 */
+                                wauRate: number;
+                                /** @description MAU 佔總用戶比例 */
+                                mauRate: number;
+                                /** @description 總用戶數 */
+                                totalUsers: number;
+                                trend?: {
+                                    /** @description DAU 較昨日變化百分比 */
+                                    dauTrend: number;
+                                    /** @description WAU 較上週變化百分比 */
+                                    wauTrend: number;
+                                    /** @description MAU 較上月變化百分比 */
+                                    mauTrend: number;
+                                };
+                            };
+                            metadata: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/device-analytics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取裝置分析
+         * @description 分析用戶登入裝置、瀏覽器和作業系統的分佈統計
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 開始日期（YYYY-MM-DD） */
+                    startDate?: string;
+                    /** @description 結束日期（YYYY-MM-DD） */
+                    endDate?: string;
+                    /** @description 如果沒提供日期範圍，預設最近 N 天（最大 365） */
+                    days?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回裝置分析 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                devices: {
+                                    deviceType: string | null;
+                                    count: number;
+                                    percentage: number;
+                                }[];
+                                browsers: {
+                                    browser: string | null;
+                                    count: number;
+                                    percentage: number;
+                                }[];
+                                operatingSystems: {
+                                    os: string | null;
+                                    count: number;
+                                    percentage: number;
+                                }[];
+                                totalLogins: number;
+                                dateRange: {
+                                    startDate: string;
+                                    endDate: string;
+                                };
+                            };
+                            metadata: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 參數錯誤 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/retention": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取用戶留存率
+         * @description 分析用戶註冊後的留存情況，支持群組分析
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 分析的群組數量（最近 N 個群組，最大 30） */
+                    cohorts?: string;
+                    /** @description 追蹤天數（最大 90） */
+                    trackDays?: string;
+                    /** @description 群組粒度 */
+                    granularity?: "day" | "week";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回留存率統計 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                cohorts: {
+                                    cohortDate: string;
+                                    size: number;
+                                    retention: {
+                                        [key: string]: number;
+                                    };
+                                }[];
+                                averageRetention: {
+                                    day1: number;
+                                    day7: number;
+                                    day14: number;
+                                    day30: number;
+                                };
+                            };
+                            metadata: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 參數錯誤 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/popular-profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取熱門檔案排行
+         * @description 返回被瀏覽次數最多的用戶檔案排行
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 返回數量（最大 100） */
+                    limit?: string;
+                    /** @description 偏移量 */
+                    offset?: string;
+                    /** @description 最低查看次數 */
+                    minViews?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回熱門檔案排行 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                profiles: {
+                                    userId: number;
+                                    externalId: string;
+                                    nickname: string | null;
+                                    photoUrl: string | null;
+                                    profileViews: number;
+                                    lastActiveAt: string | null;
+                                }[];
+                                totalCount: number;
+                            };
+                            metadata: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 參數錯誤 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/user-stats/segmentation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 獲取用戶活躍度分類
+         * @description 將用戶按活躍程度分為高度活躍、活躍、中度活躍、不活躍、休眠五個等級
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功返回用戶活躍度分類 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            success: true;
+                            data: {
+                                segments: {
+                                    /** @enum {string} */
+                                    label: "highly_active" | "active" | "moderate" | "inactive" | "dormant";
+                                    displayName: string;
+                                    description: string;
+                                    userCount: number;
+                                    percentage: number;
+                                    criteria: string;
+                                }[];
+                                totalUsers: number;
+                                lastUpdated: string;
+                            };
+                            metadata: {
+                                generated_at: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 未授權 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 權限不足 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/user-stats/active-users/trend": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Why is this necessary?

1. 在 types.ts 中缺失了 admin user-stats 的路徑型別定義，可能導致類型檢查失敗。
2. 缺少正確的型別定義會影響開發者在使用相關 API 時的開發體驗。
3. 確保型別定義的完整性有助於提高代碼的可維護性和可讀性。

## How does it address?

1. 透過修復 commit 還原了遺失的 admin user-stats 路徑型別定義。
2. 更新了 types.ts 文件，確保所有相關型別都正確定義。
3. 進行了必要的測試以驗證型別定義的正確性和有效性。