### PR TITLE
[auto] #648 返回路徑(打卡紀錄)

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from "@daodao/i18n";
 import { useParams, useSearchParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
 import { addDays, format, isValid, parse } from "date-fns";
-import { useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import {
   CheckInButton,
   CheckInDateSelector,
@@ -74,7 +74,7 @@ const generateFullDateRange = (
   return dates;
 };
 
-export default function CheckInDetailPage() {
+function CheckInDetailContent() {
   const t = useTranslations("practice");
   const params = useParams();
   const searchParams = useSearchParams();
@@ -341,5 +341,13 @@ export default function CheckInDetailPage() {
         </footer>
       )}
     </div>
+  );
+}
+
+export default function CheckInDetailPage() {
+  return (
+    <Suspense>
+      <CheckInDetailContent />
+    </Suspense>
   );
 }

--- a/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/check-ins/[checkInId]/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@daodao/api";
 import { Deco4Svg } from "@daodao/assets";
 import { useTranslations } from "@daodao/i18n";
-import { useParams } from "@daodao/i18n/navigation";
+import { useParams, useSearchParams } from "@daodao/i18n/navigation";
 import { toast } from "@daodao/ui/components/sonner";
 import { addDays, format, isValid, parse } from "date-fns";
 import { useMemo } from "react";
@@ -21,6 +21,7 @@ import {
 import type { ICheckInDisplayData, ICheckInFormData } from "@/components/check-in/types";
 import { PageHeader } from "@/components/layout";
 import { mapApiMoodToMoodType, mapMoodTypeToApiMood } from "@/constants/mood";
+import { getCheckInBackPath } from "@/utils/get-check-in-back-path";
 
 /**
  * 將 API 的 checkinDate 格式轉換為顯示格式
@@ -76,9 +77,11 @@ const generateFullDateRange = (
 export default function CheckInDetailPage() {
   const t = useTranslations("practice");
   const params = useParams();
+  const searchParams = useSearchParams();
   const practiceId = params.id as string;
   const checkInId = params.checkInId as string;
   const practiceDetailPath = `/practices/${practiceId}`;
+  const closePath = getCheckInBackPath(practiceDetailPath, searchParams.get("from"));
 
   // 獲取 practice 資料
   const { data: practiceData, isLoading: isLoadingPractice } = usePracticeById(practiceId);
@@ -231,7 +234,7 @@ export default function CheckInDetailPage() {
           title={t("checkin_title")}
           variant="light"
           disableLightOn="mobile"
-          rightActionTo={practiceDetailPath}
+          rightActionTo={closePath}
         />
         <main className="max-w-[448px] mx-auto pt-[88px] md:pt-[72px] px-5 pb-40">
           <div className="text-center text-white">{t("checkin_loading")}</div>
@@ -249,7 +252,7 @@ export default function CheckInDetailPage() {
           title={t("checkin_title")}
           variant="light"
           disableLightOn="mobile"
-          rightActionTo={practiceDetailPath}
+          rightActionTo={closePath}
         />
         <main className="max-w-[448px] mx-auto pt-[88px] md:pt-[72px] px-5 pb-40">
           <div className="text-center text-white">{t("checkin_not_found")}</div>
@@ -297,12 +300,12 @@ export default function CheckInDetailPage() {
         activeDate={activeCheckInDate}
         practiceId={practiceId}
         title={t("checkin_title")}
-        closeActionTo={practiceDetailPath}
+        closeActionTo={closePath}
       />
 
       {/* Desktop 版本的標題列 */}
       <div className="hidden md:block">
-        <PageHeader title={t("checkin_title")} variant="light" rightActionTo={practiceDetailPath} />
+        <PageHeader title={t("checkin_title")} variant="light" rightActionTo={closePath} />
       </div>
 
       <main className="max-w-[448px] mx-auto pt-[150px] md:pt-10 px-5 pb-52">

--- a/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
@@ -110,7 +110,7 @@ export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
       return;
     }
 
-    router.push(`/practices/${practice.id}/check-ins/${id}`);
+    router.push(`/practices/${practice.id}/check-ins/${id}?from=inspire`);
   };
 
   const handleOpenComments = () => {

--- a/apps/product/src/utils/__tests__/get-check-in-back-path.test.ts
+++ b/apps/product/src/utils/__tests__/get-check-in-back-path.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getCheckInBackPath } from "../get-check-in-back-path";
+
+describe("getCheckInBackPath", () => {
+  const practiceDetailPath = "/practices/abc-123";
+
+  it("returns practice detail path when from is null", () => {
+    expect(getCheckInBackPath(practiceDetailPath, null)).toBe(practiceDetailPath);
+  });
+
+  it("returns inspire feed path when from is 'inspire'", () => {
+    expect(getCheckInBackPath(practiceDetailPath, "inspire")).toBe("/");
+  });
+
+  it("returns practice detail path when from is an unknown value", () => {
+    expect(getCheckInBackPath(practiceDetailPath, "other")).toBe(practiceDetailPath);
+  });
+
+  it("returns practice detail path when from is empty string", () => {
+    expect(getCheckInBackPath(practiceDetailPath, "")).toBe(practiceDetailPath);
+  });
+});

--- a/apps/product/src/utils/get-check-in-back-path.ts
+++ b/apps/product/src/utils/get-check-in-back-path.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the path the X button should navigate to on the check-in detail page.
+ *
+ * When the user arrives from the inspire feed (from=inspire), closing should
+ * return them to the feed rather than the practice detail page.
+ */
+export function getCheckInBackPath(practiceDetailPath: string, from: string | null): string {
+  if (from === "inspire") {
+    return "/";
+  }
+  return practiceDetailPath;
+}


### PR DESCRIPTION
## Summary
Implements #648: 返回路徑(打卡紀錄)

- `CheckInShowcaseCard`: add `?from=inspire` query param when navigating from the inspire feed to a check-in detail page
- `practices/[id]/check-ins/[checkInId]/page.tsx`: read `from` search param and use `getCheckInBackPath()` to determine close action destination — returns to `/` (inspire feed) when `from=inspire`, otherwise falls back to practice detail page
- `utils/get-check-in-back-path.ts`: pure utility + 4 unit tests

## Test plan
- [ ] pnpm test passes
- [ ] pnpm lint passes
- [ ] Navigate from 靈感 feed → click a check-in card → press X → verify returns to 靈感 feed (/)
- [ ] Navigate from practice detail → check-in record → press X → verify returns to practice detail

---
🤖 Auto-generated by daodao pipeline
Closes #648

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgGfT9ce3YeinBWcsA2JDE)_