### PR TITLE
fix(task-guide): 移除新手任務 Early User Badge footer 文字

### DIFF
--- a/apps/product/src/components/task-guide/task-guide-widget.tsx
+++ b/apps/product/src/components/task-guide/task-guide-widget.tsx
@@ -238,9 +238,6 @@ export function TaskGuideWidget() {
         })}
       </ul>
 
-      <div className="border-t border-very-light-gray bg-very-light-blue px-4 py-3 text-center text-xs leading-5 text-text-dark/60">
-        {t("footer")}
-      </div>
     </div>
   );
 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4769,7 +4769,6 @@
         "badgeDescription": "Thanks for completing all onboarding tasks — you're one of Dao Dao's earliest users!"
       },
       "progress": "{completed}/{total} done",
-      "footer": "Complete all tasks to earn the Early User Badge",
       "ariaOpen": "Expand onboarding task list",
       "ariaCollapse": "Collapse",
       "ariaClose": "Close",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4769,7 +4769,6 @@
         "badgeDescription": "感謝你完成所有新手任務，你是島島阿學的早期用戶之一！"
       },
       "progress": "{completed}/{total} 完成",
-      "footer": "完成所有任務即可獲得 Early User Badge",
       "ariaOpen": "展開 Onboarding 任務清單",
       "ariaCollapse": "收合",
       "ariaClose": "關閉",


### PR DESCRIPTION
## Why is this necessary?

1. 新手任務的 footer 文字可能造成使用者混淆。
2. 移除不必要的資訊可以提升使用者體驗。
3. 確保介面簡潔明瞭，避免過多的文字干擾。

## How does it address?

1. 針對新手任務的 footer 文字進行修正，移除不必要的內容。
2. 透過清理介面，讓使用者更專注於任務本身。
3. 減少使用者的認知負擔，提高任務的完成率。