### PR TITLE
fix(page-header): 修正手機版關閉按鈕與語言切換圖示重疊問題  

### DIFF
--- a/apps/product/src/components/layout/page-header.tsx
+++ b/apps/product/src/components/layout/page-header.tsx
@@ -112,7 +112,7 @@ export const PageHeader = ({
       </div>
 
       {/* Right Action */}
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-end pr-10 md:pr-0">
         {rightAction !== null && (
           <Button
             variant="ghost"


### PR DESCRIPTION
---  
## Why is this necessary?  
- 手機版介面中，關閉按鈕與語言切換圖示重疊，影響使用者體驗。  
- 使用者無法清楚辨識按鈕功能，可能導致操作困難。  
- 確保所有按鈕和圖示在手機版上正常顯示是提升介面友好度的必要步驟。  

## How does it address?  
- 調整了關閉按鈕和語言切換圖示的位置，避免重疊。  
- 測試了不同尺寸的手機，確保在各種情況下都能正常顯示。  
- 更新了相關樣式，以提升整體介面的可用性和美觀度。  