### PR TITLE
[auto] #679 沒有可儲存為草稿選項

### DIFF
--- a/apps/product/src/app/[locale]/practices/create/manual/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/manual/page.tsx
@@ -137,12 +137,16 @@ export default function CreateManualPracticePage() {
       router.replace("/");
       return;
     }
-    const choice = await confirmLeaveWithDraft();
-    if (shouldSaveDraftOnLeave(choice)) {
-      saveDraft();
-    }
-    if (shouldNavigateOnLeave(choice)) {
-      router.replace("/");
+    try {
+      const choice = await confirmLeaveWithDraft();
+      if (shouldSaveDraftOnLeave(choice)) {
+        saveDraft();
+      }
+      if (shouldNavigateOnLeave(choice)) {
+        router.replace("/");
+      }
+    } catch {
+      // dialog dismissed or unexpected error — stay on page
     }
   }, [form.formState.isDirty, confirmLeaveWithDraft, saveDraft, router]);
 

--- a/apps/product/src/app/[locale]/practices/create/manual/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/manual/page.tsx
@@ -143,12 +143,13 @@ export default function CreateManualPracticePage() {
         saveDraft();
       }
       if (shouldNavigateOnLeave(choice)) {
+        form.reset(form.getValues());
         router.replace("/");
       }
     } catch {
       // dialog dismissed or unexpected error — stay on page
     }
-  }, [form.formState.isDirty, confirmLeaveWithDraft, saveDraft, router]);
+  }, [form.formState.isDirty, form.reset, form.getValues, confirmLeaveWithDraft, saveDraft, router]);
 
   const name = form.watch("name");
   const actionDescription = form.watch("actionDescription");

--- a/apps/product/src/app/[locale]/practices/create/manual/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/manual/page.tsx
@@ -9,6 +9,7 @@ import { Form } from "@daodao/ui/components/form";
 import { Progress } from "@daodao/ui/components/progress";
 import { toast } from "@daodao/ui/components/sonner";
 import { useNavigationBlockerEffect } from "@daodao/ui/hooks/navigation-blocker";
+import { useLeaveWithDraftConfirm } from "@daodao/ui/hooks/use-leave-with-draft-confirm";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -28,6 +29,10 @@ import {
   parseFrequency,
 } from "@/constants/practice-form";
 import { useRestoreDraftDialog } from "@/hooks/use-restore-draft-dialog";
+import {
+  shouldNavigateOnLeave,
+  shouldSaveDraftOnLeave,
+} from "@/hooks/leave-with-draft-utils";
 import {
   applyOnboardingUpdateFromResponse,
   refreshOnboardingStatus,
@@ -108,7 +113,7 @@ export default function CreateManualPracticePage() {
   });
 
   // 使用共用 Hook 處理暫存邏輯
-  const { draft, showRestoreDialog, isCheckingDraft, restoreDraft, clearDraft } =
+  const { draft, showRestoreDialog, isCheckingDraft, restoreDraft, clearDraft, saveDraft } =
     useFormDraft<ManualPracticeFormValues>({
       storageKey: StorageEnum.ManualPracticeDraft,
       form,
@@ -124,6 +129,22 @@ export default function CreateManualPracticePage() {
       setCurrentStep(draft.currentStep);
     }
   }, [draft, restoreDraft]);
+
+  const confirmLeaveWithDraft = useLeaveWithDraftConfirm();
+
+  const handleClose = useCallback(async () => {
+    if (!form.formState.isDirty) {
+      router.replace("/");
+      return;
+    }
+    const choice = await confirmLeaveWithDraft();
+    if (shouldSaveDraftOnLeave(choice)) {
+      saveDraft();
+    }
+    if (shouldNavigateOnLeave(choice)) {
+      router.replace("/");
+    }
+  }, [form.formState.isDirty, confirmLeaveWithDraft, saveDraft, router]);
 
   const name = form.watch("name");
   const actionDescription = form.watch("actionDescription");
@@ -316,7 +337,7 @@ export default function CreateManualPracticePage() {
     <div className="relative w-screen min-h-screen z-10 overflow-hidden overflow-y-auto bg-white">
       <BackgroundAnimation />
 
-      <PageHeader title={currentStep === 5 ? t("manual_preview_title") : t("manual_create_title")} rightActionTo="/" />
+      <PageHeader title={currentStep === 5 ? t("manual_preview_title") : t("manual_create_title")} onRightAction={handleClose} />
 
       <main className="relative px-5 max-w-[448px] mx-auto pb-20">
         {/* Progress Bar */}

--- a/apps/product/src/hooks/__tests__/leave-with-draft-utils.test.ts
+++ b/apps/product/src/hooks/__tests__/leave-with-draft-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  type LeaveWithDraftChoice,
+  shouldNavigateOnLeave,
+  shouldSaveDraftOnLeave,
+} from "../leave-with-draft-utils";
+
+describe("shouldNavigateOnLeave", () => {
+  it("returns true when user chooses to save draft", () => {
+    expect(shouldNavigateOnLeave("save-draft")).toBe(true);
+  });
+
+  it("returns true when user chooses to leave without saving", () => {
+    expect(shouldNavigateOnLeave("leave")).toBe(true);
+  });
+
+  it("returns false when user chooses to continue editing", () => {
+    expect(shouldNavigateOnLeave("continue")).toBe(false);
+  });
+});
+
+describe("shouldSaveDraftOnLeave", () => {
+  it("returns true only when user explicitly chooses save-draft", () => {
+    expect(shouldSaveDraftOnLeave("save-draft")).toBe(true);
+  });
+
+  it("returns false when user leaves without saving", () => {
+    expect(shouldSaveDraftOnLeave("leave")).toBe(false);
+  });
+
+  it("returns false when user continues editing", () => {
+    expect(shouldSaveDraftOnLeave("continue")).toBe(false);
+  });
+});

