### PR TITLE
[auto] #734 我的小島-人物誌題目呈現方式

### DIFF
--- a/PLAN-734.md
+++ b/PLAN-734.md
@@ -1,0 +1,26 @@
+# Plan: #734 我的小島-人物誌題目呈現方式
+
+## Current State
+
+`PersonaProfileMe` component already shows single-card + switch-question button (implemented in #750).
+
+## Remaining Gap
+
+Progress counter still shows **"已回答 {answered}/{total} 題"** but should be **"剩 {remaining}/{total} 題完成人物誌"**.
+
+## Changes Required
+
+### 1. `apps/product/src/components/persona/persona-profile-me.tsx`
+- Add `remaining = questions.length - answered.length` computed value
+- Pass `remaining` to the i18n key instead of `answered`
+
+### 2. `packages/i18n/src/locales/zh-TW.json`
+- `persona.myProfile.progress`: `"已回答 {answered}/{total} 題"` → `"剩 {remaining}/{total} 題完成人物誌"`
+
+### 3. `packages/i18n/src/locales/en.json`
+- `persona.myProfile.progress`: update to `"{remaining}/{total} questions left to complete your persona"`
+
+## Files Changed
+- `apps/product/src/components/persona/persona-profile-me.tsx`
+- `packages/i18n/src/locales/zh-TW.json`
+- `packages/i18n/src/locales/en.json`

--- a/apps/product/src/components/persona/persona-profile-me.tsx
+++ b/apps/product/src/components/persona/persona-profile-me.tsx
@@ -115,6 +115,7 @@ export function PersonaProfileMe() {
 
   const questions = useMemo(() => data?.data?.questions ?? [], [data]);
   const answered = useMemo(() => questions.filter((q) => !q.isPlaceholder), [questions]);
+  const remaining = questions.length - answered.length;
 
   const handleNextQuestion = useCallback(() => {
     setCurrentIndex((prev) => (prev + 1) % questions.length);
@@ -140,7 +141,7 @@ export function PersonaProfileMe() {
     <div className="flex flex-col gap-3 py-4">
       {/* Progress */}
       <p className="text-xs text-gray-400 text-right">
-        {t("myProfile.progress", { answered: answered.length, total: questions.length })}
+        {t("myProfile.progress", { remaining, total: questions.length })}
       </p>
 
       {/* Single question card */}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5453,7 +5453,7 @@
       "loading": "Loading...",
       "empty": "No questions yet",
       "clickToAnswer": "Answer",
-      "progress": "Answered {answered}/{total}",
+      "progress": "{remaining}/{total} questions left to complete your persona",
       "startPrompt": "Click any question to start building your learner persona",
       "showMore": "Show {count} more",
       "showLess": "Show less",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -5453,7 +5453,7 @@
       "loading": "載入中...",
       "empty": "尚無問題",
       "clickToAnswer": "填寫",
-      "progress": "已回答 {answered}/{total} 題",
+      "progress": "剩 {remaining}/{total} 題完成人物誌",
       "startPrompt": "點擊任一題開始填寫你的學習人物誌",
       "showMore": "顯示更多 {count} 題",
       "showLess": "收起",


### PR DESCRIPTION
## Summary
Implements #734: 我的小島-人物誌題目呈現方式

Change persona progress counter from "已回答 xx/yy 題" to "剩 xx/yy 題完成人物誌"
so users see how many questions remain, not how many they've answered.

## Changes
- `persona-profile-me.tsx`: compute `remaining = total - answered`, pass to i18n
- `zh-TW.json`: `"已回答 {answered}/{total} 題"` → `"剩 {remaining}/{total} 題完成人物誌"`
- `en.json`: `"Answered {answered}/{total}"` → `"{remaining}/{total} questions left to complete your persona"`

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes

---
🤖 Auto-generated by daodao pipeline
Closes #734

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvbxJfqC1FkYfFwvmctU2Q)_