### PR TITLE
[auto] #709 Email 內連結無效（接受連結）

### DIFF
--- a/apps/product/src/app/[locale]/connections/page.tsx
+++ b/apps/product/src/app/[locale]/connections/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "@daodao/i18n/navigation";
+import type { Locale } from "@daodao/i18n/routing";
+import { getConnectionsRedirectPath } from "@/utils/connection-redirect";
+
+type Props = {
+  params: Promise<{ locale: Locale }>;
+};
+
+export default async function ConnectionsRedirectPage({ params }: Props) {
+  const { locale } = await params;
+  redirect({ href: getConnectionsRedirectPath(), locale });
+}

--- a/apps/product/src/app/[locale]/connections/page.tsx
+++ b/apps/product/src/app/[locale]/connections/page.tsx
@@ -4,9 +4,12 @@ import { getConnectionsRedirectPath } from "@/utils/connection-redirect";
 
 type Props = {
   params: Promise<{ locale: Locale }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function ConnectionsRedirectPage({ params }: Props) {
-  const { locale } = await params;
-  redirect({ href: getConnectionsRedirectPath(), locale });
+export default async function ConnectionsRedirectPage({ params, searchParams }: Props) {
+  const [{ locale }, sParams] = await Promise.all([params, searchParams]);
+  const search = new URLSearchParams(sParams as Record<string, string>).toString();
+  const href = search ? `${getConnectionsRedirectPath()}?${search}` : getConnectionsRedirectPath();
+  redirect({ href, locale });
 }

--- a/apps/product/src/utils/__tests__/connection-redirect.test.ts
+++ b/apps/product/src/utils/__tests__/connection-redirect.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { getConnectionsRedirectPath } from "../connection-redirect";
+
+describe("getConnectionsRedirectPath", () => {
+  it("returns the settings connections path", () => {
+    expect(getConnectionsRedirectPath()).toBe("/settings/connections");
+  });
+});

--- a/apps/product/src/utils/connection-redirect.ts
+++ b/apps/product/src/utils/connection-redirect.ts
@@ -1,0 +1,3 @@
+export function getConnectionsRedirectPath() {
+  return "/settings/connections";
+}


### PR DESCRIPTION
## Summary
Implements #709: Email 內連結無效（接受連結）

- `apps/product/src/app/[locale]/connections/page.tsx` (new) — redirect page that redirects `/connections` to `/settings/connections` using locale-aware navigation
- `apps/product/src/utils/connection-redirect.ts` (new) — pure utility returning the redirect target path
- `apps/product/src/utils/__tests__/connection-redirect.test.ts` (new) — unit test for redirect path

Connection emails send links with `/connections` path but the actual page is at `/[locale]/settings/connections`. This redirect page handles the locale-aware redirect so email links work correctly.

Also fixes #705 (Email 內連結無效（請求連結）) — same root cause, same fix.

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes

---
🤖 Auto-generated by daodao pipeline
Closes #709
Closes #705

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1SWF51Ytv4rDGHyeY7j6Q)_