### PR TITLE
fix(auth): 限制 TaskGuide 顯示範圍並補齊公開頁面登入檢查  

### DIFF
--- a/apps/product/src/components/check-in/reactions/comment-section.tsx
+++ b/apps/product/src/components/check-in/reactions/comment-section.tsx
@@ -2,10 +2,12 @@
 
 import type { ReactionTypeValue } from "@daodao/api";
 import { removeReaction, upsertReaction, useReactions } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
 import { DialogOutlineSvg } from "@daodao/assets";
 import type { MentionCandidate } from "@daodao/features-mention";
 import { MentionInput, useMentionInput } from "@daodao/features-mention";
 import { useTranslations } from "@daodao/i18n";
+import { usePathname, useRouter } from "@daodao/i18n/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
 import { Button } from "@daodao/ui/components/button";
 import { CustomLink } from "@daodao/ui/components/custom-link";
@@ -135,6 +137,7 @@ interface CommentBubbleProps {
   onEdit?: (id: string, content: string, mentionedUserIds?: number[]) => Promise<unknown> | unknown;
   onDelete?: (id: string) => Promise<unknown> | unknown;
   participants: MentionCandidate[];
+  onAuthRequired?: () => boolean;
 }
 
 function CommentBubble({
@@ -145,6 +148,7 @@ function CommentBubble({
   onEdit,
   onDelete,
   participants,
+  onAuthRequired,
 }: CommentBubbleProps) {
   const t = useTranslations("app_product");
   const [menuOpen, setMenuOpen] = useState(false);
@@ -187,6 +191,7 @@ function CommentBubble({
 
   const handleCommentReactionToggle = useCallback(
     (type: ReactionTypeType) => {
+      if (onAuthRequired && !onAuthRequired()) return;
       const isSelected = currentUserReaction === type;
       setPendingReaction(isSelected ? null : type);
       startReactionTransition(async () => {
@@ -203,7 +208,7 @@ function CommentBubble({
         setPendingReaction(undefined);
       });
     },
-    [currentUserReaction, comment.id, mutateReactions]
+    [onAuthRequired, currentUserReaction, comment.id, mutateReactions]
   );
   const { openWarningDialog } = useDialog();
 
@@ -473,6 +478,16 @@ export function CommentSection({
   onDeleteComment,
 }: CommentSectionProps) {
   const t = useTranslations("app_product");
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+  const requireAuth = useCallback(() => {
+    if (!isAuthenticated) {
+      router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+      return false;
+    }
+    return true;
+  }, [isAuthenticated, router, pathname]);
   const [inputValue, setInputValue] = useState("");
   const [replyTo, setReplyTo] = useState<string | null>(null);
   const [replyInputs, setReplyInputs] = useState<Record<string, string>>({});
@@ -547,6 +562,7 @@ export function CommentSection({
   }, [selectedReactions]);
 
   const handleSubmit = () => {
+    if (!requireAuth()) return;
     const trimmed = inputValue.trim();
     if (!trimmed) return;
 
@@ -565,6 +581,7 @@ export function CommentSection({
   };
 
   const handleReplySubmit = (parentId: string) => {
+    if (!requireAuth()) return;
     const replyValue = replyInputs[parentId] ?? "";
     const trimmed = replyValue.trim();
     if (!trimmed) return;
@@ -600,6 +617,7 @@ export function CommentSection({
         onEdit={onEditComment}
         onDelete={onDeleteComment}
         participants={participants}
+        onAuthRequired={requireAuth}
       />
       {/* Replies */}
       {comment.replies?.map((reply) => (
@@ -614,6 +632,7 @@ export function CommentSection({
             onEdit={onEditComment}
             onDelete={onDeleteComment}
             participants={participants}
+            onAuthRequired={requireAuth}
           />
         </div>
       ))}

--- a/apps/product/src/components/check-in/reactions/comment-section.tsx
+++ b/apps/product/src/components/check-in/reactions/comment-section.tsx
@@ -483,7 +483,9 @@ export function CommentSection({
   const pathname = usePathname();
   const requireAuth = useCallback(() => {
     if (!isAuthenticated) {
-      router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+      const search = typeof window !== "undefined" ? window.location.search : "";
+      const redirectUrl = search ? `${pathname}${search}` : pathname;
+      router.push(`/auth/login?redirect=${encodeURIComponent(redirectUrl)}`);
       return false;
     }
     return true;

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -379,6 +379,10 @@ export function PracticeDetailShell({
 
   const handleHeaderReactionToggle = useCallback(
     (type: ReactionTypeType) => {
+      if (!currentUserId) {
+        router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+        return;
+      }
       const isSelected = currentUserReaction === type;
       // Optimistic update: reflect change immediately before API resolves
       setPendingReaction(isSelected ? null : type);
@@ -396,7 +400,7 @@ export function PracticeDetailShell({
         setPendingReaction(undefined);
       });
     },
-    [currentUserReaction, practiceId, mutateReactions]
+    [currentUserId, router, pathname, currentUserReaction, practiceId, mutateReactions]
   );
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { openWarningDialog } = useDialog();
@@ -423,6 +427,10 @@ export function PracticeDetailShell({
   };
 
   const handleToggleFollowPractice = async () => {
+    if (!currentUserId) {
+      router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+      return;
+    }
     const wasFollowing = isFollowingPractice;
     setIsFollowingPractice(!wasFollowing);
     try {

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -380,7 +380,9 @@ export function PracticeDetailShell({
   const handleHeaderReactionToggle = useCallback(
     (type: ReactionTypeType) => {
       if (!currentUserId) {
-        router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+        const queryString = searchParams.toString();
+        const redirectUrl = queryString ? `${pathname}?${queryString}` : pathname;
+        router.push(`/auth/login?redirect=${encodeURIComponent(redirectUrl)}`);
         return;
       }
       const isSelected = currentUserReaction === type;
@@ -400,7 +402,7 @@ export function PracticeDetailShell({
         setPendingReaction(undefined);
       });
     },
-    [currentUserId, router, pathname, currentUserReaction, practiceId, mutateReactions]
+    [currentUserId, router, pathname, searchParams, currentUserReaction, practiceId, mutateReactions]
   );
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { openWarningDialog } = useDialog();
@@ -428,7 +430,9 @@ export function PracticeDetailShell({
 
   const handleToggleFollowPractice = async () => {
     if (!currentUserId) {
-      router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+      const queryString = searchParams.toString();
+      const redirectUrl = queryString ? `${pathname}?${queryString}` : pathname;
+      router.push(`/auth/login?redirect=${encodeURIComponent(redirectUrl)}`);
       return;
     }
     const wasFollowing = isFollowingPractice;

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -14,8 +14,9 @@ import {
   FlagOutlineSvg,
   TelescopeSvg,
 } from "@daodao/assets";
+import { useAuth } from "@daodao/auth";
 import { useLocale, useTranslations } from "@daodao/i18n";
-import { Link, useRouter } from "@daodao/i18n/navigation";
+import { Link, usePathname, useRouter } from "@daodao/i18n/navigation";
 import { useSheetManager } from "@daodao/ui/components/animate-ui/components/radix/sheet";
 import { Avatar, AvatarFallback, AvatarImage } from "@daodao/ui/components/avatar";
 import { Badge } from "@daodao/ui/components/badge";
@@ -91,7 +92,9 @@ export function PracticeShowcaseCard({
   const [menuOpen, setMenuOpen] = useState(false);
   const [isFollowing, setIsFollowing] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { isAuthenticated } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { data: practiceData } = usePracticeById(id);
   const { data: commentsData } = useComments({ targetType: "practice", targetId: id });
@@ -112,6 +115,10 @@ export function PracticeShowcaseCard({
   }, [menuOpen]);
 
   const handleToggleFollow = async () => {
+    if (!isAuthenticated) {
+      router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+      return;
+    }
     const wasFollowing = isFollowing;
     setIsFollowing(!wasFollowing);
     try {

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -116,7 +116,9 @@ export function PracticeShowcaseCard({
 
   const handleToggleFollow = async () => {
     if (!isAuthenticated) {
-      router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+      const search = typeof window !== "undefined" ? window.location.search : "";
+      const redirectUrl = search ? `${pathname}${search}` : pathname;
+      router.push(`/auth/login?redirect=${encodeURIComponent(redirectUrl)}`);
       return;
     }
     const wasFollowing = isFollowing;

--- a/apps/product/src/components/task-guide/task-guide-widget.tsx
+++ b/apps/product/src/components/task-guide/task-guide-widget.tsx
@@ -96,9 +96,7 @@ export function TaskGuideWidget() {
   const strippedPath = pathname?.replace(/^\/[a-z]{2}(-[a-zA-Z]{2})?(?=\/|$)/, "") || "/";
   const isAllowedPage =
     strippedPath === "/" ||
-    strippedPath.startsWith("/notifications") ||
-    strippedPath.startsWith("/mine") ||
-    strippedPath.startsWith("/settings");
+    /^\/(notifications|mine|settings)(\/|$)/.test(strippedPath);
 
   // Gating：未登入 / isTemporary / 非白名單頁面 → 不顯示
   if (!isAuthenticated || isTemporary || !isAllowedPage) return null;

--- a/apps/product/src/components/task-guide/task-guide-widget.tsx
+++ b/apps/product/src/components/task-guide/task-guide-widget.tsx
@@ -93,10 +93,15 @@ export function TaskGuideWidget() {
     sessionStorage.setItem(SESSION_KEY, "1");
   }, []);
 
-  const isOnboarding = pathname?.replace(/^\/[a-z]{2}(-[a-zA-Z]{2})?(?=\/|$)/, "").startsWith("/auth/onboarding");
+  const strippedPath = pathname?.replace(/^\/[a-z]{2}(-[a-zA-Z]{2})?(?=\/|$)/, "") || "/";
+  const isAllowedPage =
+    strippedPath === "/" ||
+    strippedPath.startsWith("/notifications") ||
+    strippedPath.startsWith("/mine") ||
+    strippedPath.startsWith("/settings");
 
-  // Gating：未登入 / isTemporary / onboarding 頁面 → 不顯示
-  if (!isAuthenticated || isTemporary || isOnboarding) return null;
+  // Gating：未登入 / isTemporary / 非白名單頁面 → 不顯示
+  if (!isAuthenticated || isTemporary || !isAllowedPage) return null;
   if (isLoading || taskList.length === 0) return null;
 
   const total = taskList.length;

--- a/apps/product/src/hooks/use-card-reactions.ts
+++ b/apps/product/src/hooks/use-card-reactions.ts
@@ -7,6 +7,8 @@ import type {
   ReactionTypeValue,
 } from "@daodao/api";
 import { removeReaction, upsertReaction, useReactions, useReactionsList } from "@daodao/api";
+import { useAuth } from "@daodao/auth";
+import { usePathname, useRouter } from "@daodao/i18n/navigation";
 import { useCallback, useTransition } from "react";
 import type { ReactionTypeType } from "@/constants/reaction-type";
 
@@ -26,6 +28,9 @@ export function useCardReactions(
     { targetType, targetId },
     { enabled: shouldFetchIndividual }
   );
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
   const [, startTransition] = useTransition();
 
   const source = prefetchedData ?? reactionsData?.data;
@@ -44,6 +49,10 @@ export function useCardReactions(
 
   const handleToggle = useCallback(
     (type: ReactionTypeType) => {
+      if (!isAuthenticated) {
+        router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+        return;
+      }
       const isSelected = currentUserReaction === type;
       startTransition(async () => {
         if (isSelected) {
@@ -59,7 +68,7 @@ export function useCardReactions(
         onMutate?.();
       });
     },
-    [currentUserReaction, targetType, targetId, mutate, onMutate]
+    [isAuthenticated, router, pathname, currentUserReaction, targetType, targetId, mutate, onMutate]
   );
 
   return {

--- a/apps/product/src/hooks/use-card-reactions.ts
+++ b/apps/product/src/hooks/use-card-reactions.ts
@@ -50,7 +50,9 @@ export function useCardReactions(
   const handleToggle = useCallback(
     (type: ReactionTypeType) => {
       if (!isAuthenticated) {
-        router.push(`/auth/login?redirect=${encodeURIComponent(pathname)}`);
+        const search = typeof window !== "undefined" ? window.location.search : "";
+        const redirectUrl = search ? `${pathname}${search}` : pathname;
+        router.push(`/auth/login?redirect=${encodeURIComponent(redirectUrl)}`);
         return;
       }
       const isSelected = currentUserReaction === type;


### PR DESCRIPTION
---  
## Why is this necessary?  
- 為了提高 TaskGuide 的安全性，需限制其顯示範圍。  
- 需要確保公開頁面在未登入的情況下不顯示敏感資訊。  
- 增強用戶體驗，避免未授權用戶訪問不應該看到的內容。  

## How does it address?  
- 針對 TaskGuide 的顯示範圍進行了限制，確保只有授權用戶可以訪問。  
- 在公開頁面中加入登入檢查，防止未登入用戶的訪問。  
- 透過這些改動，提升了系統的整體安全性和穩定性。  