### PR TITLE
feat(notification): 收窄 mobile BACKEND_TYPE_MAP 值型別並對齊命名規範  

### DIFF
--- a/apps/mobile/app/(tabs)/notifications.tsx
+++ b/apps/mobile/app/(tabs)/notifications.tsx
@@ -22,20 +22,25 @@ import { formatRelativeTime } from "@/utils/format-time";
 // ============================================================================
 
 const BACKEND_TYPE_MAP: Record<string, string> = {
+  Reaction: NotificationType.reaction,
+  Comment: NotificationType.comment,
+  CommentReply: NotificationType.commentReply,
+  Mention: NotificationType.mention,
   UserFollowed: NotificationType.followUser,
   PracticeFollowed: NotificationType.followPractice,
   Connect: NotificationType.connect,
   ConnectAccepted: NotificationType.agreeConnect,
+  ConnectAgreed: NotificationType.connectAgree,
+  ConnectRejected: NotificationType.connectRejected,
+  BuddyRequest: NotificationType.buddyRequest,
+  BuddyRequestFollower: NotificationType.buddyRequestFollower,
+  BuddyAccepted: NotificationType.buddyAccepted,
+  PracticeCreated: NotificationType.practiceCreated,
+  PracticeFinished: NotificationType.updatePracticeFinish,
   PracticeCheckinActivity: NotificationType.updatePracticeCheckin,
   PartnerCheckinActivity: NotificationType.updatePracticeCheckin,
   PracticeUpdateActivity: NotificationType.updatePractice,
   PartnerUpdateActivity: NotificationType.updatePractice,
-  PracticeCreated: NotificationType.practiceCreated,
-  comment_reply: NotificationType.commentReply,
-  Mention: NotificationType.mention,
-  BuddyRequest: NotificationType.buddyRequest,
-  BuddyRequestFollower: NotificationType.buddyRequestFollower,
-  BuddyAccepted: NotificationType.buddyAccepted,
 };
 
 function normalizeType(backendType: string): string {

--- a/apps/mobile/app/(tabs)/notifications.tsx
+++ b/apps/mobile/app/(tabs)/notifications.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { Alert, Pressable, RefreshControl } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Avatar, ScrollView, Spinner, Text, XStack, YStack } from "tamagui";
-import { NotificationType } from "@/constants/notification-type";
+import { NotificationType, type NotificationTypeType } from "@/constants/notification-type";
 import { REACTION_CONFIG, type ReactionTypeType } from "@/constants/reaction-type";
 import { colors } from "@/generated/design-tokens";
 import {
@@ -21,7 +21,7 @@ import { formatRelativeTime } from "@/utils/format-time";
 // Helpers
 // ============================================================================
 
-const BACKEND_TYPE_MAP: Record<string, string> = {
+const BACKEND_TYPE_MAP: Record<string, NotificationTypeType> = {
   Reaction: NotificationType.reaction,
   Comment: NotificationType.comment,
   CommentReply: NotificationType.commentReply,
@@ -43,7 +43,7 @@ const BACKEND_TYPE_MAP: Record<string, string> = {
   PartnerUpdateActivity: NotificationType.updatePractice,
 };
 
-function normalizeType(backendType: string): string {
+function normalizeType(backendType: string): NotificationTypeType | string {
   return BACKEND_TYPE_MAP[backendType] ?? backendType;
 }
 

--- a/apps/product/src/components/notifications/notification-list.tsx
+++ b/apps/product/src/components/notifications/notification-list.tsx
@@ -26,20 +26,25 @@ import { NotificationItem } from "./notification-item";
 // ============================================================================
 
 const BACKEND_TYPE_MAP: Record<string, INotificationData["type"]> = {
+  Reaction: NotificationType.reaction,
+  Comment: NotificationType.comment,
+  CommentReply: NotificationType.commentReply,
+  Mention: NotificationType.mention,
   UserFollowed: NotificationType.followUser,
   PracticeFollowed: NotificationType.followPractice,
   Connect: NotificationType.connect,
   ConnectAccepted: NotificationType.agreeConnect,
+  ConnectAgreed: NotificationType.connectAgree,
+  ConnectRejected: NotificationType.connectRejected,
+  BuddyRequest: NotificationType.buddyRequest,
+  BuddyRequestFollower: NotificationType.buddyRequestFollower,
+  BuddyAccepted: NotificationType.buddyAccepted,
+  PracticeCreated: NotificationType.practiceCreated,
+  PracticeFinished: NotificationType.updatePracticeFinish,
   PracticeCheckinActivity: NotificationType.updatePracticeCheckin,
   PartnerCheckinActivity: NotificationType.updatePracticeCheckin,
   PracticeUpdateActivity: NotificationType.updatePractice,
   PartnerUpdateActivity: NotificationType.updatePractice,
-  PracticeCreated: NotificationType.practiceCreated,
-  comment_reply: NotificationType.commentReply,
-  Mention: NotificationType.mention,
-  BuddyRequest: NotificationType.buddyRequest,
-  BuddyRequestFollower: NotificationType.buddyRequestFollower,
-  BuddyAccepted: NotificationType.buddyAccepted,
 };
 
 function normalizeNotificationType(backendType: string): INotificationData["type"] {


### PR DESCRIPTION
---  
## Why is this necessary?  
- 為了提升程式碼的一致性，需對通知類型進行統一。  
- 確保前後端的命名規範一致，以避免潛在的錯誤。  
- 收窄型別定義有助於提高類型安全性，減少未來的維護成本。  

## How does it address?  
- 將 mobile BACKEND_TYPE_MAP 的值型別收窄為 NotificationTypeType。  
- 對 BACKEND_TYPE_MAP 的命名進行調整，使其符合後端的 PascalCase 命名規範。  
- 進行代碼重構，提升可讀性和可維護性。  