### PR TITLE
fix(api): 補回遺失的健康檢查路徑與隱私欄位

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -7855,6 +7855,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 健康檢查
+         * @description 檢查 API 服務是否正常運行
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 服務正常運行 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            status: string;
+                            uptime: number;
+                            timestamp: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/monitor": {
         parameters: {
             query?: never;
@@ -29325,6 +29368,10 @@ export interface components {
             reactionType: string;
             /** @description 反應時間（ISO 8601） */
             reactedAt: string;
+            /** @description 該用戶是否公開帳號 */
+            isPublic: boolean;
+            /** @description 請求方是否與該用戶有 Connection 關係 */
+            isConnection: boolean;
         };
         /** @description 個別用戶反應列表回應 */
         GetReactionsListResponse: {


### PR DESCRIPTION
## Why is this necessary?

1. 健康檢查路徑 `/api/v1/health` 的缺失可能導致系統無法正確監控健康狀態。
2. 隱私欄位的缺失可能影響到用戶資料的安全性與隱私保護。
3. 確保 API 的完整性與正確性對於系統的穩定運行至關重要。

## How does it address?

1. 補回了遺失的 `/api/v1/health` 路徑，恢復健康檢查功能。
2. 修正了 `ReactionListItem` 中隱私欄位的缺失，增強用戶資料的保護。
3. 確保 API 文檔與實際實現的一致性，提升開發效率。