### PR TITLE
fix(practice): 處理使用者資料中的可選 customId

### DIFF
--- a/apps/product/src/app/[locale]/practices/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/practices/[id]/page.tsx
@@ -494,7 +494,7 @@ export default function PracticeDetailPage() {
                   id: practiceData.data.user.id,
                   name: practiceData.data.user.name,
                   photoURL: practiceData.data.user.photoURL,
-                  customId: practiceData.data.user.customId,
+                  customId: (practiceData.data.user as { customId?: string | null }).customId ?? undefined,
                   date: creatorDate,
                 }
               : undefined,


### PR DESCRIPTION
## Why is this necessary?

1. 使用者資料中可能包含可選的 customId，這對於某些功能的正常運作至關重要。
2. 如果不處理這個可選欄位，可能會導致資料不一致或錯誤。
3. 確保系統能夠正確處理不同情況下的使用者資料，提高穩定性和可靠性。

## How does it address?

1. 在程式碼中新增邏輯以處理可選的 customId 欄位。
2. 確保在讀取和寫入使用者資料時，正確檢查 customId 的存在性。
3. 進行測試以驗證在有和沒有 customId 的情況下系統的行為。