### PR TITLE
[auto] #739 英文修正-登出

### DIFF
--- a/apps/product/src/hooks/__tests__/logout-i18n.test.ts
+++ b/apps/product/src/hooks/__tests__/logout-i18n.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import enMessages from "../../../../../packages/i18n/src/locales/en.json";
+import zhTWMessages from "../../../../../packages/i18n/src/locales/zh-TW.json";
+
+describe("logout dialog i18n keys", () => {
+  it("en common.cancel must be 'Cancel', not the raw key", () => {
+    const cancel = (enMessages as Record<string, Record<string, string>>)["common"]?.["cancel"];
+    expect(cancel).toBe("Cancel");
+    expect(cancel).not.toContain("common.");
+  });
+
+  it("en common.logout_title exists", () => {
+    const title = (enMessages as Record<string, Record<string, string>>)["common"]?.["logout_title"];
+    expect(title).toBeTruthy();
+  });
+
+  it("en common.logout_confirm exists", () => {
+    const confirm = (enMessages as Record<string, Record<string, string>>)["common"]?.["logout_confirm"];
+    expect(confirm).toBeTruthy();
+  });
+
+  it("en common.logout_message exists", () => {
+    const message = (enMessages as Record<string, Record<string, string>>)["common"]?.["logout_message"];
+    expect(message).toBeTruthy();
+  });
+
+  it("zh-TW common.cancel must not be the raw key", () => {
+    const cancel = (zhTWMessages as Record<string, Record<string, string>>)["common"]?.["cancel"];
+    expect(cancel).toBeTruthy();
+    expect(cancel).not.toContain("common.");
+  });
+});

--- a/apps/product/src/hooks/__tests__/logout-i18n.test.ts
+++ b/apps/product/src/hooks/__tests__/logout-i18n.test.ts
@@ -4,28 +4,25 @@ import zhTWMessages from "../../../../../packages/i18n/src/locales/zh-TW.json";
 
 describe("logout dialog i18n keys", () => {
   it("en common.cancel must be 'Cancel', not the raw key", () => {
-    const cancel = (enMessages as Record<string, Record<string, string>>)["common"]?.["cancel"];
+    const cancel = enMessages.common.cancel;
     expect(cancel).toBe("Cancel");
     expect(cancel).not.toContain("common.");
   });
 
   it("en common.logout_title exists", () => {
-    const title = (enMessages as Record<string, Record<string, string>>)["common"]?.["logout_title"];
-    expect(title).toBeTruthy();
+    expect(enMessages.common.logout_title).toBeTruthy();
   });
 
   it("en common.logout_confirm exists", () => {
-    const confirm = (enMessages as Record<string, Record<string, string>>)["common"]?.["logout_confirm"];
-    expect(confirm).toBeTruthy();
+    expect(enMessages.common.logout_confirm).toBeTruthy();
   });
 
   it("en common.logout_message exists", () => {
-    const message = (enMessages as Record<string, Record<string, string>>)["common"]?.["logout_message"];
-    expect(message).toBeTruthy();
+    expect(enMessages.common.logout_message).toBeTruthy();
   });
 
   it("zh-TW common.cancel must not be the raw key", () => {
-    const cancel = (zhTWMessages as Record<string, Record<string, string>>)["common"]?.["cancel"];
+    const cancel = zhTWMessages.common.cancel;
     expect(cancel).toBeTruthy();
     expect(cancel).not.toContain("common.");
   });


### PR DESCRIPTION
## Summary
Implements #739: 英文修正-登出

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes

---
🤖 Auto-generated by daodao pipeline
Closes #739

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxnP3KFRDNtvm8EmyJzXcf)_