### PR TITLE
[auto] #690 計算打卡留言的第二層留言數

### DIFF
--- a/apps/product/src/components/check-in/display/check-in-detail.tsx
+++ b/apps/product/src/components/check-in/display/check-in-detail.tsx
@@ -46,6 +46,7 @@ import { applyOnboardingUpdateFromResponse } from "@/components/task-guide/onboa
 import type { ReactionTypeType } from "@/constants/reaction-type";
 import { useEditCheckInSheet } from "@/hooks/use-edit-check-in-sheet";
 import { useShareCheckInSheet } from "@/hooks/use-share-check-in-sheet";
+import { countTotalComments } from "@/utils/count-comments";
 import { formatRelativeTime } from "@/utils/format-time";
 import type { ICheckInDisplayData, ICheckInFormData } from "../types";
 import { CheckInCard } from "./check-in-card";
@@ -365,7 +366,7 @@ export const CheckInDetail = ({
 
   const commentCount = React.useMemo(() => {
     const raw = commentsData?.data;
-    return Array.isArray(raw) ? raw.filter(isApiCommentNode).length : 0;
+    return Array.isArray(raw) ? countTotalComments(raw.filter(isApiCommentNode)) : 0;
   }, [commentsData]);
 
   const currentUser = currentUserData?.data;

--- a/apps/product/src/utils/__tests__/count-comments.test.ts
+++ b/apps/product/src/utils/__tests__/count-comments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ApiCommentNode } from "@/components/check-in/display/check-in-detail";
 import { countTotalComments } from "../count-comments";
 
 describe("countTotalComments", () => {
@@ -7,12 +8,12 @@ describe("countTotalComments", () => {
   });
 
   it("counts only first-level comments when there are no replies", () => {
-    const comments = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const comments: ApiCommentNode[] = [{ id: 1 }, { id: 2 }, { id: 3 }];
     expect(countTotalComments(comments)).toBe(3);
   });
 
   it("includes second-level (reply) comments in total", () => {
-    const comments = [
+    const comments: ApiCommentNode[] = [
       { id: 1, replies: [{ id: 10 }, { id: 11 }] },
       { id: 2, replies: [{ id: 12 }] },
     ];
@@ -20,17 +21,17 @@ describe("countTotalComments", () => {
   });
 
   it("handles comments with empty replies array", () => {
-    const comments = [{ id: 1, replies: [] }, { id: 2 }];
+    const comments: ApiCommentNode[] = [{ id: 1, replies: [] }, { id: 2 }];
     expect(countTotalComments(comments)).toBe(2);
   });
 
   it("handles comments with no replies field", () => {
-    const comments = [{ id: 1 }, { id: 2, replies: [{ id: 20 }] }];
+    const comments: ApiCommentNode[] = [{ id: 1 }, { id: 2, replies: [{ id: 20 }] }];
     expect(countTotalComments(comments)).toBe(3); // 2 top + 1 reply
   });
 
   it("handles mixed comments with and without replies", () => {
-    const comments = [
+    const comments: ApiCommentNode[] = [
       { id: 1, replies: [{ id: 10 }, { id: 11 }, { id: 12 }] },
       { id: 2 },
       { id: 3, replies: [{ id: 13 }] },

--- a/apps/product/src/utils/__tests__/count-comments.test.ts
+++ b/apps/product/src/utils/__tests__/count-comments.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { countTotalComments } from "../count-comments";
+
+describe("countTotalComments", () => {
+  it("returns 0 for empty array", () => {
+    expect(countTotalComments([])).toBe(0);
+  });
+
+  it("counts only first-level comments when there are no replies", () => {
+    const comments = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    expect(countTotalComments(comments)).toBe(3);
+  });
+
+  it("includes second-level (reply) comments in total", () => {
+    const comments = [
+      { id: 1, replies: [{ id: 10 }, { id: 11 }] },
+      { id: 2, replies: [{ id: 12 }] },
+    ];
+    expect(countTotalComments(comments)).toBe(5); // 2 top + 3 replies
+  });
+
+  it("handles comments with empty replies array", () => {
+    const comments = [{ id: 1, replies: [] }, { id: 2 }];
+    expect(countTotalComments(comments)).toBe(2);
+  });
+
+  it("handles comments with no replies field", () => {
+    const comments = [{ id: 1 }, { id: 2, replies: [{ id: 20 }] }];
+    expect(countTotalComments(comments)).toBe(3); // 2 top + 1 reply
+  });
+
+  it("handles mixed comments with and without replies", () => {
+    const comments = [
+      { id: 1, replies: [{ id: 10 }, { id: 11 }, { id: 12 }] },
+      { id: 2 },
+      { id: 3, replies: [{ id: 13 }] },
+    ];
+    expect(countTotalComments(comments)).toBe(7); // 3 top + 3 + 0 + 1 replies
+  });
+});

--- a/apps/product/src/utils/count-comments.ts
+++ b/apps/product/src/utils/count-comments.ts
@@ -1,0 +1,17 @@
+interface CommentLike {
+  id: number | string;
+  replies?: unknown[];
+}
+
+function isCommentLike(v: unknown): v is CommentLike {
+  return typeof v === "object" && v !== null && "id" in v;
+}
+
+export function countTotalComments(comments: CommentLike[]): number {
+  return comments.reduce((total, comment) => {
+    const replies = Array.isArray(comment.replies)
+      ? comment.replies.filter(isCommentLike).length
+      : 0;
+    return total + 1 + replies;
+  }, 0);
+}

--- a/apps/product/src/utils/count-comments.ts
+++ b/apps/product/src/utils/count-comments.ts
@@ -1,18 +1,14 @@
-interface CommentLike {
-  id: number | string;
-  replies?: unknown[];
-}
+import {
+  type ApiCommentNode,
+  isApiCommentNode,
+} from "@/components/check-in/display/check-in-detail";
 
-function isCommentLike(v: unknown): v is CommentLike {
-  return typeof v === "object" && v !== null && "id" in v;
-}
-
-export function countTotalComments(comments: CommentLike[]): number {
+export function countTotalComments(comments: ApiCommentNode[]): number {
   return comments.reduce((total, comment) => {
     let replyCount = 0;
     if (Array.isArray(comment.replies)) {
       for (const reply of comment.replies) {
-        if (isCommentLike(reply)) {
+        if (isApiCommentNode(reply)) {
           replyCount++;
         }
       }

--- a/apps/product/src/utils/count-comments.ts
+++ b/apps/product/src/utils/count-comments.ts
@@ -9,9 +9,14 @@ function isCommentLike(v: unknown): v is CommentLike {
 
 export function countTotalComments(comments: CommentLike[]): number {
   return comments.reduce((total, comment) => {
-    const replies = Array.isArray(comment.replies)
-      ? comment.replies.filter(isCommentLike).length
-      : 0;
-    return total + 1 + replies;
+    let replyCount = 0;
+    if (Array.isArray(comment.replies)) {
+      for (const reply of comment.replies) {
+        if (isCommentLike(reply)) {
+          replyCount++;
+        }
+      }
+    }
+    return total + 1 + replyCount;
   }, 0);
 }


### PR DESCRIPTION
## Summary
Implements #690: 計算打卡留言的第二層留言數

- `apps/product/src/utils/count-comments.ts` (new) — `countTotalComments` utility that sums first-level + second-level reply counts
- `apps/product/src/utils/__tests__/count-comments.test.ts` (new) — 6 unit tests
- `apps/product/src/components/check-in/display/check-in-detail.tsx` — use `countTotalComments` so the comment badge reflects the full thread depth

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes

---
🤖 Auto-generated by daodao pipeline
Closes #690

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCQXfSBeMoADt2v2riwKVS)_