### PR TITLE
[auto] #742 人物誌快速回應

### DIFF
--- a/apps/product/src/app/[locale]/persona/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/persona/[id]/page.tsx
@@ -391,8 +391,8 @@ function PersonaAnswerInteractions({ answerId }: { answerId: number }) {
   }, [isAuthenticated, login, openSheet, answerId, t]);
 
   return (
-    <div className="-mx-4 -mb-4 mt-3 rounded-b-2xl overflow-hidden">
-      <div className="flex items-center bg-white border-t border-[#E4EAE9] py-1">
+    <div className="-mx-4 -mb-4 mt-3">
+      <div className="flex items-center bg-white border-t border-[#E4EAE9] py-1 rounded-b-2xl">
         <div className="flex-1 flex justify-center rounded-xl hover:bg-gray-50 transition-colors py-1 mx-1">
           <ReactionPickerButton
             selectedReactions={selectedReactions}


### PR DESCRIPTION
## Summary

Closes #742

**Root cause:** `PersonaAnswerInteractions` wrapped its interaction bar in `<div className="... overflow-hidden">`. The `ReactionPickerButton` popup renders with `position: absolute; bottom: 100%` (above the trigger), but `overflow-hidden` on the ancestor clipped it — making the picker invisible on hover.

**Fix:** Removed `overflow-hidden` from the outer wrapper and moved `rounded-b-2xl` to the inner white bar div. Visual appearance is unchanged; the popup is now unclipped.

## Acceptance Criteria

- ✅ 滑鼠移至 icon 上需出現系統中的4個 reaction icon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvbxJfqC1FkYfFwvmctU2Q)_