### PR TITLE
fix(action-maker): 修正行動製作器的寬度及分享圖片問題

### DIFF
--- a/packages/features/action-maker/src/components/action-maker-result.tsx
+++ b/packages/features/action-maker/src/components/action-maker-result.tsx
@@ -47,6 +47,18 @@ export function ActionMakerResult() {
     if (!result || !cardRef.current) return;
     setDownloading(true);
 
+    // Temporarily remove overflow-hidden from ancestors so html-to-image captures the full card
+    const overflowAncestors: { el: HTMLElement; original: string }[] = [];
+    let parent = cardRef.current.parentElement;
+    while (parent) {
+      const style = getComputedStyle(parent);
+      if (style.overflow === "hidden" || style.overflowX === "hidden") {
+        overflowAncestors.push({ el: parent, original: parent.style.overflow });
+        parent.style.overflow = "visible";
+      }
+      parent = parent.parentElement;
+    }
+
     try {
       const imageData = await captureElementAsImage(cardRef.current);
       if (!imageData) return;
@@ -89,6 +101,10 @@ export function ActionMakerResult() {
       // Delay revoke so browsers (esp. Safari) can complete the download
       setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
     } finally {
+      // Restore ancestor overflow styles
+      for (const { el, original } of overflowAncestors) {
+        el.style.overflow = original;
+      }
       setDownloading(false);
     }
   }, [result]);
@@ -161,7 +177,7 @@ export function ActionMakerResult() {
           恭喜！你建立了新的習慣
         </h1>
         {/* ===== Share card area (captured by cardRef) ===== */}
-        <div ref={cardRef} className="mx-auto p-6">
+        <div ref={cardRef} className="mx-auto w-fit p-6">
           <div
             className="flex w-[350px] flex-col rounded-2xl px-5 pb-6 pt-12"
             style={{

--- a/packages/features/action-maker/src/components/action-maker-result.tsx
+++ b/packages/features/action-maker/src/components/action-maker-result.tsx
@@ -47,7 +47,10 @@ export function ActionMakerResult() {
     if (!result || !cardRef.current) return;
     setDownloading(true);
 
-    // Temporarily remove overflow-hidden from ancestors so html-to-image captures the full card
+    // Temporarily adjust styles so html-to-image captures the full card on narrow viewports
+    const savedWidth = cardRef.current.style.width;
+    cardRef.current.style.width = "fit-content";
+
     const overflowAncestors: { el: HTMLElement; original: string }[] = [];
     let parent = cardRef.current.parentElement;
     while (parent) {
@@ -101,7 +104,7 @@ export function ActionMakerResult() {
       // Delay revoke so browsers (esp. Safari) can complete the download
       setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
     } finally {
-      // Restore ancestor overflow styles
+      cardRef.current.style.width = savedWidth;
       for (const { el, original } of overflowAncestors) {
         el.style.overflow = original;
       }
@@ -177,7 +180,7 @@ export function ActionMakerResult() {
           恭喜！你建立了新的習慣
         </h1>
         {/* ===== Share card area (captured by cardRef) ===== */}
-        <div ref={cardRef} className="mx-auto w-fit p-6">
+        <div ref={cardRef} className="mx-auto p-6">
           <div
             className="flex w-[350px] flex-col rounded-2xl px-5 pb-6 pt-12"
             style={{

--- a/packages/features/action-maker/src/components/action-maker-result.tsx
+++ b/packages/features/action-maker/src/components/action-maker-result.tsx
@@ -104,7 +104,9 @@ export function ActionMakerResult() {
       // Delay revoke so browsers (esp. Safari) can complete the download
       setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
     } finally {
-      cardRef.current.style.width = savedWidth;
+      if (cardRef.current) {
+        cardRef.current.style.width = savedWidth;
+      }
       for (const { el, original } of overflowAncestors) {
         el.style.overflow = original;
       }


### PR DESCRIPTION
## Why is this necessary?

1. 行動製作器在捕捉時的寬度設定不應該是永久性的，這會影響到使用者體驗。
2. 在行動裝置上下載的分享圖片被裁剪，導致圖片顯示不完整，影響視覺效果。
3. 這些問題可能會影響到使用者對應用程式的滿意度和使用意願。

## How does it address?

1. 修正行動製作器的寬度設定，使其僅在捕捉過程中生效，避免對其他操作造成影響。
2. 調整分享圖片的處理邏輯，確保在行動裝置上下載的圖片不會被裁剪。
3. 進行測試以驗證這些修正能有效改善使用者在行動裝置上的體驗。