### PR TITLE
fix(cohort): 允許 IShowcaseCheckIn 中的 note 為可空以符合 API 架構  

### DIFF
--- a/apps/mobile/components/showcase/CheckInShowcaseCard.tsx
+++ b/apps/mobile/components/showcase/CheckInShowcaseCard.tsx
@@ -121,7 +121,7 @@ export function CheckInShowcaseCard({
               taskTitle={practice.title}
               date={checkin_date}
               mood={frontendMood}
-              content={note}
+              content={note ?? ""}
               tags={tags ?? []}
               images={[]}
               titleColor={colors.basic.white}

--- a/apps/mobile/hooks/useFeed.ts
+++ b/apps/mobile/hooks/useFeed.ts
@@ -19,7 +19,7 @@ export interface IShowcaseCheckIn {
   id: string;
   checkin_date: string;
   mood: ApiMoodType;
-  note: string;
+  note: string | null;
   tags: string[];
   image_urls: string[];
   created_at: string;

--- a/apps/product/src/components/lighthouse/cohort-feed.tsx
+++ b/apps/product/src/components/lighthouse/cohort-feed.tsx
@@ -34,7 +34,7 @@ function CoachFeedItem({
     id: string;
     checkinDate: string;
     mood: string | null;
-    note: string;
+    note: string | null;
     tags: string[];
     imageUrls: string[];
     createdAt: string;

--- a/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
+++ b/apps/product/src/components/showcase/CheckInShowcaseCard.tsx
@@ -171,7 +171,7 @@ export function CheckInShowcaseCard(props: CheckInShowcaseCardProps) {
               taskTitle={practice.title}
               date={checkin_date}
               mood={frontendMood}
-              content={note}
+              content={note ?? ""}
               tags={tags ?? []}
               images={[]}
               showTape={false}

--- a/packages/api/src/services/feed-hooks.ts
+++ b/packages/api/src/services/feed-hooks.ts
@@ -22,7 +22,7 @@ export interface IShowcaseCheckIn {
   id: string;
   checkin_date: string;
   mood: ApiMoodType;
-  note: string;
+  note: string | null;
   tags: string[];
   image_urls: string[];
   created_at: string;


### PR DESCRIPTION
---  
## Why is this necessary?  
- 目前的 IShowcaseCheckIn 結構不符合 API 的定義。  
- API 允許 note 欄位為可空，但現有實作不支持。  
- 修正此問題可以避免在與 API 交互時出現錯誤。  

## How does it address?  
- 更新 IShowcaseCheckIn 的定義，允許 note 欄位為可空。  
- 確保與 API 的一致性，提升系統的穩定性。  
- 減少未來因不符合 API 而產生的潛在錯誤。  