### PR TITLE
fix: check-in comment count includes 2nd-level replies (#756)

### DIFF
--- a/apps/product/src/components/check-in/display/check-in-detail.tsx
+++ b/apps/product/src/components/check-in/display/check-in-detail.tsx
@@ -46,6 +46,7 @@ import { applyOnboardingUpdateFromResponse } from "@/components/task-guide/onboa
 import type { ReactionTypeType } from "@/constants/reaction-type";
 import { useEditCheckInSheet } from "@/hooks/use-edit-check-in-sheet";
 import { useShareCheckInSheet } from "@/hooks/use-share-check-in-sheet";
+import { countTotalComments } from "@/utils/count-comments";
 import { formatRelativeTime } from "@/utils/format-time";
 import type { ICheckInDisplayData, ICheckInFormData } from "../types";
 import { CheckInCard } from "./check-in-card";
@@ -365,7 +366,7 @@ export const CheckInDetail = ({
 
   const commentCount = React.useMemo(() => {
     const raw = commentsData?.data;
-    return Array.isArray(raw) ? raw.filter(isApiCommentNode).length : 0;
+    return Array.isArray(raw) ? countTotalComments(raw.filter(isApiCommentNode)) : 0;
   }, [commentsData]);
 
   const currentUser = currentUserData?.data;

--- a/apps/product/src/utils/__tests__/count-comments.test.ts
+++ b/apps/product/src/utils/__tests__/count-comments.test.ts
@@ -37,4 +37,11 @@ describe("countTotalComments", () => {
     ];
     expect(countTotalComments(comments)).toBe(7); // 3 top + 3 + 0 + 1 replies
   });
+
+  it("ignores invalid reply nodes that do not have an id", () => {
+    const comments = [
+      { id: 1, replies: [{ id: 10 }, null, { content: "invalid" }] },
+    ];
+    expect(countTotalComments(comments)).toBe(2); // 1 top + 1 valid reply
+  });
 });

--- a/apps/product/src/utils/__tests__/count-comments.test.ts
+++ b/apps/product/src/utils/__tests__/count-comments.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { countTotalComments } from "../count-comments";
+
+describe("countTotalComments", () => {
+  it("returns 0 for empty array", () => {
+    expect(countTotalComments([])).toBe(0);
+  });
+
+  it("counts only first-level comments when there are no replies", () => {
+    const comments = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    expect(countTotalComments(comments)).toBe(3);
+  });
+
+  it("includes second-level reply comments in total", () => {
+    const comments = [
+      { id: 1, replies: [{ id: 10 }, { id: 11 }] },
+      { id: 2, replies: [{ id: 12 }] },
+    ];
+    expect(countTotalComments(comments)).toBe(5); // 2 top + 3 replies
+  });
+
+  it("handles comments with empty replies array", () => {
+    const comments = [{ id: 1, replies: [] }, { id: 2 }];
+    expect(countTotalComments(comments)).toBe(2);
+  });
+
+  it("handles comments with no replies field", () => {
+    const comments = [{ id: 1 }, { id: 2, replies: [{ id: 20 }] }];
+    expect(countTotalComments(comments)).toBe(3); // 2 top + 1 reply
+  });
+
+  it("handles mixed comments with and without replies", () => {
+    const comments = [
+      { id: 1, replies: [{ id: 10 }, { id: 11 }, { id: 12 }] },
+      { id: 2 },
+      { id: 3, replies: [{ id: 13 }] },
+    ];
+    expect(countTotalComments(comments)).toBe(7); // 3 top + 3 + 0 + 1 replies
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted `countTotalComments` utility that recursively counts top-level comments plus all their replies
- Updated `check-in-detail.tsx` to use `countTotalComments` so the displayed count reflects all 2nd-level replies
- Added 6 unit tests (TDD: failing tests committed first, then implementation)

## Root Cause

`commentsData` contains nested reply arrays on each comment, but the previous code only called `.length` on the top-level filtered array, ignoring all replies.

## Files Changed

- `apps/product/src/utils/count-comments.ts` — new utility
- `apps/product/src/utils/__tests__/count-comments.test.ts` — 6 unit tests
- `apps/product/src/components/check-in/display/check-in-detail.tsx` — use `countTotalComments`

Closes #756

---
_Generated by [Claude Code](https://claude.ai/code/session_01QajwAfaXyGEUg2qK2DXo6Z)_