### PR TITLE
[auto] #685 主頁-我的 篩選鈕調整

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/mine/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/mine/page.tsx
@@ -22,12 +22,13 @@ import {
   type FilterStatus as FilterStatusType,
   mapPracticeStatusToTaskStatus,
 } from "@/constants/task-status";
+import { applyMineFilter, buildMineFilterCounts } from "@/utils/mine-filter";
 
 const filterOptions = [
+  { value: FilterStatus.inProgress, labelKey: "filter_in_progress" },
   { value: FilterStatus.all, labelKey: "filter_all" },
   { value: FilterStatus.draft, labelKey: "filter_draft" },
   { value: FilterStatus.notStarted, labelKey: "filter_not_started" },
-  { value: FilterStatus.inProgress, labelKey: "filter_in_progress" },
   { value: FilterStatus.completed, labelKey: "filter_completed" },
 ] as const;
 
@@ -64,13 +65,10 @@ export default function MyPage() {
     return { inProgressTasks: inProgressTasksData };
   }, [allPracticesData, t]);
 
-  const filteredInProgressTasks = useMemo(() => {
-    if (filterStatus === FilterStatus.completed)
-      return inProgressTasks.filter((task) => task.status === FilterStatus.completed);
-    if (filterStatus === FilterStatus.all)
-      return inProgressTasks.filter((task) => task.status !== FilterStatus.completed);
-    return inProgressTasks.filter((task) => task.status === filterStatus);
-  }, [inProgressTasks, filterStatus]);
+  const filteredInProgressTasks = useMemo(
+    () => applyMineFilter(inProgressTasks, filterStatus),
+    [inProgressTasks, filterStatus]
+  );
 
   const stats = useMemo(() => {
     const statsDataValue = statsData?.data;
@@ -92,24 +90,7 @@ export default function MyPage() {
 
   const hasPractices = inProgressTasks.length > 0;
 
-  const filterCounts = useMemo(() => {
-    const counts = {
-      [FilterStatus.all]: 0,
-      [FilterStatus.draft]: 0,
-      [FilterStatus.notStarted]: 0,
-      [FilterStatus.inProgress]: 0,
-      [FilterStatus.completed]: 0,
-    };
-    for (const task of inProgressTasks) {
-      if (task.status !== FilterStatus.completed) {
-        counts[FilterStatus.all]++;
-      }
-      if (task.status in counts) {
-        counts[task.status as keyof typeof counts]++;
-      }
-    }
-    return counts;
-  }, [inProgressTasks]);
+  const filterCounts = useMemo(() => buildMineFilterCounts(inProgressTasks), [inProgressTasks]);
 
   return (
     <div className="relative min-h-screen">

--- a/apps/product/src/utils/__tests__/mine-filter.test.ts
+++ b/apps/product/src/utils/__tests__/mine-filter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMineFilterCounts,
+  applyMineFilter,
+} from "../mine-filter";
+import { FilterStatus } from "@/constants/task-status";
+
+interface Task {
+  status: string;
+}
+
+describe("buildMineFilterCounts", () => {
+  const tasks: Task[] = [
+    { status: FilterStatus.inProgress },
+    { status: FilterStatus.inProgress },
+    { status: FilterStatus.notStarted },
+    { status: FilterStatus.draft },
+    { status: FilterStatus.completed },
+  ];
+
+  it("all count equals total number of tasks (all statuses)", () => {
+    const counts = buildMineFilterCounts(tasks);
+    expect(counts[FilterStatus.all]).toBe(5);
+  });
+
+  it("inProgress count is correct", () => {
+    const counts = buildMineFilterCounts(tasks);
+    expect(counts[FilterStatus.inProgress]).toBe(2);
+  });
+
+  it("notStarted count is correct", () => {
+    const counts = buildMineFilterCounts(tasks);
+    expect(counts[FilterStatus.notStarted]).toBe(1);
+  });
+
+  it("draft count is correct", () => {
+    const counts = buildMineFilterCounts(tasks);
+    expect(counts[FilterStatus.draft]).toBe(1);
+  });
+
+  it("completed count is correct", () => {
+    const counts = buildMineFilterCounts(tasks);
+    expect(counts[FilterStatus.completed]).toBe(1);
+  });
+
+  it("returns zero for all counts on empty input", () => {
+    const counts = buildMineFilterCounts([]);
+    expect(counts[FilterStatus.all]).toBe(0);
+    expect(counts[FilterStatus.inProgress]).toBe(0);
+    expect(counts[FilterStatus.completed]).toBe(0);
+  });
+
+  it("all count does NOT equal inProgress count when there are other statuses", () => {
+    const counts = buildMineFilterCounts(tasks);
+    expect(counts[FilterStatus.all]).not.toBe(counts[FilterStatus.inProgress]);
+  });
+});
+
+describe("applyMineFilter", () => {
+  const tasks: Task[] = [
+    { status: FilterStatus.inProgress },
+    { status: FilterStatus.notStarted },
+    { status: FilterStatus.draft },
+    { status: FilterStatus.completed },
+  ];
+
+  it("all filter returns all tasks", () => {
+    expect(applyMineFilter(tasks, FilterStatus.all)).toEqual(tasks);
+  });
+
+  it("inProgress filter returns only inProgress tasks", () => {
+    expect(applyMineFilter(tasks, FilterStatus.inProgress)).toEqual([
+      { status: FilterStatus.inProgress },
+    ]);
+  });
+
+  it("completed filter returns only completed tasks", () => {
+    expect(applyMineFilter(tasks, FilterStatus.completed)).toEqual([
+      { status: FilterStatus.completed },
+    ]);
+  });
+
+  it("draft filter returns only draft tasks", () => {
+    expect(applyMineFilter(tasks, FilterStatus.draft)).toEqual([
+      { status: FilterStatus.draft },
+    ]);
+  });
+
+  it("notStarted filter returns only notStarted tasks", () => {
+    expect(applyMineFilter(tasks, FilterStatus.notStarted)).toEqual([
+      { status: FilterStatus.notStarted },
+    ]);
+  });
+});

--- a/apps/product/src/utils/mine-filter.ts
+++ b/apps/product/src/utils/mine-filter.ts
@@ -15,8 +15,9 @@ export function buildMineFilterCounts(tasks: HasStatus[]): MineFilterCounts {
     [FilterStatus.completed]: 0,
   };
   for (const task of tasks) {
-    if (task.status in counts && task.status !== FilterStatus.all) {
-      counts[task.status as FilterStatusType]++;
+    const status = task.status as FilterStatusType;
+    if (status !== FilterStatus.all && Object.hasOwn(counts, status)) {
+      counts[status]++;
     }
   }
   return counts;

--- a/apps/product/src/utils/mine-filter.ts
+++ b/apps/product/src/utils/mine-filter.ts
@@ -1,0 +1,28 @@
+import { FilterStatus, type FilterStatus as FilterStatusType } from "@/constants/task-status";
+
+interface HasStatus {
+  status: string;
+}
+
+export type MineFilterCounts = Record<FilterStatusType, number>;
+
+export function buildMineFilterCounts(tasks: HasStatus[]): MineFilterCounts {
+  const counts: MineFilterCounts = {
+    [FilterStatus.all]: tasks.length,
+    [FilterStatus.draft]: 0,
+    [FilterStatus.notStarted]: 0,
+    [FilterStatus.inProgress]: 0,
+    [FilterStatus.completed]: 0,
+  };
+  for (const task of tasks) {
+    if (task.status in counts && task.status !== FilterStatus.all) {
+      counts[task.status as FilterStatusType]++;
+    }
+  }
+  return counts;
+}
+
+export function applyMineFilter<T extends HasStatus>(tasks: T[], status: FilterStatusType): T[] {
+  if (status === FilterStatus.all) return tasks;
+  return tasks.filter((t) => t.status === status);
+}


### PR DESCRIPTION
## Summary
Implements #685: 主頁-我的 篩選鈕調整

- `apps/product/src/utils/mine-filter.ts` (new) — testable utilities `buildMineFilterCounts` and `applyMineFilter`
- `apps/product/src/utils/__tests__/mine-filter.test.ts` (new) — 12 unit tests
- `apps/product/src/app/[locale]/(with-layout)/mine/page.tsx` — fix `全部` count (now includes all statuses), swap 進行中↔全部 button order, use utility functions

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes

---
🤖 Auto-generated by daodao pipeline
Closes #685

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCQXfSBeMoADt2v2riwKVS)_