### PR TITLE
[auto] #756 修正打卡留言數量統計，納入二層回覆

### DIFF
--- a/apps/product/src/components/check-in/display/check-in-detail.tsx
+++ b/apps/product/src/components/check-in/display/check-in-detail.tsx
@@ -46,6 +46,7 @@ import { applyOnboardingUpdateFromResponse } from "@/components/task-guide/onboa
 import type { ReactionTypeType } from "@/constants/reaction-type";
 import { useEditCheckInSheet } from "@/hooks/use-edit-check-in-sheet";
 import { useShareCheckInSheet } from "@/hooks/use-share-check-in-sheet";
+import { countCommentsWithReplies } from "@/utils/count-comments";
 import { formatRelativeTime } from "@/utils/format-time";
 import type { ICheckInDisplayData, ICheckInFormData } from "../types";
 import { CheckInCard } from "./check-in-card";
@@ -364,8 +365,7 @@ export const CheckInDetail = ({
   const { data: currentUserData } = useCurrentUser();
 
   const commentCount = React.useMemo(() => {
-    const raw = commentsData?.data;
-    return Array.isArray(raw) ? raw.filter(isApiCommentNode).length : 0;
+    return countCommentsWithReplies(commentsData?.data);
   }, [commentsData]);
 
   const currentUser = currentUserData?.data;

--- a/apps/product/src/utils/__tests__/count-comments.test.ts
+++ b/apps/product/src/utils/__tests__/count-comments.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { countCommentsWithReplies } from "../count-comments";
+
+describe("countCommentsWithReplies", () => {
+  it("returns 0 for non-array input", () => {
+    expect(countCommentsWithReplies(null)).toBe(0);
+    expect(countCommentsWithReplies(undefined)).toBe(0);
+    expect(countCommentsWithReplies("string")).toBe(0);
+  });
+
+  it("counts top-level comments with no replies", () => {
+    const comments = [
+      { id: 1, content: "Hello" },
+      { id: 2, content: "World" },
+    ];
+    expect(countCommentsWithReplies(comments)).toBe(2);
+  });
+
+  it("includes second-level replies in total count", () => {
+    const comments = [
+      { id: 1, content: "Parent", replies: [{ id: 3, content: "Reply A" }, { id: 4, content: "Reply B" }] },
+      { id: 2, content: "Parent 2", replies: [] },
+    ];
+    expect(countCommentsWithReplies(comments)).toBe(4);
+  });
+
+  it("skips invalid reply entries that lack an id", () => {
+    const comments = [
+      { id: 1, replies: [{ id: 2 }, null, "invalid", { id: 3 }] },
+    ];
+    expect(countCommentsWithReplies(comments)).toBe(3);
+  });
+
+  it("returns 0 for empty array", () => {
+    expect(countCommentsWithReplies([])).toBe(0);
+  });
+});

--- a/apps/product/src/utils/count-comments.ts
+++ b/apps/product/src/utils/count-comments.ts
@@ -4,15 +4,29 @@ type CommentLike = {
 };
 
 function isCommentLike(v: unknown): v is CommentLike {
-  return typeof v === "object" && v !== null && "id" in v;
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "id" in v &&
+    (typeof (v as { id: unknown }).id === "number" ||
+      typeof (v as { id: unknown }).id === "string")
+  );
 }
 
 export function countCommentsWithReplies(raw: unknown): number {
   if (!Array.isArray(raw)) return 0;
-  const topLevel = raw.filter(isCommentLike);
-  const replyCount = topLevel.reduce((sum, c) => {
-    const replies = Array.isArray(c.replies) ? c.replies : [];
-    return sum + replies.filter(isCommentLike).length;
-  }, 0);
-  return topLevel.length + replyCount;
+  let count = 0;
+  for (const c of raw) {
+    if (isCommentLike(c)) {
+      count++;
+      if (Array.isArray(c.replies)) {
+        for (const r of c.replies) {
+          if (isCommentLike(r)) {
+            count++;
+          }
+        }
+      }
+    }
+  }
+  return count;
 }

--- a/apps/product/src/utils/count-comments.ts
+++ b/apps/product/src/utils/count-comments.ts
@@ -1,0 +1,18 @@
+type CommentLike = {
+  id: number | string;
+  replies?: unknown[];
+};
+
+function isCommentLike(v: unknown): v is CommentLike {
+  return typeof v === "object" && v !== null && "id" in v;
+}
+
+export function countCommentsWithReplies(raw: unknown): number {
+  if (!Array.isArray(raw)) return 0;
+  const topLevel = raw.filter(isCommentLike);
+  const replyCount = topLevel.reduce((sum, c) => {
+    const replies = Array.isArray(c.replies) ? c.replies : [];
+    return sum + replies.filter(isCommentLike).length;
+  }, 0);
+  return topLevel.length + replyCount;
+}


### PR DESCRIPTION
## Summary\nImplements #756: 打卡留言數量統計\n\n- 新增 `countCommentsWithReplies` utility 計算頂層留言 + 二層回覆的總數\n- 更新 `check-in-detail.tsx` 使用新的 utility 取代僅計算頂層留言\n- 新增 5 個 vitest 單元測試（TDD：先寫測試再實作）\n\n## Test plan\n- [x] `pnpm --filter @daodao/product run test` → 41/41 passed\n- [x] `pnpm run lint` → no errors (43 pre-existing warnings)\n\n---\n🤖 Auto-generated by daodao pipeline\nCloses #756

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmnr4z6czb3GMkpQ7Kj7X4)_