### PR TITLE
fix: make persona answer author avatar and name clickable links (#733)

### DIFF
--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -21,6 +21,7 @@ import type { MentionCandidate } from "@daodao/features-mention";
 import { useLocale, useTranslations } from "@daodao/i18n";
 import { useRouter } from "@daodao/i18n/navigation";
 import { useSheetManager } from "@daodao/ui/components/animate-ui/components/radix/sheet";
+import { CustomLink } from "@daodao/ui/components/custom-link";
 import { toast } from "@daodao/ui/components/sonner";
 import { cn } from "@daodao/ui/lib/utils";
 import { CheckCircle2, ChevronDown, X } from "lucide-react";
@@ -426,6 +427,7 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
   const isLong = answer.length > 70;
   const displayName = item.name ?? "??";
   const initial = displayName[0] ?? "?";
+  const authorHref = item.userId ? `/users/${item.userId}` : null;
 
   const AVATAR_COLORS = [
     "#F5A93E",
@@ -440,6 +442,15 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
     displayName.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % AVATAR_COLORS.length;
   const avatarColor = item.isSelf ? "#16B9B3" : (AVATAR_COLORS[colorIndex] ?? "#16B9B3");
 
+  const avatarNode = (
+    <div
+      className="size-9 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0 mt-0.5"
+      style={{ background: avatarColor }}
+    >
+      {initial}
+    </div>
+  );
+
   return (
     <div
       className={cn(
@@ -450,14 +461,26 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
       )}
     >
       <div className="flex items-start gap-3">
-        <div
-          className="size-9 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0 mt-0.5"
-          style={{ background: avatarColor }}
-        >
-          {initial}
-        </div>
+        {authorHref ? (
+          <CustomLink href={authorHref} aria-label={displayName}>
+            {avatarNode}
+          </CustomLink>
+        ) : (
+          avatarNode
+        )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1.5">
+            {authorHref ? (
+              <CustomLink
+                href={authorHref}
+                className={cn(
+                  "text-sm font-semibold hover:underline",
+                  item.isSelf ? "text-logo-cyan" : "text-text-dark"
+                )}
+              >
+                {displayName}
+              </CustomLink>
+            ) : (
             <span
               className={cn(
                 "text-sm font-semibold",
@@ -466,6 +489,7 @@ function ResponseItem({ item }: { item: PersonaQuestionAnswerItem }) {
             >
               {displayName}
             </span>
+            )}
             {item.isSelf && (
               <span className="text-[10px] text-logo-cyan bg-logo-cyan/10 rounded-full px-2 py-0.5 font-medium leading-none">
                 {t("myAnswer")}


### PR DESCRIPTION
## Summary

- Added `CustomLink` import to `apps/product/src/app/[locale]/persona/[id]/page.tsx`
- In `ResponseItem`, compute `authorHref = item.userId ? \`/users/${item.userId}\` : null`
- Conditionally wrap the avatar div and name span in `CustomLink` to `/users/{userId}` when the API provides a `userId`
- Falls back to plain elements when `userId` is null (anonymous or unavailable)

Closes #733

---
_Generated by [Claude Code](https://claude.ai/code/session_01QajwAfaXyGEUg2qK2DXo6Z)_