### PR TITLE
[auto] #735 修正人物誌 textPlaceholder 文字

### DIFF
--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -5463,7 +5463,7 @@
       "submitError": "送出失敗，請稍後再試",
       "selectRequired": "請選擇一個選項",
       "textRequired": "請填寫答案",
-      "textPlaceholder": "請輸入你的答案...",
+      "textPlaceholder": "讓大家和你更認識自己",
       "resonances": "共鳴",
       "unansweredHint": "回答後即可查看大家的想法",
       "unansweredLabel": "尚未回答",


### PR DESCRIPTION
## Summary\nImplements #735: 人物誌 placeholder 文字修改\n\n- 將 `zh-TW.json` 的 `persona.myProfile.textPlaceholder` 從 `\"請輸入你的答案...\"` 改為 `\"讓大家和你更認識自己\"`\n\n## Test plan\n- [x] Single-line i18n change, no logic modified\n- [x] `pnpm run lint` → no errors\n\n---\n🤖 Auto-generated by daodao pipeline\nCloses #735

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmnr4z6czb3GMkpQ7Kj7X4)_