### PR TITLE
feat(showcase): 增加 feed 卡片顯示編輯精選徽章功能  

### DIFF
--- a/apps/product/src/components/showcase/FeedLabel.tsx
+++ b/apps/product/src/components/showcase/FeedLabel.tsx
@@ -1,6 +1,6 @@
 import type { FeedReasonType } from "@daodao/api";
 import { useTranslations } from "@daodao/i18n";
-import { CalendarCheck, Rss, ThumbsUp } from "lucide-react";
+import { CalendarCheck, Rss, Star, ThumbsUp } from "lucide-react";
 
 interface FeedLabelProps {
   feedReason: FeedReasonType;
@@ -16,6 +16,15 @@ export function FeedLabel({
   latestActorName,
 }: FeedLabelProps) {
   const t = useTranslations("app_product");
+
+  if (feedReason === "featured") {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-text-dark/60 mt-4 mb-4 px-1">
+        <Star className="size-3.5 shrink-0" />
+        <span>{t("showcase_feed_featured")}</span>
+      </div>
+    );
+  }
 
   if (feedReason === "new_practice") {
     return (

--- a/packages/api/src/services/feed-hooks.ts
+++ b/packages/api/src/services/feed-hooks.ts
@@ -53,7 +53,7 @@ export interface IShowcaseCheckIn {
   }[];
 }
 
-export type FeedReasonType = "new_practice" | "new_release" | "checked_in" | "cheered";
+export type FeedReasonType = "new_practice" | "new_release" | "checked_in" | "cheered" | "featured";
 
 export interface ActivityCardItem {
   type: "activity";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5762,6 +5762,7 @@
     "showcase_feed_new_practice": "{userName} published a new practice",
     "showcase_feed_checked_in": "{userName} checked in to {practiceTitle}",
     "showcase_feed_cheered": "{actorName} cheered",
+    "showcase_feed_featured": "Editor's pick",
     "showcase_data": "Data",
     "showcase_echo": "Echoes",
     "showcase_views": "Views",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -5762,6 +5762,7 @@
     "showcase_feed_new_practice": "{userName} 發布了新實踐",
     "showcase_feed_checked_in": "{userName} 在 {practiceTitle} 打卡",
     "showcase_feed_cheered": "{actorName} 表達了加油",
+    "showcase_feed_featured": "編輯精選",
     "showcase_data": "數據",
     "showcase_echo": "迴響",
     "showcase_views": "瀏覽",


### PR DESCRIPTION
---  
## Why is this necessary?  
- 提升使用者對編輯精選內容的辨識度。  
- 增強 feed 卡片的視覺吸引力。  
- 促進使用者對精選內容的互動。  

## How does it address?  
- 在 feed 卡片上新增編輯精選徽章的顯示功能。  
- 確保徽章在不同裝置上的顯示效果一致。  
- 進行測試以確保徽章的正確性和穩定性。  