### PR TITLE
[auto] #649 返回路徑

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -286,11 +286,17 @@ export default function PracticeDetailPage() {
   }, [practicesListData, practiceId]);
 
   const handlePrevious = () => {
-    if (previousPracticeId) router.push(`/practices/${previousPracticeId}`);
+    if (previousPracticeId) {
+      const from = searchParams.get("from");
+      router.push(`/practices/${previousPracticeId}${from ? `?from=${from}` : ""}`);
+    }
   };
 
   const handleNext = () => {
-    if (nextPracticeId) router.push(`/practices/${nextPracticeId}`);
+    if (nextPracticeId) {
+      const from = searchParams.get("from");
+      router.push(`/practices/${nextPracticeId}${from ? `?from=${from}` : ""}`);
+    }
   };
 
   const handleEdit = () => {

--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -20,7 +20,7 @@ import {
 } from "@daodao/api";
 import type { MentionCandidate } from "@daodao/features-mention";
 import { useLocale, useTranslations } from "@daodao/i18n";
-import { useParams, useRouter } from "@daodao/i18n/navigation";
+import { useParams, useRouter, useSearchParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
 import { format, isValid, parseISO } from "date-fns";
 import { X } from "lucide-react";
@@ -38,6 +38,7 @@ import { BackgroundAnimation } from "@/components/layout";
 import { PracticeDetailShell } from "@/components/practice";
 import { applyOnboardingUpdateFromResponse } from "@/components/task-guide/onboarding-progress-context";
 import { HOME_TAB_PATHS } from "@/constants/home-navigation";
+import { getBackPath } from "@/utils/get-back-path";
 import {
   type DurationDays,
   DurationDays as DurationDaysConst,
@@ -135,7 +136,9 @@ export default function PracticeDetailPage() {
   );
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const practiceId = params.id as string;
+  const backPath = getBackPath(searchParams.get("from"));
   const {
     data: practiceData,
     isLoading,
@@ -414,7 +417,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace(HOME_TAB_PATHS.mine)}
+            onClick={() => router.replace(backPath)}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label={t("close")}
           >
@@ -435,7 +438,7 @@ export default function PracticeDetailPage() {
         <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
           <button
             type="button"
-            onClick={() => router.replace(HOME_TAB_PATHS.mine)}
+            onClick={() => router.replace(backPath)}
             className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
             aria-label={t("close")}
           >
@@ -465,7 +468,7 @@ export default function PracticeDetailPage() {
       <div className="sticky top-0 z-50 max-w-[448px] mx-auto w-full">
         <button
           type="button"
-          onClick={() => router.replace(HOME_TAB_PATHS.mine)}
+          onClick={() => router.replace(backPath)}
           className="absolute top-2 right-2 flex items-center justify-center size-10 rounded-full text-light-gray bg-very-light-gray/50 hover:text-logo-cyan"
           aria-label={t("close")}
         >

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -180,7 +180,7 @@ export function PracticeShowcaseCard({
     // biome-ignore lint/a11y/noStaticElementInteractions: card click for navigation
     <div
       className="bg-white rounded-xl p-5 cursor-pointer shadow-sm hover:shadow-md hover:ring-2 hover:ring-logo-cyan transition-all duration-200"
-      onClick={() => router.push(`/practices/${id}`)}
+      onClick={() => router.push(`/practices/${id}?from=inspire`)}
     >
       {/* Header row */}
       <div className="flex items-center gap-2 mb-2">
@@ -323,7 +323,7 @@ export function PracticeShowcaseCard({
         />
 
         <Link
-          href={`/practices/${id}?tab=comments`}
+          href={`/practices/${id}?tab=comments&from=inspire`}
           className="flex items-center gap-1.5 text-[#9FB5B8] hover:text-text-dark transition-colors"
         >
           <DialogOutlineSvg className="size-6" />

--- a/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/PracticeShowcaseCard.tsx
@@ -367,7 +367,6 @@ export function PracticeShowcaseCard({
                   {commentUserIslandHref ? (
                     <Link
                       href={commentUserIslandHref}
-                      // 預先載入使用者小島頁，降低點擊頭像後的等待體感
                       prefetch
                       aria-label={t("showcase_user_island_aria", { userName: commentUserName })}
                       className="shrink-0"
@@ -381,7 +380,6 @@ export function PracticeShowcaseCard({
                     {commentUserIslandHref ? (
                       <Link
                         href={commentUserIslandHref}
-                        // 預先載入使用者小島頁，降低點擊名稱後的等待體感
                         prefetch
                         className="text-xs font-semibold text-[#295E5C] mr-1.5 hover:underline"
                       >

--- a/apps/product/src/utils/__tests__/get-back-path.test.ts
+++ b/apps/product/src/utils/__tests__/get-back-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getBackPath } from "../get-back-path";
+
+describe("getBackPath", () => {
+  it("returns inspire path when from=inspire", () => {
+    expect(getBackPath("inspire")).toBe("/");
+  });
+
+  it("returns mine path when from=mine", () => {
+    expect(getBackPath("mine")).toBe("/mine");
+  });
+
+  it("returns mine path when from is null", () => {
+    expect(getBackPath(null)).toBe("/mine");
+  });
+
+  it("returns mine path when from is an unknown value", () => {
+    expect(getBackPath("persona")).toBe("/mine");
+  });
+});

--- a/apps/product/src/utils/__tests__/get-back-path.test.ts
+++ b/apps/product/src/utils/__tests__/get-back-path.test.ts
@@ -14,7 +14,11 @@ describe("getBackPath", () => {
     expect(getBackPath(null)).toBe("/mine");
   });
 
+  it("returns persona path when from=persona", () => {
+    expect(getBackPath("persona")).toBe("/persona");
+  });
+
   it("returns mine path when from is an unknown value", () => {
-    expect(getBackPath("persona")).toBe("/mine");
+    expect(getBackPath("unknown-tab")).toBe("/mine");
   });
 });

--- a/apps/product/src/utils/get-back-path.ts
+++ b/apps/product/src/utils/get-back-path.ts
@@ -1,0 +1,5 @@
+import { HOME_TAB_PATHS } from "@/constants/home-navigation";
+
+export function getBackPath(from: string | null): string {
+  return from === "inspire" ? HOME_TAB_PATHS.inspire : HOME_TAB_PATHS.mine;
+}

--- a/apps/product/src/utils/get-back-path.ts
+++ b/apps/product/src/utils/get-back-path.ts
@@ -1,5 +1,8 @@
 import { HOME_TAB_PATHS } from "@/constants/home-navigation";
 
 export function getBackPath(from: string | null): string {
-  return from === "inspire" ? HOME_TAB_PATHS.inspire : HOME_TAB_PATHS.mine;
+  if (from && from in HOME_TAB_PATHS) {
+    return HOME_TAB_PATHS[from as keyof typeof HOME_TAB_PATHS];
+  }
+  return HOME_TAB_PATHS.mine;
 }


### PR DESCRIPTION
## Summary
Implements #649: 返回路徑

- `PracticeShowcaseCard` 導航連結加 `?from=inspire` 參數（router.push 及 Link href）
- `practices/[id]/page.tsx` 讀取 `from` query param，透過 `getBackPath()` 決定關閉時的返回路徑
- 新增 `utils/get-back-path.ts` 純函數 + 單元測試

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes
- [ ] 從靈感頁點進實踐詳情 → 關閉 X 按鈕 → 回到靈感頁 (/)
- [ ] 從我的頁面點進實踐詳情 → 關閉 X 按鈕 → 回到 /mine

---
🤖 Auto-generated by daodao pipeline
Closes #649

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HwAymCnmckKPV2hQxZV6)_