### PR TITLE
fix: update persona carousel input placeholder text (#735)

### DIFF
--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -5561,7 +5561,7 @@
       "submit": "送出",
       "submitError": "送出失敗，請稍後再試",
       "submitting": "送出中...",
-      "textPlaceholder": "分享你的想法..."
+      "textPlaceholder": "讓大家和你更認識自己"
     },
     "answeredLabel": "已回答",
     "unansweredLabel": "未回答",


### PR DESCRIPTION
## Summary

Updates `textPlaceholder` in `packages/i18n/src/locales/zh-TW.json` under the `persona.carousel` namespace from `"分享你的想法..."` to `"讓大家和你更認識自己"` as specified.

Closes #735

---
_Generated by [Claude Code](https://claude.ai/code/session_01QajwAfaXyGEUg2qK2DXo6Z)_