### PR TITLE
[auto] #741 人物誌留言

### DIFF
--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -273,8 +273,8 @@ function PersonaAnswerCommentSheetContent({ answerId }: { answerId: number }) {
         toast.error(t("commentSubmitError"));
         return;
       }
-      await mutateComments();
       toast.success(t("commentSubmitSuccess"));
+      await mutateComments();
     },
     [targetId, mutateComments, t]
   );

--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -274,6 +274,7 @@ function PersonaAnswerCommentSheetContent({ answerId }: { answerId: number }) {
         return;
       }
       await mutateComments();
+      toast.success(t("commentSubmitSuccess"));
     },
     [targetId, mutateComments, t]
   );

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5528,6 +5528,7 @@
       "anonymousUser": "Anonymous user",
       "justNow": "Just now",
       "commentSubmitError": "Failed to post comment",
+      "commentSubmitSuccess": "Comment posted!",
       "commentsTitle": "Comments",
       "myAnswer": "My answer",
       "collapse": "Collapse",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -5528,6 +5528,7 @@
       "anonymousUser": "匿名用戶",
       "justNow": "剛剛",
       "commentSubmitError": "留言失敗",
+      "commentSubmitSuccess": "留言成功！",
       "commentsTitle": "留言",
       "myAnswer": "我的回答",
       "collapse": "收起",


### PR DESCRIPTION
## Summary

Fixes #741 — persona answer comment submission was missing a success toast notification.

**Changes:**
- `apps/product/src/app/[locale]/persona/[id]/page.tsx`: Add `toast.success(t("commentSubmitSuccess"))` after `mutateComments()` in `handleSubmitComment`
- `packages/i18n/src/locales/zh-TW.json`: Add `"commentSubmitSuccess": "留言成功！"` to `persona.detail`
- `packages/i18n/src/locales/en.json`: Add `"commentSubmitSuccess": "Comment posted!"` to `persona.detail`

**Root cause:** `handleSubmitComment` in `PersonaAnswerCommentSheetContent` called `createComment()` and then `mutateComments()` on success, but never showed feedback to the user. The error path already had `toast.error(t("commentSubmitError"))`, so the pattern was consistent — just the success branch was missing.

## Test plan
- [ ] Open a persona question detail page (`/persona/[id]`)
- [ ] Click the comment button (requires login)
- [ ] Submit a comment
- [ ] Verify a green success toast "留言成功！" (zh-TW) or "Comment posted!" (en) appears
- [ ] Verify the comment list refreshes and shows the new comment
- [ ] Submit an invalid comment (network off) and verify the error toast still appears

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXQkdXrHFYCAwuWAX7Qa9Q)_