### PR TITLE
[auto] #740 修正英文版 tab 顯示 Inspire → Inspiration

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5287,7 +5287,7 @@
     "header_day_unit": "",
     "want_to_practice": "I want to try this too",
     "continue_editing": "Continue editing",
-    "tab_inspire": "Inspire",
+    "tab_inspire": "Inspiration",
     "tab_persona": "Persona",
     "tab_mine": "Mine",
     "loading": "Loading...",


### PR DESCRIPTION
## Summary\nImplements #740: 英文版 tab 修改\n\n- 將 `en.json` dashboard namespace 中的 `tab_inspire` 從 `\"Inspire\"` 改為 `\"Inspiration\"`\n\n## Test plan\n- [x] `pnpm run lint` → no errors\n- [x] Single-line i18n change, no logic modified\n\n---\n🤖 Auto-generated by daodao pipeline\nCloses #740

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmnr4z6czb3GMkpQ7Kj7X4)_