### PR TITLE
[auto] #733 人物誌回覆頭像與名字點擊連結至用戶頁

### DIFF
--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -459,6 +459,8 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
             href={userHref}
             className={cn(avatarClasses, "hover:opacity-80 transition-opacity")}
             style={{ background: avatarColor }}
+            tabIndex={-1}
+            aria-hidden="true"
           >
             {initial}
           </Link>

--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -19,7 +19,7 @@ import { DialogOutlineSvg } from "@daodao/assets";
 import { useAuth } from "@daodao/auth";
 import type { MentionCandidate } from "@daodao/features-mention";
 import { useLocale, useTranslations } from "@daodao/i18n";
-import { useRouter } from "@daodao/i18n/navigation";
+import { Link, useRouter } from "@daodao/i18n/navigation";
 import { useSheetManager } from "@daodao/ui/components/animate-ui/components/radix/sheet";
 import { toast } from "@daodao/ui/components/sonner";
 import { cn } from "@daodao/ui/lib/utils";
@@ -426,6 +426,7 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
   const isLong = answer.length > 70;
   const displayName = item.name ?? "??";
   const initial = displayName[0] ?? "?";
+  const userHref = item.userId ? (`/users/${item.userId}` as const) : null;
 
   const AVATAR_COLORS = [
     "#F5A93E",
@@ -440,6 +441,9 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
     displayName.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % AVATAR_COLORS.length;
   const avatarColor = item.isSelf ? "#16B9B3" : (AVATAR_COLORS[colorIndex] ?? "#16B9B3");
 
+  const avatarClasses = "size-9 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0 mt-0.5";
+  const nameClasses = cn("text-sm font-semibold", item.isSelf ? "text-logo-cyan" : "text-text-dark");
+
   return (
     <div
       className={cn(
@@ -450,22 +454,30 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
       )}
     >
       <div className="flex items-start gap-3">
-        <div
-          className="size-9 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0 mt-0.5"
-          style={{ background: avatarColor }}
-        >
-          {initial}
-        </div>
+        {userHref ? (
+          <Link
+            href={userHref}
+            className={cn(avatarClasses, "hover:opacity-80 transition-opacity")}
+            style={{ background: avatarColor }}
+          >
+            {initial}
+          </Link>
+        ) : (
+          <div className={avatarClasses} style={{ background: avatarColor }}>
+            {initial}
+          </div>
+        )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1.5">
-            <span
-              className={cn(
-                "text-sm font-semibold",
-                item.isSelf ? "text-logo-cyan" : "text-text-dark"
-              )}
-            >
-              {displayName}
-            </span>
+            {userHref ? (
+              <Link href={userHref} className={cn(nameClasses, "hover:underline")}>
+                {displayName}
+              </Link>
+            ) : (
+              <span className={nameClasses}>
+                {displayName}
+              </span>
+            )}
             {item.isSelf && (
               <span className="text-[10px] text-logo-cyan bg-logo-cyan/10 rounded-full px-2 py-0.5 font-medium leading-none">
                 {t("myAnswer")}


### PR DESCRIPTION
## Summary\nImplements #733: 人物誌回覆後的頭像/名字點選\n\n- 在 `ResponseItem` 中，當 `item.userId` 存在時，將頭像和名字包成 `Link` 並導向 `/users/${userId}`\n- 當 `userId` 為 null 時維持原本的 `div`/`span` 不可點擊行為\n- 頭像加 `hover:opacity-80` 效果，名字加 `hover:underline` 效果\n\n## Test plan\n- [x] `pnpm run lint` → no errors (43 pre-existing warnings)\n- [x] `pnpm --filter @daodao/product run test` → 36/36 passed\n\n---\n🤖 Auto-generated by daodao pipeline\nCloses #733

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmnr4z6czb3GMkpQ7Kj7X4)_