--- a/apps/product/src/hooks/leave-with-draft-utils.ts
+++ b/apps/product/src/hooks/leave-with-draft-utils.ts
@@ -1,0 +1,9 @@
+export type LeaveWithDraftChoice = "save-draft" | "leave" | "continue";
+
+export function shouldNavigateOnLeave(choice: LeaveWithDraftChoice): boolean {
+  return choice === "save-draft" || choice === "leave";
+}
+
+export function shouldSaveDraftOnLeave(choice: LeaveWithDraftChoice): boolean {
+  return choice === "save-draft";
+}

--- a/apps/product/src/hooks/leave-with-draft-utils.ts
+++ b/apps/product/src/hooks/leave-with-draft-utils.ts
@@ -1,4 +1,6 @@
-export type LeaveWithDraftChoice = "save-draft" | "leave" | "continue";
+import type { LeaveWithDraftChoice } from "@daodao/ui/hooks/use-leave-with-draft-confirm";
+
+export type { LeaveWithDraftChoice };
 
 export function shouldNavigateOnLeave(choice: LeaveWithDraftChoice): boolean {
   return choice === "save-draft" || choice === "leave";

--- a/packages/ui/src/hooks/use-leave-with-draft-confirm.tsx
+++ b/packages/ui/src/hooks/use-leave-with-draft-confirm.tsx
@@ -29,7 +29,7 @@ export function useLeaveWithDraftConfirm() {
   return useCallback((): Promise<LeaveWithDraftChoice> => {
     return openWarningDialog<"continue" | "save-draft" | "leave">({
       title: "尚未儲存你的資料",
-      message: "確定要先離開這裡嗎？已經編輯的資料將無法被儲存。",
+      message: "您有尚未儲存的變更，確定要離開嗎？",
       textAlign: "left",
       buttons: [
         { label: "繼續編輯", value: "continue", variant: "outline" },

--- a/packages/ui/src/hooks/use-leave-with-draft-confirm.tsx
+++ b/packages/ui/src/hooks/use-leave-with-draft-confirm.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback } from "react";
+import { useDialog } from "./use-dialog";
+
+export type LeaveWithDraftChoice = "save-draft" | "leave" | "continue";
+
+/**
+ * Shows an unsaved-changes dialog with an explicit "Save Draft" option.
+ * Returns the user's choice as a Promise.
+ *
+ * @example
+ * ```typescript
+ * const confirmLeaveWithDraft = useLeaveWithDraftConfirm();
+ *
+ * const choice = await confirmLeaveWithDraft();
+ * if (choice === "save-draft") {
+ *   saveDraft();
+ *   router.replace("/");
+ * } else if (choice === "leave") {
+ *   router.replace("/");
+ * }
+ * // "continue" → do nothing
+ * ```
+ */
+export function useLeaveWithDraftConfirm() {
+  const { openWarningDialog } = useDialog();
+
+  return useCallback((): Promise<LeaveWithDraftChoice> => {
+    return openWarningDialog<"continue" | "save-draft" | "leave">({
+      title: "尚未儲存你的資料",
+      message: "確定要先離開這裡嗎？已經編輯的資料將無法被儲存。",
+      textAlign: "left",
+      buttons: [
+        { label: "繼續編輯", value: "continue", variant: "outline" },
+        { label: "儲存草稿", value: "save-draft", variant: "default" },
+        { label: "確定離開", value: "leave", variant: "orange" },
+      ],
+      strict: false,
+      customConfig: {
+        dismissible: false,
+        closeOnEscape: false,
+        showCloseButton: true,
+      },
+    }).then((result) => {
+      if (result.value === "save-draft") return "save-draft";
+      if (result.value === "leave") return "leave";
+      return "continue";
+    });
+  }, [openWarningDialog]);
+}


### PR DESCRIPTION
## Summary
Implements #679: 沒有可儲存為草稿選項

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes

---
🤖 Auto-generated by daodao pipeline
Closes #679

---
_Generated by [Claude Code](https://claude.ai/code/session_012mCppfJM5r1hH5SnHrfFtp)_