### PR TITLE
feat(check-in): 調整打卡流程，新增標籤與心情選擇功能  

### DIFF
--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -528,7 +528,9 @@ export default function LearningPersonaDetailPage() {
 
   // Question + answers state
   const [questionPrompt, setQuestionPrompt] = useState("");
-  const [questionType, setQuestionType] = useState<"choice" | "sentence_completion" | "scenario">("sentence_completion");
+  const [questionType, setQuestionType] = useState<"choice" | "sentence_completion" | "scenario">(
+    "sentence_completion"
+  );
   const [questionOptions, setQuestionOptions] = useState<string[] | null>(null);
   const [totalCount, setTotalCount] = useState<number | null>(null);
   const [answers, setAnswers] = useState<PersonaQuestionAnswerItem[]>([]);

--- a/apps/product/src/components/check-in/form/check-in-sheet.tsx
+++ b/apps/product/src/components/check-in/form/check-in-sheet.tsx
@@ -21,7 +21,11 @@ import { ReflectionQuestion } from "./components/reflection-question";
 import { TagSelector } from "./components/tag-selector";
 import { useCheckInStatus } from "./hooks/use-check-in-status";
 import { useCheckInSubmit } from "./hooks/use-check-in-submit";
-import { type CheckInFormValuesType, createCheckInFormSchema } from "./schema";
+import {
+  type CheckInFormValuesType,
+  createCheckInFormSchema,
+  createCheckInPhase2Schema,
+} from "./schema";
 
 export type { ICheckInFormData as CheckInData, ICheckInStatusOptions as CheckInStatusOptions };
 export type { CheckInStatusType as CheckInStatus } from "@/constants/check-in-status";
@@ -39,6 +43,8 @@ interface ICheckInSheetContentProps {
   existingImages?: string[];
   /** 提交按鈕文字 */
   submitButtonText?: string;
+  /** 是否顯示心情選擇（編輯模式用） */
+  showMood?: boolean;
 }
 
 export const CheckInSheetContent = ({
@@ -47,6 +53,7 @@ export const CheckInSheetContent = ({
   initialValues,
   existingImages,
   submitButtonText,
+  showMood = false,
 }: ICheckInSheetContentProps) => {
   const t = useTranslations("check_in");
   const resolvedSubmitButtonText = submitButtonText ?? t("submit_check_in");
@@ -88,22 +95,20 @@ export const CheckInSheetContent = ({
           {taskTitle}
         </h2>
 
-        {/* Mood Selection */}
-        <MoodSelector form={form} />
+        {/* Mood Selection (edit mode only) */}
+        {showMood && <MoodSelector form={form} />}
 
         {/* Thought Sharing (tags, description, media) */}
-        {initialValues && (
-          <div className="mb-8">
-            <h3 className="text-base font-medium mb-3 text-text-dark">{t("thought_sharing")}</h3>
-            <TagSelector form={form} />
-            <DescriptionField form={form} beforeTextarea={<ReflectionQuestion />} />
-            <MediaUploadField
-              form={form}
-              existingImages={existingImages}
-              onExistingImagesChange={setKeptExistingImages}
-            />
-          </div>
-        )}
+        <div className="mb-8">
+          <h3 className="text-base font-medium mb-3 text-text-dark">{t("thought_sharing")}</h3>
+          <TagSelector form={form} />
+          <DescriptionField form={form} beforeTextarea={<ReflectionQuestion />} />
+          <MediaUploadField
+            form={form}
+            existingImages={existingImages}
+            onExistingImagesChange={setKeptExistingImages}
+          />
+        </div>
 
         {/* Complete Button */}
         <div className="sticky bottom-0 left-0 right-0 border-t border-light-gray bg-white p-6 -mx-6 -mb-6">
@@ -256,28 +261,22 @@ export const CheckInButton = ({
 
 interface ICheckInPhase2SheetContentProps {
   taskTitle: string;
-  /** Phase 1 選擇的心情（用於渲染卡片圖） */
-  mood: ICheckInFormData["mood"];
   onComplete: (data: ICheckInFormData) => Promise<void> | void;
-  /** API 無資料時的備用標籤列表（例如 mock 環境） */
-  suggestedTags?: string[];
 }
 
 /**
  * 打卡第二階段表單
- * 讓使用者在快速打卡（心情）完成後，進一步填寫標籤、心得描述與照片
+ * 讓使用者在打卡（標籤、心得）完成後，進一步選擇心情
  */
 export const CheckInPhase2SheetContent = ({
   taskTitle,
-  mood,
   onComplete,
-  suggestedTags,
 }: ICheckInPhase2SheetContentProps) => {
   const t = useTranslations("check_in");
   const form = useForm<CheckInFormValuesType>({
-    resolver: zodResolver(createCheckInFormSchema(t)),
+    resolver: zodResolver(createCheckInPhase2Schema(t)),
     defaultValues: {
-      mood,
+      mood: null,
       tags: [],
       description: "",
       media: [],
@@ -309,15 +308,8 @@ export const CheckInPhase2SheetContent = ({
           {taskTitle}
         </h2>
 
-        {/* Thought Sharing */}
-        <div className="mb-8">
-          <h3 className="text-base font-medium mb-3 text-text-dark">{t("thought_sharing")}</h3>
-          <TagSelector form={form} fallbackTags={suggestedTags} />
-          <DescriptionField form={form} beforeTextarea={<ReflectionQuestion />} />
-        </div>
-
-        {/* Media Upload */}
-        <MediaUploadField form={form} />
+        {/* Mood Selection */}
+        <MoodSelector form={form} />
 
         {/* Submit Button */}
         <div className="sticky bottom-0 left-0 right-0 border-t border-light-gray bg-white p-6 -mx-6 -mb-6">

--- a/apps/product/src/components/check-in/form/hooks/use-check-in-submit.ts
+++ b/apps/product/src/components/check-in/form/hooks/use-check-in-submit.ts
@@ -14,8 +14,8 @@ interface UseCheckInSubmitOptions {
   taskTitle: string;
   progressPercentage?: number;
   onComplete?: (data: ICheckInFormData) => void;
-  /** Phase 2 回調：打卡成功後使用者選擇「繼續分享心得」時呼叫，帶入打卡記錄 ID 和心情 */
-  onOpenPhase2?: (checkInId: string, mood: ICheckInFormData["mood"]) => void;
+  /** Phase 2 回調：打卡成功後使用者選擇「繼續選擇心情」時呼叫，帶入打卡記錄 ID */
+  onOpenPhase2?: (checkInId: string) => void;
 }
 
 /**
@@ -86,8 +86,8 @@ export const useCheckInSubmit = ({
       const result = await openSuccessDialog(from, to, encouragement);
 
       if (result.value === "share" && checkInId && onOpenPhase2) {
-        // 使用者選擇繼續分享心得，開啟 Phase 2 Sheet
-        onOpenPhase2(checkInId, data.mood);
+        // 使用者選擇繼續選擇心情，開啟 Phase 2 Sheet
+        onOpenPhase2(checkInId);
       } else if (result.value === "complete") {
         // 成功對話框關閉後，執行原本的完成回調
         onComplete?.(data);

--- a/apps/product/src/components/check-in/form/schema.ts
+++ b/apps/product/src/components/check-in/form/schema.ts
@@ -6,9 +6,35 @@ import type { ICheckInFormData } from "../types";
 type TFunction = ReturnType<typeof useTranslations<"check_in">>;
 
 /**
- * 打卡表單驗證 schema
+ * 打卡表單驗證 schema（Phase 1：標籤、描述、媒體）
  */
 export const createCheckInFormSchema = (t?: TFunction) => {
+  const msg = (key: string, params?: Record<string, string | number>) => {
+    if (t) return t(key as Parameters<TFunction>[0], params as never);
+    return key;
+  };
+
+  return z.object({
+    mood: z
+      .enum(MOOD_OPTIONS.map((option) => option.id) as [MoodType, ...MoodType[]])
+      .nullable()
+      .default(null),
+    tags: z.array(z.string()).min(1, msg("validation_tags_required")).default([]),
+    description: z
+      .string()
+      .max(300, msg("validation_description_max", { max: 300 }))
+      .default(""),
+    media: z
+      .array(z.instanceof(File))
+      .max(3, msg("validation_media_max", { max: 3 }))
+      .default([]),
+  });
+};
+
+/**
+ * 打卡 Phase 2 驗證 schema（心情選擇）
+ */
+export const createCheckInPhase2Schema = (t?: TFunction) => {
   const msg = (key: string, params?: Record<string, string | number>) => {
     if (t) return t(key as Parameters<TFunction>[0], params as never);
     return key;
@@ -21,14 +47,8 @@ export const createCheckInFormSchema = (t?: TFunction) => {
       .default(null)
       .refine((val) => val !== null, { message: msg("validation_mood_required") }),
     tags: z.array(z.string()).default([]),
-    description: z
-      .string()
-      .max(300, msg("validation_description_max", { max: 300 }))
-      .default(""),
-    media: z
-      .array(z.instanceof(File))
-      .max(3, msg("validation_media_max", { max: 3 }))
-      .default([]),
+    description: z.string().default(""),
+    media: z.array(z.instanceof(File)).default([]),
   });
 };
 

--- a/apps/product/src/components/check-in/reactions/comment-section.tsx
+++ b/apps/product/src/components/check-in/reactions/comment-section.tsx
@@ -2,8 +2,8 @@
 
 import type { ReactionTypeValue } from "@daodao/api";
 import { removeReaction, upsertReaction, useReactions } from "@daodao/api";
-import { useAuth } from "@daodao/auth";
 import { DialogOutlineSvg } from "@daodao/assets";
+import { useAuth } from "@daodao/auth";
 import type { MentionCandidate } from "@daodao/features-mention";
 import { MentionInput, useMentionInput } from "@daodao/features-mention";
 import { useTranslations } from "@daodao/i18n";

--- a/apps/product/src/components/layout/sidebar/desktop.tsx
+++ b/apps/product/src/components/layout/sidebar/desktop.tsx
@@ -13,7 +13,6 @@ import { NotificationBell } from "@/components/notifications/notification-bell";
 import { menuItems } from "./constant";
 import type { SidebarProps } from "./type";
 
-
 export const DesktopSidebar = ({ identifier }: SidebarProps) => {
   const pathname = usePathname();
   const t = useTranslations("app_product");
@@ -114,7 +113,6 @@ export const DesktopSidebar = ({ identifier }: SidebarProps) => {
           );
         })}
       </ul>
-
     </nav>
   );
 };

--- a/apps/product/src/components/layout/sidebar/mobile.tsx
+++ b/apps/product/src/components/layout/sidebar/mobile.tsx
@@ -15,7 +15,6 @@ import type { SidebarProps } from "./type";
 
 gsap.registerPlugin(ScrollTrigger);
 
-
 export const MobileSidebar = ({ identifier }: SidebarProps) => {
   const pathname = usePathname();
   const t = useTranslations("app_product");

--- a/apps/product/src/components/practice/detail/practice-detail-shell.tsx
+++ b/apps/product/src/components/practice/detail/practice-detail-shell.tsx
@@ -402,7 +402,15 @@ export function PracticeDetailShell({
         setPendingReaction(undefined);
       });
     },
-    [currentUserId, router, pathname, searchParams, currentUserReaction, practiceId, mutateReactions]
+    [
+      currentUserId,
+      router,
+      pathname,
+      searchParams,
+      currentUserReaction,
+      practiceId,
+      mutateReactions,
+    ]
   );
   const { open: openSheet, close: closeSheet } = useSheetManager();
   const { openWarningDialog } = useDialog();

--- a/apps/product/src/components/practice/list/practice-section.tsx
+++ b/apps/product/src/components/practice/list/practice-section.tsx
@@ -13,9 +13,9 @@ import { cn } from "@daodao/ui/lib/utils";
 import type { ElementType } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import type { PracticeStatus } from "@/constants/practice-status";
 import { PersonaProfileMe } from "@/components/persona/persona-profile-me";
 import { PersonaProfileUser } from "@/components/persona/persona-profile-user";
+import type { PracticeStatus } from "@/constants/practice-status";
 import {
   mapPracticeStatusToTaskStatus,
   TaskStatus,
@@ -96,7 +96,12 @@ export function PracticeSection({ userId }: PracticeSectionProps) {
   const personaT = useTranslations("persona");
   const tabs: Tab[] = [
     { id: "practices", label: t("practice_section_title"), Icon: ExperimentSvg },
-    { id: "persona", label: personaT("tabLabel"), mobileLabel: personaT("tabLabelShort"), Icon: BookSvg },
+    {
+      id: "persona",
+      label: personaT("tabLabel"),
+      mobileLabel: personaT("tabLabelShort"),
+      Icon: BookSvg,
+    },
     { id: "plans", label: t("practice_tab_plans"), disabled: true, Icon: FlagSvg },
     { id: "ideas", label: t("practice_tab_ideas"), disabled: true, Icon: NoteSvg },
   ];

--- a/apps/product/src/components/task-guide/task-guide-widget.tsx
+++ b/apps/product/src/components/task-guide/task-guide-widget.tsx
@@ -95,8 +95,7 @@ export function TaskGuideWidget() {
 
   const strippedPath = pathname?.replace(/^\/[a-z]{2}(-[a-zA-Z]{2})?(?=\/|$)/, "") || "/";
   const isAllowedPage =
-    strippedPath === "/" ||
-    /^\/(notifications|mine|settings)(\/|$)/.test(strippedPath);
+    strippedPath === "/" || /^\/(notifications|mine|settings)(\/|$)/.test(strippedPath);
 
   // Gating：未登入 / isTemporary / 非白名單頁面 → 不顯示
   if (!isAuthenticated || isTemporary || !isAllowedPage) return null;

--- a/apps/product/src/hooks/use-check-in-phase2-sheet.tsx
+++ b/apps/product/src/hooks/use-check-in-phase2-sheet.tsx
@@ -6,7 +6,6 @@ import { useSheetManager } from "@daodao/ui/components/animate-ui/components/rad
 import { toast } from "@daodao/ui/components/sonner";
 import { useCallback, useRef } from "react";
 import { CheckInPhase2SheetContent } from "@/components/check-in/form/check-in-sheet";
-import type { MoodType } from "@/constants/mood";
 import { mapMoodTypeToApiMood } from "@/constants/mood";
 
 interface IUseCheckInPhase2SheetOptions {
@@ -30,23 +29,19 @@ export function useCheckInPhase2Sheet({
   const closeRef = useRef<(() => void) | null>(null);
 
   const openPhase2Sheet = useCallback(
-    (checkInId: string, mood: MoodType | null) => {
+    (checkInId: string) => {
       const { close } = open({
         title: t("phase2_title"),
         description: t("phase2_description"),
         content: (
           <CheckInPhase2SheetContent
             taskTitle={taskTitle}
-            mood={mood}
             onComplete={async (data) => {
               const loadingToast = toast.loading(t("saving"));
               try {
                 const apiMood = data.mood ? mapMoodTypeToApiMood(data.mood) : undefined;
                 await updatePracticeCheckInWithFormData(practiceId, checkInId, {
                   mood: apiMood,
-                  tags: data.tags,
-                  description: data.description,
-                  media: data.media,
                 });
                 closeRef.current?.();
                 // 刷新打卡列表 cache

--- a/apps/product/src/hooks/use-edit-check-in-sheet.tsx
+++ b/apps/product/src/hooks/use-edit-check-in-sheet.tsx
@@ -45,6 +45,7 @@ export function useEditCheckInSheet({
       content: (
         <CheckInSheetContent
           taskTitle={taskTitle}
+          showMood={true}
           initialValues={{
             mood: checkInData.mood,
             tags: checkInData.tags,

--- a/packages/api/src/services/practice-hooks.ts
+++ b/packages/api/src/services/practice-hooks.ts
@@ -379,7 +379,7 @@ export const createPracticeCheckInWithFormData = async (
 export const updatePracticeCheckInWithFormData = async (
   practiceId: string,
   checkInId: string,
-  data: ICheckInFormData
+  data: Partial<ICheckInFormData>
 ): Promise<CreateCheckInResponse> => {
   const formData = new FormData();
 
@@ -520,7 +520,7 @@ export const useCreatePracticeCheckIn = (practiceId: string) => {
 export const useUpdatePracticeCheckIn = (practiceId: string, checkInId: string) => {
   const mutate = useMutate();
 
-  const updateCheckIn = async (formData: ICheckInFormData) => {
+  const updateCheckIn = async (formData: Partial<ICheckInFormData>) => {
     const response = await updatePracticeCheckInWithFormData(practiceId, checkInId, formData);
 
     // 刷新打卡列表的 cache（使用空 query 對象來匹配所有 query 參數組合）

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4837,15 +4837,15 @@
     "edit_sheet_title": "Edit Check-in",
     "edit_sheet_description": "Update your check-in content",
     "save_changes": "Save Changes",
-    "phase2_title": "Share Notes",
-    "phase2_description": "Add tags, notes, and photos",
+    "phase2_title": "Select Mood",
+    "phase2_description": "How did you feel about today's learning?",
     "notes_saved": "Notes saved!",
     "save_failed": "Failed to save, please try again later",
     "share_sheet_title": "Share",
     "share_sheet_description": "Share your check-in record",
     "success_title": "Check-in complete!",
     "success_default_encouragement": "Congrats, you took action again!",
-    "success_continue_hint": "Want to leave more notes? Add tags, thoughts, and photos.",
+    "success_continue_hint": "Want to record your mood? Continue filling in!",
     "success_share_more": "Share more notes",
     "success_complete": "Done",
     "delete_dialog_title": "Delete this check-in?",
@@ -4922,6 +4922,7 @@
     "date_scroll_up": "Scroll up",
     "date_scroll_down": "Scroll down",
     "validation_mood_required": "Please select a mood",
+    "validation_tags_required": "Please select at least one tag",
     "validation_description_max": "Maximum {max} characters",
     "validation_media_max": "You can upload up to {max} images",
     "anonymous": "Anonymous",
@@ -6825,44 +6826,20 @@
         "explorer": {
           "name": "Explorer Island",
           "description": "You are a curious explorer who enjoys trying new things.",
-          "traits": [
-            "Curious",
-            "Willing to try",
-            "Independent thinker"
-          ],
-          "recommendations": [
-            "Daily reading",
-            "Coding practice",
-            "Language learning"
-          ]
+          "traits": ["Curious", "Willing to try", "Independent thinker"],
+          "recommendations": ["Daily reading", "Coding practice", "Language learning"]
         },
         "creator": {
           "name": "Creator Island",
           "description": "You are highly creative and good at turning ideas into action.",
-          "traits": [
-            "Creative",
-            "Hands-on",
-            "Artistic"
-          ],
-          "recommendations": [
-            "Writing practice",
-            "Art creation",
-            "Design learning"
-          ]
+          "traits": ["Creative", "Hands-on", "Artistic"],
+          "recommendations": ["Writing practice", "Art creation", "Design learning"]
         },
         "connector": {
           "name": "Connector Island",
           "description": "You build relationships easily and enjoy learning with others.",
-          "traits": [
-            "Communicative",
-            "Team-oriented",
-            "Empathetic"
-          ],
-          "recommendations": [
-            "Community activities",
-            "Language learning",
-            "Team projects"
-          ]
+          "traits": ["Communicative", "Team-oriented", "Empathetic"],
+          "recommendations": ["Community activities", "Language learning", "Team projects"]
         }
       }
     },

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4846,7 +4846,7 @@
     "success_title": "Check-in complete!",
     "success_default_encouragement": "Congrats, you took action again!",
     "success_continue_hint": "Want to record your mood? Continue filling in!",
-    "success_share_more": "Share more notes",
+    "success_share_more": "Record mood",
     "success_complete": "Done",
     "delete_dialog_title": "Delete this check-in?",
     "delete_dialog_message": "Are you sure you want to say goodbye to this check-in? This cannot be undone.",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4846,7 +4846,7 @@
     "success_title": "打卡成功!",
     "success_default_encouragement": "恭喜，你又成功行動了一次！",
     "success_continue_hint": "想紀錄今天的心情嗎？繼續填寫吧！",
-    "success_share_more": "繼續分享心得",
+    "success_share_more": "記錄心情",
     "success_complete": "完成",
     "delete_dialog_title": "確定刪除這個打卡?",
     "delete_dialog_message": "確定要跟這個打卡說再見了嗎？一旦刪除，就無法復原囉。",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4837,15 +4837,15 @@
     "edit_sheet_title": "編輯打卡",
     "edit_sheet_description": "修改你的打卡內容",
     "save_changes": "儲存變更",
-    "phase2_title": "分享心得",
-    "phase2_description": "補充你的標籤、心得與照片",
+    "phase2_title": "選擇心情",
+    "phase2_description": "告訴我們今天的學習心情",
     "notes_saved": "心得已儲存！",
     "save_failed": "儲存失敗，請稍後再試",
     "share_sheet_title": "分享",
     "share_sheet_description": "分享你的打卡記錄",
     "success_title": "打卡成功!",
     "success_default_encouragement": "恭喜，你又成功行動了一次！",
-    "success_continue_hint": "想留下更多紀錄嗎？繼續填寫標籤、心得與照片吧！",
+    "success_continue_hint": "想紀錄今天的心情嗎？繼續填寫吧！",
     "success_share_more": "繼續分享心得",
     "success_complete": "完成",
     "delete_dialog_title": "確定刪除這個打卡?",
@@ -4922,6 +4922,7 @@
     "date_scroll_up": "向上滾動",
     "date_scroll_down": "向下滾動",
     "validation_mood_required": "請選擇心情",
+    "validation_tags_required": "請至少選擇一個標籤",
     "validation_description_max": "最多 {max} 字",
     "validation_media_max": "最多只能上傳 {max} 張圖片",
     "anonymous": "匿名",
@@ -6825,44 +6826,20 @@
         "explorer": {
           "name": "探索者島",
           "description": "你是一位好奇心旺盛的探索者，喜歡嘗試新事物",
-          "traits": [
-            "好奇心強",
-            "勇於嘗試",
-            "獨立思考"
-          ],
-          "recommendations": [
-            "每日閱讀",
-            "程式學習",
-            "語言學習"
-          ]
+          "traits": ["好奇心強", "勇於嘗試", "獨立思考"],
+          "recommendations": ["每日閱讀", "程式學習", "語言學習"]
         },
         "creator": {
           "name": "創造者島",
           "description": "你擁有豐富的創造力，善於將想法付諸實踐",
-          "traits": [
-            "創意豐富",
-            "動手能力強",
-            "有藝術天賦"
-          ],
-          "recommendations": [
-            "寫作練習",
-            "藝術創作",
-            "設計學習"
-          ]
+          "traits": ["創意豐富", "動手能力強", "有藝術天賦"],
+          "recommendations": ["寫作練習", "藝術創作", "設計學習"]
         },
         "connector": {
           "name": "連結者島",
           "description": "你善於建立人際關係，喜歡與他人合作學習",
-          "traits": [
-            "善於溝通",
-            "團隊合作",
-            "同理心強"
-          ],
-          "recommendations": [
-            "社群活動",
-            "語言學習",
-            "團隊專案"
-          ]
+          "traits": ["善於溝通", "團隊合作", "同理心強"],
+          "recommendations": ["社群活動", "語言學習", "團隊專案"]
         }
       }
     },


### PR DESCRIPTION
---  
## Why is this necessary?  
- 目前的打卡流程缺乏靈活性，無法滿足用戶需求。  
- 用戶希望能夠在打卡時添加標籤，以便更好地記錄打卡內容。  
- 心情選擇功能可以幫助用戶更直觀地表達當前狀態。  

## How does it address?  
- 在打卡流程中新增標籤填寫功能，讓用戶可以自定義打卡內容。  
- 引入心情選擇功能，使用戶在打卡時能夠選擇當前心情。  
- 這些改動將分階段實施，首先完成標籤的填寫，接著實現心情選擇。  