### PR TITLE
fix(dashboard): 修復實踐卡片總天數與已過天數少算一天的問題  

### DIFF
--- a/apps/product/src/utils/__tests__/practice-card.test.ts
+++ b/apps/product/src/utils/__tests__/practice-card.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { calculateRemainingDays, formatCardDate } from "../practice-card";
+import { calculateDaysProgress, calculateRemainingDays, formatCardDate } from "../practice-card";
 
 describe("calculateRemainingDays", () => {
   afterEach(() => {
@@ -30,6 +30,62 @@ describe("calculateRemainingDays", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-18T00:00:00Z"));
     expect(calculateRemainingDays("2026-05-10")).toBe(-8);
+  });
+});
+
+describe("calculateDaysProgress", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null for null startDate", () => {
+    expect(calculateDaysProgress(null, "2026-05-25")).toBeNull();
+  });
+
+  it("returns null for null endDate", () => {
+    expect(calculateDaysProgress("2026-05-18", null)).toBeNull();
+  });
+
+  it("returns null when endDate is before startDate", () => {
+    expect(calculateDaysProgress("2026-05-20", "2026-05-19")).toBeNull();
+  });
+
+  it("counts total days inclusively of both start and end date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T00:00:00Z"));
+    // startDate + (durationDays - 1) = endDate, so a 30-day practice starting
+    // 05/01 ends 05/30 — total must report 30, matching backend durationDays.
+    expect(calculateDaysProgress("2026-05-01", "2026-05-30")).toEqual({
+      elapsed: 1,
+      total: 30,
+    });
+  });
+
+  it("returns total of 1 for a single-day practice", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T00:00:00Z"));
+    expect(calculateDaysProgress("2026-05-01", "2026-05-01")).toEqual({
+      elapsed: 1,
+      total: 1,
+    });
+  });
+
+  it("counts today as an elapsed day (day 1 on the start date)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-03T00:00:00Z"));
+    expect(calculateDaysProgress("2026-05-01", "2026-05-30")).toEqual({
+      elapsed: 3,
+      total: 30,
+    });
+  });
+
+  it("caps elapsed at total once the practice period has passed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-23T00:00:00Z"));
+    expect(calculateDaysProgress("2026-06-10", "2026-06-22")).toEqual({
+      elapsed: 13,
+      total: 13,
+    });
   });
 });
 

--- a/apps/product/src/utils/__tests__/practice-card.test.ts
+++ b/apps/product/src/utils/__tests__/practice-card.test.ts
@@ -52,7 +52,10 @@ describe("calculateDaysProgress", () => {
 
   it("counts total days inclusively of both start and end date", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-01T00:00:00Z"));
+    // Local Date constructor (not a UTC ISO string) so the mocked "now"
+    // lines up with parseISO's local-timezone parsing of date-only strings,
+    // regardless of the machine's timezone offset.
+    vi.setSystemTime(new Date(2026, 4, 1));
     // startDate + (durationDays - 1) = endDate, so a 30-day practice starting
     // 05/01 ends 05/30 — total must report 30, matching backend durationDays.
     expect(calculateDaysProgress("2026-05-01", "2026-05-30")).toEqual({
@@ -63,7 +66,7 @@ describe("calculateDaysProgress", () => {
 
   it("returns total of 1 for a single-day practice", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-01T00:00:00Z"));
+    vi.setSystemTime(new Date(2026, 4, 1));
     expect(calculateDaysProgress("2026-05-01", "2026-05-01")).toEqual({
       elapsed: 1,
       total: 1,
@@ -72,7 +75,7 @@ describe("calculateDaysProgress", () => {
 
   it("counts today as an elapsed day (day 1 on the start date)", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-03T00:00:00Z"));
+    vi.setSystemTime(new Date(2026, 4, 3));
     expect(calculateDaysProgress("2026-05-01", "2026-05-30")).toEqual({
       elapsed: 3,
       total: 30,
@@ -81,7 +84,7 @@ describe("calculateDaysProgress", () => {
 
   it("caps elapsed at total once the practice period has passed", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-23T00:00:00Z"));
+    vi.setSystemTime(new Date(2026, 5, 23));
     expect(calculateDaysProgress("2026-06-10", "2026-06-22")).toEqual({
       elapsed: 13,
       total: 13,

--- a/apps/product/src/utils/practice-card.ts
+++ b/apps/product/src/utils/practice-card.ts
@@ -15,9 +15,9 @@ export function calculateDaysProgress(
   const start = parseISO(startDate);
   const end = parseISO(endDate);
   if (!isValid(start) || !isValid(end)) return null;
-  const total = differenceInCalendarDays(end, start);
+  const total = differenceInCalendarDays(end, start) + 1;
   if (total <= 0) return null;
-  const elapsed = Math.min(total, Math.max(0, differenceInCalendarDays(new Date(), start)));
+  const elapsed = Math.min(total, Math.max(0, differenceInCalendarDays(new Date(), start) + 1));
   return { elapsed, total };
 }
 


### PR DESCRIPTION
---  
## Why is this necessary?  
- 實踐卡片的總天數計算不正確，影響用戶的使用體驗。  
- 已過天數的顯示不準確，可能導致用戶錯過重要的時間管理。  
- 需要確保數據的準確性，以提高系統的可靠性。  

## How does it address?  
- 修正了計算邏輯，確保總天數與已過天數的正確性。  
- 進行了單元測試，以驗證修復的有效性。  
- 更新了相關文檔，說明修復的內容及影響範圍。  