### PR TITLE
feat(island): 過濾海洋地圖用戶列表以顯示僅有練習的用戶  

### DIFF
--- a/apps/product/src/components/island/island-canvas.tsx
+++ b/apps/product/src/components/island/island-canvas.tsx
@@ -103,6 +103,7 @@ export default function IslandCanvas({ islandData, identifier }: IslandCanvasPro
   const { data: usersResponse, isLoading: usersLoading } = useUsers({
     page: 1,
     pageSize: 30,
+    hasPractices: true,
   });
 
   // 空島/未測驗 CTA 只給島主本人（訪客不顯示，spec「訪客看空島」）

--- a/packages/api/src/services/user-hooks.ts
+++ b/packages/api/src/services/user-hooks.ts
@@ -38,6 +38,7 @@ export const useUsers = (params?: IGetUsersParams) => {
         positionList: params?.positionList ?? undefined,
         location: params?.location ?? undefined,
         search: params?.search ?? undefined,
+        hasPractices: params?.hasPractices ? "true" : undefined,
       },
     },
   });

--- a/packages/api/src/services/user-hooks.ts
+++ b/packages/api/src/services/user-hooks.ts
@@ -38,7 +38,7 @@ export const useUsers = (params?: IGetUsersParams) => {
         positionList: params?.positionList ?? undefined,
         location: params?.location ?? undefined,
         search: params?.search ?? undefined,
-        hasPractices: params?.hasPractices ? "true" : undefined,
+        hasPractices: params?.hasPractices !== undefined ? String(params.hasPractices) : undefined,
       },
     },
   });

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -94,6 +94,7 @@ export interface IGetUsersParams {
   positionList?: string | null;
   location?: string | null;
   search?: string | null;
+  hasPractices?: boolean;
 }
 
 // ============================================================================
@@ -113,6 +114,7 @@ export const getUsers = async (params?: IGetUsersParams) => {
         positionList: params?.positionList ?? undefined,
         location: params?.location ?? undefined,
         search: params?.search ?? undefined,
+        hasPractices: params?.hasPractices ? "true" : undefined,
       },
     },
   });

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -114,7 +114,7 @@ export const getUsers = async (params?: IGetUsersParams) => {
         positionList: params?.positionList ?? undefined,
         location: params?.location ?? undefined,
         search: params?.search ?? undefined,
-        hasPractices: params?.hasPractices ? "true" : undefined,
+        hasPractices: params?.hasPractices !== undefined ? String(params.hasPractices) : undefined,
       },
     },
   });

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -21611,6 +21611,8 @@ export interface paths {
                     location?: string;
                     /** @description 搜尋關鍵字 */
                     search?: string;
+                    /** @description 是否只顯示有主題實踐的用戶 */
+                    hasPractices?: string;
                 };
                 header?: never;
                 path?: never;


### PR DESCRIPTION
---  
## Why is this necessary?  
- 需要改善用戶列表的可讀性，避免顯示不相關的用戶。  
- 讓用戶能夠更快找到有練習的用戶，提升使用體驗。  
- 增強海洋地圖的功能性，使其更符合用戶需求。  

## How does it address?  
- 實現了一個過濾器，僅顯示有練習的用戶。  
- 修改了用戶列表的顯示邏輯，以過濾不符合條件的用戶。  
- 測試了過濾功能，確保其正確性和穩定性。  