### PR TITLE
fix(api): 修正 API 以接受可為 null 的結果數據於回應結構中  

### DIFF
--- a/packages/api/src/__tests__/cohort.test.ts
+++ b/packages/api/src/__tests__/cohort.test.ts
@@ -241,6 +241,15 @@ describe("Lighthouse API runtime schemas", () => {
     expect(responses.every((result) => result.success)).toBe(true);
   });
 
+  it("accepts null outcome data when snapshot has not been generated", () => {
+    const result = lighthouseOutcomeResponseSchema.safeParse({
+      success: true,
+      data: null,
+      timestamp,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("whitelists learner and organization-member response fields", () => {
     const learners = lighthouseCohortMembersResponseSchema.parse({
       success: true,

--- a/packages/api/src/services/cohort.ts
+++ b/packages/api/src/services/cohort.ts
@@ -171,14 +171,16 @@ export const lighthouseFocusResponseSchema = apiSuccessSchema(
 );
 
 export const lighthouseOutcomeResponseSchema = apiSuccessSchema(
-  z.object({
-    cohortId: z.number().int().positive(),
-    completedCount: z.number().int().nonnegative(),
-    enrolledCount: z.number().int().nonnegative(),
-    sustainedParticipationCount: z.number().int().nonnegative(),
-    sustainedParticipationRate: z.number().min(0).max(1),
-    computedAt: z.string().datetime(),
-  })
+  z
+    .object({
+      cohortId: z.number().int().positive(),
+      completedCount: z.number().int().nonnegative(),
+      enrolledCount: z.number().int().nonnegative(),
+      sustainedParticipationCount: z.number().int().nonnegative(),
+      sustainedParticipationRate: z.number().min(0).max(1),
+      computedAt: z.string().datetime(),
+    })
+    .nullable()
 );
 
 const cohortFeedCommentPreviewUserSchema = z.object({


### PR DESCRIPTION
---  
## Why is this necessary?  
- 目前的 API 回應結構不允許結果數據為 null，這可能導致不必要的錯誤。  
- 有些情況下，結果數據可能不存在，應該允許這種情況。  
- 修正此問題可以提高 API 的靈活性和穩定性。  

## How does it address?  
- 更新了 API 的回應結構，允許結果數據為 null。  
- 修改了相關的驗證邏輯，以確保在結果數據為 null 時不會產生錯誤。  
- 提供了相應的單元測試，以驗證此變更的正確性。  