### PR TITLE
fix(task-guide): 移除新手任務 Early User Badge 頁腳文字  

### DIFF
--- a/apps/product/src/components/task-guide/task-guide-widget.tsx
+++ b/apps/product/src/components/task-guide/task-guide-widget.tsx
@@ -238,9 +238,6 @@ export function TaskGuideWidget() {
         })}
       </ul>
 
-      <div className="border-t border-very-light-gray bg-very-light-blue px-4 py-3 text-center text-xs leading-5 text-text-dark/60">
-        {t("footer")}
-      </div>
     </div>
   );
 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4769,7 +4769,6 @@
         "badgeDescription": "Thanks for completing all onboarding tasks — you're one of Dao Dao's earliest users!"
       },
       "progress": "{completed}/{total} done",
-      "footer": "Complete all tasks to earn the Early User Badge",
       "ariaOpen": "Expand onboarding task list",
       "ariaCollapse": "Collapse",
       "ariaClose": "Close",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4769,7 +4769,6 @@
         "badgeDescription": "感謝你完成所有新手任務，你是島島阿學的早期用戶之一！"
       },
       "progress": "{completed}/{total} 完成",
-      "footer": "完成所有任務即可獲得 Early User Badge",
       "ariaOpen": "展開 Onboarding 任務清單",
       "ariaCollapse": "收合",
       "ariaClose": "關閉",


### PR DESCRIPTION
---  
## Why is this necessary?  
- 新手任務的頁腳文字可能造成使用者困惑。  
- 移除不必要的文字可以提升使用者體驗。  
- 確保任務指引的簡潔性和清晰度。  

## How does it address?  
- 直接從新手任務的頁面中移除了相關的頁腳文字。  
- 減少了使用者在完成任務時的干擾。  
- 使得任務指引更加專注於核心內容。  