### PR TITLE
fix(persona): 修正 flip card 選擇題選項與送出按鈕重疊

### DIFF
--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -76,22 +76,13 @@ function InlineFlipCard({
   const tProfile = useTranslations("persona.myProfile");
   const [answer, setAnswer] = useState("");
   const [selected, setSelected] = useState("");
-  const [extraMinHeight, setExtraMinHeight] = useState(0);
-  const backRef = useRef<HTMLDivElement>(null);
 
   const isChoice = questionType === "choice" && options && options.length > 0;
-
-  useEffect(() => {
-    const el = backRef.current;
-    if (!el) return;
-    const contentHeight = el.scrollHeight;
-    setExtraMinHeight((prev) => Math.max(prev, contentHeight));
-  }, [isChoice, options?.length]);
 
   return (
     <div style={{ perspective: "1000px" }} className="w-full mb-4">
       <div
-        className="relative w-full transition-transform duration-500 ease-in-out"
+        className="grid w-full transition-transform duration-500 ease-in-out"
         style={{
           transformStyle: "preserve-3d",
           transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
@@ -101,8 +92,8 @@ function InlineFlipCard({
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: card flip */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: card flip */}
         <div
-          className="group w-full bg-white rounded-2xl px-5 pt-5 pb-5 shadow-sm hover:shadow-md hover:ring-2 hover:ring-logo-cyan transition-all duration-200 flex flex-col cursor-pointer select-none"
-          style={{ backfaceVisibility: "hidden", minHeight: extraMinHeight || undefined }}
+          className="group w-full bg-white rounded-2xl px-5 pt-5 pb-5 shadow-sm hover:shadow-md hover:ring-2 hover:ring-logo-cyan transition-all duration-200 flex flex-col cursor-pointer select-none [grid-area:1/1]"
+          style={{ backfaceVisibility: "hidden" }}
           onClick={() => onFlippedChange(true)}
         >
           <QuoteSvg className="mt-1 mb-3 self-center shrink-0" />
@@ -138,8 +129,7 @@ function InlineFlipCard({
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: card flip */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: card flip */}
         <div
-          ref={backRef}
-          className="absolute inset-0 bg-white rounded-2xl px-6 pt-5 pb-6 shadow-sm border border-[#E8F8FF] flex flex-col cursor-pointer"
+          className="bg-white rounded-2xl px-6 pt-5 pb-6 shadow-sm border border-[#E8F8FF] flex flex-col cursor-pointer [grid-area:1/1]"
           style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
           onClick={() => onFlippedChange(false)}
         >
@@ -183,8 +173,6 @@ function InlineFlipCard({
                   setAnswer(e.target.value);
                   e.target.style.height = "auto";
                   e.target.style.height = `${e.target.scrollHeight}px`;
-                  const newHeight = e.target.scrollHeight + 160;
-                  if (newHeight > 280) setExtraMinHeight(newHeight);
                 }}
                 placeholder={t("thoughtPlaceholder")}
                 className="w-full border-0 border-b-2 border-logo-cyan text-base text-text-dark outline-none bg-transparent placeholder:text-text-dark/25 pb-1 resize-none overflow-hidden"


### PR DESCRIPTION
## Summary
- persona 詳情頁的 flip card 選擇題選項多時，Submit 按鈕會與選項重疊
- 將 flip card 容器從 `absolute inset-0` 改為 CSS grid stacking (`[grid-area:1/1]`)，容器自動取兩張卡片最大高度
- 移除無效的 `extraMinHeight` / `backRef` / `useEffect` 高度測量邏輯

## Test plan
- [ ] 開啟 `/persona/8`（選擇題），確認選項與 Submit 按鈕不重疊
- [ ] 開啟其他 persona 題目（文字題），確認 textarea 模式正常
- [ ] 翻轉卡片動畫正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)