### PR TITLE
feat(future-letter): 時間軸改版為垂直/精簡雙視圖，比照設計稿

### DIFF
--- a/.claude/skills/implement-from-prototype/SKILL.md
+++ b/.claude/skills/implement-from-prototype/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: implement-from-prototype
+description: 依 Claude Design / Figma 匯出的 standalone HTML prototype 實作 UI 時，從 prototype 實際渲染結果精確萃取 DOM/CSS 數值再轉 React，不要用截圖用眼睛比對
+---
+
+# Implement From Prototype
+
+依設計稿（Claude Design、Figma 匯出的 standalone HTML 等）實作 UI 元件時，禁止只憑截圖肉眼比對顏色/尺寸/間距後憑印象寫 CSS。這樣做出來的東西看起來「差不多」但實際數值都是猜的，跟設計稿有落差，使用者要一輪一輪來回糾正才會抓到準確值。
+
+正確做法：把 prototype 實際跑起來，用瀏覽器 JS 直接讀取渲染後的 DOM 與 computed style，拿到真正的數值，再照著轉成 React + Tailwind。
+
+## 適用時機
+
+- 使用者提供 Claude Design canvas 連結、Figma 匯出的 standalone HTML 檔案、或任何「照著這個畫面做」的 prototype
+- 要實作/修正的是視覺細節（顏色、尺寸、間距、漸層、陰影），不是純邏輯
+
+## 步驟 1：讓 prototype 真正渲染出來
+
+standalone HTML 檔案通常是巨大的 bundle（可能好幾 MB），不能直接用 `file://` 開（瀏覽器自動化工具通常會擋），也不要只用 `grep`/`cat` 讀原始檔內容當作依據——內容是 build 過的 bundle，肉眼讀不出實際渲染結果。
+
+```bash
+mkdir -p /tmp/prototype-serve
+cp "<使用者提供的 .html 路徑>" /tmp/prototype-serve/prototype.html
+cd /tmp/prototype-serve && python3 -m http.server 8899 &
+```
+
+用瀏覽器工具（claude-in-chrome）導到 `http://localhost:8899/prototype.html`，等待完全渲染（這類 bundle 通常有 "Unpacking..." 的載入動畫，要等它跑完）。
+
+## 步驟 2：用 JS 精確萃取數值，不要用截圖比對
+
+先用 `computer` 工具截圖找到目標元件大概的螢幕座標，接著用 `javascript_tool` 執行 JS，透過 `document.elementFromPoint(x, y)` 抓到實際 DOM 節點，再用 `getComputedStyle()` 讀出真正的 CSS 數值：
+
+```js
+const el = document.elementFromPoint(x, y);
+const cs = getComputedStyle(el);
+JSON.stringify({
+  bg: cs.backgroundColor,
+  borderRadius: cs.borderRadius,
+  borderStyle: cs.borderStyle,
+  borderColor: cs.borderColor,
+  borderWidth: cs.borderWidth,
+  fontSize: cs.fontSize,
+  color: cs.color,
+  w: Math.round(el.getBoundingClientRect().width),
+  h: Math.round(el.getBoundingClientRect().height),
+});
+```
+
+**重點技巧**：
+
+- 這類 bundle 常把 class name 做成無語意的 hash（如 `scp0`），不能靠 class name 找元件，要用座標、文字內容、或元素尺寸範圍去篩選（例如「找出寬高都 < 30px 且 border-radius 非 0 的元素」抓出所有小圓點）。
+- 一次遍歷同一列的所有子節點（`row.children`），逐一印出尺寸/顏色，比對出漸層/分級規律（例如本專案時間軸元件實測出的三階圓點：最舊 8px 淺色、中間 9-10px 中teal、今天 14px 深teal、未來信 18px 米白虛線框）。
+- 文字類樣式（月份標籤等）用「找出符合特定文字 pattern 且無子元素的節點」（例如 `/^\d+月$/`）比座標更穩定。
+- 回傳值若被系統判定像 cookie/query string 格式會被擋（`[BLOCKED: Cookie/query string data]`），改成回傳結構化 JSON（純數值/顏色字串），不要直接吐一大包 outerHTML。
+- 漸層/陰影等視覺效果，prototype 匯出工具有時會用非典型技巧實作（例如虛線用 `repeating-linear-gradient` 而非 `border-style: dashed`）——這是匯出工具的實作細節，轉譯到真正的網站時，用該技巧對應的正規 CSS/Tailwind 寫法（例如直接用 `border-dashed`）即可，不必照抄非典型手法。
+
+## 步驟 3：轉譯成 React + Tailwind
+
+拿到精確數值後才開始寫元件：
+
+- 顏色直接用十六進位或 rgb 值寫成 Tailwind 任意值（`bg-[#0E9E99]`），不要用最接近的 Tailwind 預設色號去猜
+- 尺寸優先對應 Tailwind 預設 scale（例如 8px = `size-2`），對不上時用任意值（`size-[9px]`）
+- 完成後截圖跟 prototype 原圖並排比對，確認顏色/尺寸/間距一致才算完成
+
+## 注意事項
+
+- 不要只做到「看起來像」就停手，使用者要的是實際數值一致，不是風格相似
+- prototype 用完記得關掉本地 HTTP server（`lsof -ti:8899 | xargs kill -9`）

--- a/apps/product/e2e/future-letter/helpers.ts
+++ b/apps/product/e2e/future-letter/helpers.ts
@@ -18,3 +18,9 @@ export async function nodeX(locator: Locator): Promise<number> {
   if (!box) throw new Error("Expected timeline node to have a bounding box");
   return box.x + box.width / 2;
 }
+
+export async function nodeY(locator: Locator): Promise<number> {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error("Expected timeline node to have a bounding box");
+  return box.y + box.height / 2;
+}

--- a/apps/product/e2e/future-letter/timeline-summary.spec.ts
+++ b/apps/product/e2e/future-letter/timeline-summary.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures";
-import { deliveryDate, FOOTPRINTS_PATH, HOME_PATH, nodeX, privacySentinel } from "./helpers";
+import { deliveryDate, FOOTPRINTS_PATH, HOME_PATH, nodeY, privacySentinel } from "./helpers";
 
 test("full timeline and homepage summary share ordered date coordinates and state", async ({
   page,
@@ -30,8 +30,10 @@ test("full timeline and homepage summary share ordered date coordinates and stat
   await expect(opened).toBeVisible();
   await expect(today).toBeVisible();
   await expect(scheduled).toBeVisible();
-  expect(await nodeX(opened)).toBeLessThan(await nodeX(today));
-  expect(await nodeX(today)).toBeLessThan(await nodeX(scheduled));
+  // The full footprints timeline stacks vertically: pending future letters at the
+  // top, "today" in the middle, past/delivered events below.
+  expect(await nodeY(scheduled)).toBeLessThan(await nodeY(today));
+  expect(await nodeY(today)).toBeLessThan(await nodeY(opened));
 
   const scheduledDate = await scheduled.getAttribute("data-date");
   expect(scheduledDate).toBeTruthy();

--- a/apps/product/src/app/[locale]/(with-layout)/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/page.tsx
@@ -287,7 +287,8 @@ export default function HomePage() {
               onSearch={handleSearch}
             />
           </div>
-          <ResonanceCarousel />
+          {/* Temporarily disabled per product request */}
+          {false && <ResonanceCarousel />}
 
           {isShowcaseLoading && feedItems.length === 0 ? (
             <div className="flex flex-col gap-3">

--- a/apps/product/src/components/future-letter/compact-timeline-strip.tsx
+++ b/apps/product/src/components/future-letter/compact-timeline-strip.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { cn } from "@daodao/ui/lib/utils";
+import { ChevronsRight } from "lucide-react";
+import type { TimelineCoordinate } from "./timeline-model";
+
+interface CompactTimelineStripProps {
+  coordinates: TimelineCoordinate[];
+  onNodeClick?: (node: TimelineCoordinate) => void;
+}
+
+const isFutureLetterKind = (kind: TimelineCoordinate["kind"]) =>
+  kind === "scheduled" || kind === "delivered-unopened" || kind === "opened";
+
+export function CompactTimelineStrip({ coordinates, onNodeClick }: CompactTimelineStripProps) {
+  const todayIndex = coordinates.findIndex((node) => node.kind === "today");
+
+  return (
+    <div className="flex items-center gap-1 px-6 py-5" data-testid="home-timeline-summary">
+      {coordinates.map((node, index) => {
+        const isToday = node.kind === "today";
+        const isFuture = isFutureLetterKind(node.kind) || (todayIndex >= 0 && index > todayIndex);
+        const isPastConnector = todayIndex < 0 || index < todayIndex;
+
+        return (
+          <div key={node.id} className="flex items-center">
+            {index > 0 && (
+              <div
+                className={cn(
+                  "h-px w-6",
+                  isPastConnector || (todayIndex >= 0 && index === todayIndex)
+                    ? "bg-[#5FAFAC]"
+                    : "border-t border-dashed border-[#E4B84D] bg-transparent"
+                )}
+                aria-hidden="true"
+              />
+            )}
+            <button
+              type="button"
+              data-testid="timeline-node"
+              data-kind={node.kind}
+              data-date={node.date.slice(0, 10)}
+              data-node-id={node.id}
+              onClick={() => onNodeClick?.(node)}
+              aria-label={node.monthLabel ? `${node.monthLabel} ${node.dateLabel}` : node.dateLabel}
+              className="relative flex items-center justify-center"
+            >
+              {node.monthLabel && !isFuture && (
+                <span className="absolute -top-6 whitespace-nowrap text-[11px] text-[#295E5C]/70">
+                  {node.monthLabel}
+                </span>
+              )}
+              <span
+                className={cn(
+                  "rounded-full transition-colors",
+                  isToday
+                    ? "size-6 border-2 border-[#0D7C78] bg-[#0D7C78]"
+                    : isFuture
+                      ? "size-4 border-2 border-dashed border-[#E4B84D] bg-white"
+                      : "size-3.5 bg-[#5FAFAC]"
+                )}
+              />
+            </button>
+          </div>
+        );
+      })}
+      <div
+        className="ml-2 border-t border-dashed border-[#E4B84D]"
+        style={{ width: 24 }}
+        aria-hidden="true"
+      />
+      <ChevronsRight className="size-5 shrink-0 text-[#295E5C]/60" aria-hidden="true" />
+    </div>
+  );
+}

--- a/apps/product/src/components/future-letter/compact-timeline-strip.tsx
+++ b/apps/product/src/components/future-letter/compact-timeline-strip.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import { useLocale } from "@daodao/i18n";
 import { cn } from "@daodao/ui/lib/utils";
 import { ChevronsRight } from "lucide-react";
+import { useMemo } from "react";
 import type { TimelineCoordinate } from "./timeline-model";
 
 interface CompactTimelineStripProps {
   coordinates: TimelineCoordinate[];
   onNodeClick?: (node: TimelineCoordinate) => void;
 }
-
-const isFutureLetterKind = (kind: TimelineCoordinate["kind"]) =>
-  kind === "scheduled" || kind === "delivered-unopened" || kind === "opened";
 
 /** Past dots fade smaller/lighter the further back they sit from "today",
  *  matching the reference prototype's 3-tier size/color ramp. */
@@ -21,17 +20,17 @@ function pastDotClass(distanceFromToday: number): string {
 }
 
 export function CompactTimelineStrip({ coordinates, onNodeClick }: CompactTimelineStripProps) {
+  const locale = useLocale();
+  const monthFormatter = useMemo(() => new Intl.DateTimeFormat(locale, { month: "short" }), [locale]);
   const todayIndex = coordinates.findIndex((node) => node.kind === "today");
 
   return (
     <div className="flex items-center gap-1 px-6 py-5" data-testid="home-timeline-summary">
       {coordinates.map((node, index) => {
         const isToday = node.kind === "today";
-        const isFuture = isFutureLetterKind(node.kind) || (todayIndex >= 0 && index > todayIndex);
+        const isFuture = todayIndex >= 0 && index > todayIndex;
         const isPastConnector = todayIndex < 0 || index < todayIndex;
-        const monthShortLabel = node.monthLabel
-          ? `${new Date(node.date).getMonth() + 1}月`
-          : null;
+        const monthShortLabel = node.monthLabel ? monthFormatter.format(new Date(node.date)) : null;
 
         return (
           <div key={node.id} className="flex items-center">

--- a/apps/product/src/components/future-letter/compact-timeline-strip.tsx
+++ b/apps/product/src/components/future-letter/compact-timeline-strip.tsx
@@ -12,6 +12,14 @@ interface CompactTimelineStripProps {
 const isFutureLetterKind = (kind: TimelineCoordinate["kind"]) =>
   kind === "scheduled" || kind === "delivered-unopened" || kind === "opened";
 
+/** Past dots fade smaller/lighter the further back they sit from "today",
+ *  matching the reference prototype's 3-tier size/color ramp. */
+function pastDotClass(distanceFromToday: number): string {
+  if (distanceFromToday >= 5) return "size-2 bg-[#89DAD7]";
+  if (distanceFromToday >= 3) return "size-[9px] bg-[#0E9E99]";
+  return "size-2.5 bg-[#0E9E99]";
+}
+
 export function CompactTimelineStrip({ coordinates, onNodeClick }: CompactTimelineStripProps) {
   const todayIndex = coordinates.findIndex((node) => node.kind === "today");
 
@@ -21,6 +29,9 @@ export function CompactTimelineStrip({ coordinates, onNodeClick }: CompactTimeli
         const isToday = node.kind === "today";
         const isFuture = isFutureLetterKind(node.kind) || (todayIndex >= 0 && index > todayIndex);
         const isPastConnector = todayIndex < 0 || index < todayIndex;
+        const monthShortLabel = node.monthLabel
+          ? `${new Date(node.date).getMonth() + 1}月`
+          : null;
 
         return (
           <div key={node.id} className="flex items-center">
@@ -29,8 +40,8 @@ export function CompactTimelineStrip({ coordinates, onNodeClick }: CompactTimeli
                 className={cn(
                   "h-px w-6",
                   isPastConnector || (todayIndex >= 0 && index === todayIndex)
-                    ? "bg-[#5FAFAC]"
-                    : "border-t border-dashed border-[#E4B84D] bg-transparent"
+                    ? "bg-[#295E5C]/60"
+                    : "border-t border-dashed border-[#C79E0A] bg-transparent"
                 )}
                 aria-hidden="true"
               />
@@ -42,34 +53,34 @@ export function CompactTimelineStrip({ coordinates, onNodeClick }: CompactTimeli
               data-date={node.date.slice(0, 10)}
               data-node-id={node.id}
               onClick={() => onNodeClick?.(node)}
-              aria-label={node.monthLabel ? `${node.monthLabel} ${node.dateLabel}` : node.dateLabel}
-              className="relative flex items-center justify-center"
+              aria-label={monthShortLabel ? `${monthShortLabel} ${node.dateLabel}` : node.dateLabel}
+              className="relative flex flex-col items-center justify-center"
             >
-              {node.monthLabel && !isFuture && (
-                <span className="absolute -top-6 whitespace-nowrap text-[11px] text-[#295E5C]/70">
-                  {node.monthLabel}
-                </span>
-              )}
               <span
                 className={cn(
                   "rounded-full transition-colors",
                   isToday
-                    ? "size-6 border-2 border-[#0D7C78] bg-[#0D7C78]"
+                    ? "size-3.5 bg-[#0D7C78]"
                     : isFuture
-                      ? "size-4 border-2 border-dashed border-[#E4B84D] bg-white"
-                      : "size-3.5 bg-[#5FAFAC]"
+                      ? "size-[18px] border-2 border-dashed border-[#C79E0A] bg-[#FFFDF0]"
+                      : pastDotClass(todayIndex >= 0 ? todayIndex - index : 0)
                 )}
               />
+              {monthShortLabel && !isFuture && (
+                <span className="mt-2 whitespace-nowrap text-[10px] text-[#7FA3A6]">
+                  {monthShortLabel}
+                </span>
+              )}
             </button>
           </div>
         );
       })}
       <div
-        className="ml-2 border-t border-dashed border-[#E4B84D]"
+        className="ml-2 border-t border-dashed border-[#C79E0A]"
         style={{ width: 24 }}
         aria-hidden="true"
       />
-      <ChevronsRight className="size-5 shrink-0 text-[#295E5C]/60" aria-hidden="true" />
+      <ChevronsRight className="size-5 shrink-0 text-[#295E5C]/70" aria-hidden="true" />
     </div>
   );
 }

--- a/apps/product/src/components/future-letter/future-letter-dialog.tsx
+++ b/apps/product/src/components/future-letter/future-letter-dialog.tsx
@@ -256,7 +256,7 @@ export function FutureLetterDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleDialogOpenChange}>
-      <DialogContent className="max-h-[90vh] w-[calc(100%-2rem)] max-w-lg overflow-y-auto p-6">
+      <DialogContent className="max-h-[90vh] w-[calc(100%-2rem)] max-w-lg sm:max-w-lg overflow-y-auto p-6">
         <DialogHeader className="items-start pt-0 text-left">
           <DialogTitle className="text-left text-xl font-bold">{t("dialog_title")}</DialogTitle>
           <DialogDescription>{t("dialog_description")}</DialogDescription>

--- a/apps/product/src/components/future-letter/future-letter-timeline.tsx
+++ b/apps/product/src/components/future-letter/future-letter-timeline.tsx
@@ -15,9 +15,9 @@ import { useDialog } from "@daodao/ui/hooks/use-dialog";
 import { format, parseISO } from "date-fns";
 import { Mail, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { HorizontalTimeline } from "./horizontal-timeline";
 import { LetterDetailCard } from "./letter-detail-card";
-import { buildTimelineCoordinates, type TimelineCoordinate } from "./timeline-model";
+import { buildFootprintTimeline } from "./timeline-model";
+import { VerticalTimeline } from "./vertical-timeline";
 
 type LifecycleLetter = FutureLetterType & { sentAt?: string | null; openedAt?: string | null };
 
@@ -37,7 +37,6 @@ export function FutureLetterTimeline({
   const searchParams = useSearchParams();
   const { openWarningDialog } = useDialog();
   const deepLinkedLetterId = searchParams.get("futureLetterId");
-  const focusDate = searchParams.get("focusDate");
   const [pendingRouteTarget, setPendingRouteTarget] = useState<string | null | undefined>(
     undefined
   );
@@ -53,18 +52,13 @@ export function FutureLetterTimeline({
     () => (lettersQuery.data?.flatMap((page) => page.data) ?? []) as LifecycleLetter[],
     [lettersQuery.data]
   );
-  const coordinates = useMemo(
-    () => buildTimelineCoordinates(timelineEntries, letters, new Date()),
+  const { futureLetters, pastGroups } = useMemo(
+    () => buildFootprintTimeline(timelineEntries, letters, new Date()),
     [letters, timelineEntries]
   );
   const selectedLetter =
     pendingRouteTarget === undefined
       ? letters.find((letter) => letter.id === deepLinkedLetterId)
-      : undefined;
-  const focusId = deepLinkedLetterId
-    ? `letter-${deepLinkedLetterId}`
-    : focusDate
-      ? coordinates.find((node) => node.date.startsWith(focusDate))?.id
       : undefined;
 
   const refresh = useCallback(
@@ -83,12 +77,11 @@ export function FutureLetterTimeline({
     if (pendingRouteTarget === deepLinkedLetterId) setPendingRouteTarget(undefined);
   }, [deepLinkedLetterId, pendingRouteTarget]);
 
-  const handleNodeClick = (node: TimelineCoordinate) => {
-    if (!node.letterId) return;
-    setPendingRouteTarget(node.letterId);
+  const handleLetterClick = (letterId: string, date: string) => {
+    setPendingRouteTarget(letterId);
     const params = new URLSearchParams(searchParams.toString());
-    params.set("futureLetterId", node.letterId);
-    params.set("focusDate", node.date.slice(0, 10));
+    params.set("futureLetterId", letterId);
+    params.set("focusDate", date.slice(0, 10));
     router.replace(`/me/footprints?${params.toString()}`, { scroll: false });
   };
 
@@ -148,20 +141,9 @@ export function FutureLetterTimeline({
 
   return (
     <section className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-bold text-text-dark">{t("section_title")}</h2>
-          <p className="text-sm text-text-secondary">{t("timeline_quiet_description")}</p>
-        </div>
-        <Button
-          onClick={onWriteLetter}
-          disabled={isWriteLetterDisabled}
-          variant="outline"
-          className="rounded-full border-logo-cyan text-logo-cyan hover:bg-[#E7FAF7] hover:text-logo-cyan"
-        >
-          <Mail className="size-4" />
-          {t("cta_button")}
-        </Button>
+      <div>
+        <h2 className="text-lg font-bold text-text-dark">{t("section_title")}</h2>
+        <p className="text-sm text-text-secondary">{t("timeline_quiet_description")}</p>
       </div>
 
       {isLoading && (
@@ -169,13 +151,18 @@ export function FutureLetterTimeline({
       )}
       {hasError && <p className="py-8 text-center text-sm text-red">{t("timeline_error")}</p>}
       {!isLoading && !hasError && (
-        <div className="rounded-3xl border border-border bg-white py-3">
-          <HorizontalTimeline
-            coordinates={coordinates}
-            focusId={focusId}
-            onNodeClick={handleNodeClick}
-          />
-        </div>
+        <VerticalTimeline
+          futureLetters={futureLetters}
+          pastGroups={pastGroups}
+          onWriteLetter={onWriteLetter}
+          isWriteLetterDisabled={isWriteLetterDisabled}
+          onLetterClick={handleLetterClick}
+          onDeleteLetter={(letterId) => {
+            const letter = letters.find((item) => item.id === letterId);
+            if (letter) void handleDelete(letter);
+          }}
+          focusLetterId={deepLinkedLetterId ?? undefined}
+        />
       )}
 
       {selectedLetter?.status === "scheduled" && (

--- a/apps/product/src/components/future-letter/future-letter-timeline.tsx
+++ b/apps/product/src/components/future-letter/future-letter-timeline.tsx
@@ -37,6 +37,7 @@ export function FutureLetterTimeline({
   const searchParams = useSearchParams();
   const { openWarningDialog } = useDialog();
   const deepLinkedLetterId = searchParams.get("futureLetterId");
+  const focusDate = searchParams.get("focusDate");
   const [pendingRouteTarget, setPendingRouteTarget] = useState<string | null | undefined>(
     undefined
   );
@@ -122,10 +123,12 @@ export function FutureLetterTimeline({
         toast.error(t("letter_delete_failed"));
         return;
       }
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete("futureLetterId");
-      setPendingRouteTarget(null);
-      router.replace(`/me/footprints?${params.toString()}`, { scroll: false });
+      if (letter.id === deepLinkedLetterId) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.delete("futureLetterId");
+        setPendingRouteTarget(null);
+        router.replace(`/me/footprints?${params.toString()}`, { scroll: false });
+      }
       toast.success(t("letter_deleted"));
       await refresh();
     } catch (error) {
@@ -162,6 +165,7 @@ export function FutureLetterTimeline({
             if (letter) void handleDelete(letter);
           }}
           focusLetterId={deepLinkedLetterId ?? undefined}
+          focusDate={focusDate ?? undefined}
         />
       )}
 

--- a/apps/product/src/components/future-letter/home-timeline-summary.tsx
+++ b/apps/product/src/components/future-letter/home-timeline-summary.tsx
@@ -3,7 +3,7 @@
 import { useAllMyTimeline } from "@daodao/api";
 import { useRouter } from "@daodao/i18n/navigation";
 import { useMemo } from "react";
-import { HorizontalTimeline } from "./horizontal-timeline";
+import { CompactTimelineStrip } from "./compact-timeline-strip";
 import {
   buildTimelineCoordinates,
   getTimelineSummary,
@@ -34,8 +34,8 @@ export function HomeTimelineSummary() {
   };
 
   return (
-    <div className="relative z-[22] -mt-8">
-      <HorizontalTimeline coordinates={summary} summary onNodeClick={navigate} />
+    <div className="relative z-[22] -mt-8 flex justify-center md:pl-44">
+      <CompactTimelineStrip coordinates={summary} onNodeClick={navigate} />
     </div>
   );
 }

--- a/apps/product/src/components/future-letter/timeline-model.ts
+++ b/apps/product/src/components/future-letter/timeline-model.ts
@@ -108,6 +108,155 @@ export function buildTimelineCoordinates(
   });
 }
 
+export interface FootprintLetterCard {
+  id: string;
+  letterId: string;
+  date: string;
+  status: "scheduled" | "delivered";
+  opened: boolean;
+  daysRemaining?: number;
+  sentAt?: string | null;
+  practiceTitle?: string | null;
+}
+
+export interface FootprintEventCard {
+  id: string;
+  kind: "check-in" | "milestone" | "learning-dna";
+  date: string;
+  title: string;
+  description: string | null;
+}
+
+export type FootprintTimelineItem =
+  | { type: "letter"; card: FootprintLetterCard }
+  | { type: "event"; card: FootprintEventCard }
+  | { type: "collapsed-check-ins"; id: string; items: FootprintEventCard[] };
+
+export interface FootprintMonthGroup {
+  key: string;
+  label: string;
+  items: FootprintTimelineItem[];
+}
+
+export interface FootprintTimeline {
+  futureLetters: FootprintLetterCard[];
+  pastGroups: FootprintMonthGroup[];
+}
+
+function toLetterCard(
+  entryLetterId: string,
+  entryDate: string,
+  status: "scheduled" | "delivered",
+  now: Date,
+  lettersById: Map<string, FutureLetterType>
+): FootprintLetterCard {
+  const letter = lettersById.get(entryLetterId) as
+    | (FutureLetterType & { sentAt?: string | null; openedAt?: string | null })
+    | undefined;
+  return {
+    id: `letter-${entryLetterId}`,
+    letterId: entryLetterId,
+    date: entryDate,
+    status,
+    opened: Boolean(letter?.openedAt),
+    daysRemaining:
+      status === "scheduled"
+        ? Math.max(0, differenceInCalendarDays(parseISO(entryDate), startOfDay(now)))
+        : undefined,
+    sentAt: letter?.sentAt ?? letter?.createdAt ?? null,
+    practiceTitle: letter?.practice?.title ?? null,
+  };
+}
+
+/** Build the vertical "footprints" timeline: upcoming/pending letters, then a mixed
+ *  past feed (delivered letters, check-ins, milestones, learning-DNA) grouped by month,
+ *  with note-less check-ins collapsed into a single row per group. */
+export function buildFootprintTimeline(
+  entries: TimelineEntryType[],
+  letters: FutureLetterType[],
+  now: Date
+): FootprintTimeline {
+  const lettersById = new Map(letters.map((letter) => [letter.id, letter]));
+
+  const futureLetters: FootprintLetterCard[] = letters
+    .filter((letter) => letter.status === "scheduled" && letter.deliverAt)
+    .sort((a, b) => (b.deliverAt as string).localeCompare(a.deliverAt as string))
+    .map((letter) => toLetterCard(letter.id, letter.deliverAt as string, "scheduled", now, lettersById));
+
+  const pastGroups: FootprintMonthGroup[] = [];
+  const groupsByKey = new Map<string, FootprintMonthGroup>();
+  let bareCheckins: FootprintEventCard[] = [];
+  let bareCheckinsGroupKey: string | undefined;
+
+  const flushBareCheckins = () => {
+    if (bareCheckins.length === 0 || !bareCheckinsGroupKey) return;
+    const group = groupsByKey.get(bareCheckinsGroupKey);
+    if (group) {
+      group.items.push({
+        type: "collapsed-check-ins",
+        id: `collapsed-${bareCheckinsGroupKey}-${group.items.length}`,
+        items: bareCheckins,
+      });
+    }
+    bareCheckins = [];
+  };
+
+  entries.forEach((entry, index) => {
+    const isScheduledLetter =
+      entry.type === "letter" && (entry.meta.status as string | undefined) === "scheduled";
+    if (isScheduledLetter) return;
+
+    const monthKey = format(parseISO(entry.date), "yyyy / MM");
+    if (monthKey !== bareCheckinsGroupKey) flushBareCheckins();
+    if (!groupsByKey.has(monthKey)) {
+      const group: FootprintMonthGroup = { key: monthKey, label: monthKey, items: [] };
+      groupsByKey.set(monthKey, group);
+      pastGroups.push(group);
+    }
+    const group = groupsByKey.get(monthKey) as FootprintMonthGroup;
+
+    if (entry.type === "letter") {
+      const letterId = typeof entry.meta.letterId === "string" ? entry.meta.letterId : undefined;
+      if (!letterId) return;
+      bareCheckinsGroupKey = monthKey;
+      flushBareCheckins();
+      group.items.push({
+        type: "letter",
+        card: toLetterCard(letterId, entry.date, "delivered", now, lettersById),
+      });
+      return;
+    }
+
+    if (entry.type === "check-in" && !entry.description) {
+      bareCheckinsGroupKey = monthKey;
+      bareCheckins.push({
+        id: `event-${entry.type}-${entry.date}-${index}`,
+        kind: entry.type,
+        date: entry.date,
+        title: entry.title,
+        description: entry.description,
+      });
+      return;
+    }
+
+    bareCheckinsGroupKey = monthKey;
+    flushBareCheckins();
+    group.items.push({
+      type: "event",
+      card: {
+        id: `event-${entry.type}-${entry.date}-${index}`,
+        kind: entry.type as "check-in" | "milestone" | "learning-dna",
+        date: entry.date,
+        title: entry.title,
+        description: entry.description,
+      },
+    });
+  });
+  flushBareCheckins();
+
+  return { futureLetters, pastGroups };
+}
+
 export function getTimelineSummary(
   coordinates: TimelineCoordinate[],
   focusId: string | undefined,

--- a/apps/product/src/components/future-letter/vertical-timeline.tsx
+++ b/apps/product/src/components/future-letter/vertical-timeline.tsx
@@ -26,6 +26,7 @@ interface VerticalTimelineProps {
   onLetterClick: (letterId: string, date: string) => void;
   onDeleteLetter: (letterId: string) => void;
   focusLetterId?: string;
+  focusDate?: string;
 }
 
 const eventIconClass: Record<FootprintEventCard["kind"], string> = {
@@ -174,7 +175,13 @@ function DeliveredLetterCard({
 
 function EventCardView({ card }: { card: FootprintEventCard }) {
   return (
-    <div className="rounded-2xl border border-border bg-white p-4">
+    <div
+      data-testid="timeline-node"
+      data-kind={card.kind}
+      data-date={card.date.slice(0, 10)}
+      data-node-id={card.id}
+      className="rounded-2xl border border-border bg-white p-4"
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-2">
           <span
@@ -239,17 +246,19 @@ export function VerticalTimeline({
   onLetterClick,
   onDeleteLetter,
   focusLetterId,
+  focusDate,
 }: VerticalTimelineProps) {
   const t = useTranslations("future_letter");
   const containerRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    if (!focusLetterId) return;
-    const target = containerRef.current?.querySelector<HTMLElement>(
-      `[data-node-id="letter-${focusLetterId}"]`
-    );
+    if (!focusLetterId && !focusDate) return;
+    const selector = focusLetterId
+      ? `[data-node-id="letter-${focusLetterId}"]`
+      : `[data-date="${focusDate}"]`;
+    const target = containerRef.current?.querySelector<HTMLElement>(selector);
     target?.scrollIntoView({ behavior: "instant", block: "center" });
-  }, [focusLetterId]);
+  }, [focusLetterId, focusDate]);
 
   return (
     <div ref={containerRef} data-testid="future-letter-timeline">
@@ -303,6 +312,8 @@ export function VerticalTimeline({
           <span
             data-testid="timeline-node"
             data-kind="today"
+            data-date={new Date().toISOString().slice(0, 10)}
+            data-node-id="today"
             className="flex size-3 items-center justify-center rounded-full bg-logo-cyan ring-4 ring-logo-cyan/20"
           />
         }

--- a/apps/product/src/components/future-letter/vertical-timeline.tsx
+++ b/apps/product/src/components/future-letter/vertical-timeline.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useTranslations } from "@daodao/i18n";
+import { Button } from "@daodao/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@daodao/ui/components/dropdown-menu";
+import { cn } from "@daodao/ui/lib/utils";
+import { format, parseISO } from "date-fns";
+import { CalendarCheck, ChevronDown, Dna, Mail, MoreHorizontal, Sparkles } from "lucide-react";
+import { useLayoutEffect, useRef, useState } from "react";
+import type {
+  FootprintEventCard,
+  FootprintLetterCard,
+  FootprintMonthGroup,
+} from "./timeline-model";
+
+interface VerticalTimelineProps {
+  futureLetters: FootprintLetterCard[];
+  pastGroups: FootprintMonthGroup[];
+  onWriteLetter: () => void;
+  isWriteLetterDisabled?: boolean;
+  onLetterClick: (letterId: string, date: string) => void;
+  onDeleteLetter: (letterId: string) => void;
+  focusLetterId?: string;
+}
+
+const eventIconClass: Record<FootprintEventCard["kind"], string> = {
+  "check-in": "border-logo-cyan bg-white text-logo-cyan",
+  milestone: "border-[#E4B84D] bg-[#FFF6D9] text-[#9A7419]",
+  "learning-dna": "border-[#77A9C4] bg-[#EDF5FA] text-[#4A90B8]",
+};
+
+function EventIcon({ kind }: { kind: FootprintEventCard["kind"] }) {
+  if (kind === "learning-dna") return <Dna className="size-4" />;
+  if (kind === "milestone") return <Sparkles className="size-4" />;
+  return <CalendarCheck className="size-4" />;
+}
+
+function Row({
+  dateLabel,
+  dot,
+  children,
+}: {
+  dateLabel?: string;
+  dot: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex gap-3 pb-4">
+      <div className="w-12 shrink-0 pt-1.5 text-right text-xs leading-tight text-text-secondary">
+        {dateLabel}
+      </div>
+      <div className="relative flex w-6 shrink-0 justify-center">
+        <div className="absolute top-0 bottom-0 w-px bg-[#C9DADA]" aria-hidden="true" />
+        <div className="relative z-10 pt-1">{dot}</div>
+      </div>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+function ScheduledLetterCard({
+  letter,
+  onClick,
+  onDelete,
+}: {
+  letter: FootprintLetterCard;
+  onClick: () => void;
+  onDelete: () => void;
+}) {
+  const t = useTranslations("future_letter");
+  return (
+    <div
+      data-testid="timeline-node"
+      data-kind="scheduled"
+      data-date={letter.date.slice(0, 10)}
+      data-node-id={`letter-${letter.letterId}`}
+      className="rounded-2xl border border-dashed border-[#E4B84D] bg-[#FFFDF5] p-4"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <button type="button" onClick={onClick} className="flex-1 text-left">
+          <div className="flex items-center gap-2">
+            <span className="rounded-full bg-[#FFF6D9] px-2 py-0.5 text-xs font-bold text-[#9A7419]">
+              {t("unopened_label")}
+            </span>
+            <span className="text-xs text-[#B88B23]">
+              {t("days_remaining", { days: letter.daysRemaining ?? 0 })}
+            </span>
+          </div>
+          <p className="mt-2 font-bold text-text-dark">
+            {t("scheduled_countdown", { days: letter.daysRemaining ?? 0 })}
+          </p>
+          <p className="mt-1 text-xs text-text-secondary">
+            {letter.practiceTitle
+              ? t("sent_at_with_practice", {
+                  date: letter.sentAt ? format(parseISO(letter.sentAt), "yyyy/MM/dd") : "",
+                  practice: letter.practiceTitle,
+                })
+              : letter.sentAt
+                ? t("sent_at", { date: format(parseISO(letter.sentAt), "yyyy/MM/dd") })
+                : null}
+          </p>
+        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={t("letter_menu")}
+              className="size-7 shrink-0 text-text-secondary"
+            >
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onDelete} className="text-red">
+              {t("delete_scheduled_title")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}
+
+function DeliveredLetterCard({
+  letter,
+  onClick,
+}: {
+  letter: FootprintLetterCard;
+  onClick: () => void;
+}) {
+  const t = useTranslations("future_letter");
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid="timeline-node"
+      data-kind={letter.opened ? "opened" : "delivered-unopened"}
+      data-date={letter.date.slice(0, 10)}
+      data-node-id={`letter-${letter.letterId}`}
+      className="w-full rounded-2xl border border-[#F0DFA0] bg-[#FFF9E6] p-4 text-left"
+    >
+      <div className="flex items-center gap-2">
+        <span className="rounded-full bg-[#FCDD84] px-2 py-0.5 text-xs font-bold text-text-dark">
+          {t("delivered_badge")}
+        </span>
+        <span className="text-xs text-[#9A7419]">
+          {t("delivered_at", { date: format(parseISO(letter.date), "MM/dd") })}
+        </span>
+        {!letter.opened && (
+          <span className="rounded-full bg-logo-cyan/10 px-2 py-0.5 text-xs font-medium text-logo-cyan">
+            {t("unopened_label")}
+          </span>
+        )}
+      </div>
+      <p className="mt-2 flex items-center gap-2 font-bold text-text-dark">
+        <Mail className="size-4 shrink-0 text-[#9A7419]" />
+        {t("detail_title")}
+      </p>
+      {letter.sentAt && (
+        <p className="mt-1 text-xs text-text-secondary">
+          {t("sent_at", { date: format(parseISO(letter.sentAt), "yyyy/MM/dd") })}
+        </p>
+      )}
+    </button>
+  );
+}
+
+function EventCardView({ card }: { card: FootprintEventCard }) {
+  return (
+    <div className="rounded-2xl border border-border bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <span
+            className={cn(
+              "flex size-6 shrink-0 items-center justify-center rounded-full border-2",
+              eventIconClass[card.kind]
+            )}
+          >
+            <EventIcon kind={card.kind} />
+          </span>
+          <p className="font-bold text-text-dark">{card.title}</p>
+        </div>
+        <span className="shrink-0 text-xs text-text-secondary">
+          {format(parseISO(card.date), "MM/dd")}
+        </span>
+      </div>
+      {card.description && (
+        <p className="mt-2 text-sm leading-relaxed text-text-secondary">{card.description}</p>
+      )}
+    </div>
+  );
+}
+
+function CollapsedCheckins({ items }: { items: FootprintEventCard[] }) {
+  const t = useTranslations("future_letter");
+  const [expanded, setExpanded] = useState(false);
+  if (expanded) {
+    return (
+      <div className="space-y-3">
+        {items.map((item) => (
+          <EventCardView key={item.id} card={item} />
+        ))}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setExpanded(false)}
+          className="text-text-secondary"
+        >
+          <ChevronDown className="size-4 rotate-180" />
+          {t("collapse_action")}
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => setExpanded(true)}
+      className="rounded-full bg-[#F3F6F6] px-4 py-2 text-sm text-text-secondary hover:bg-[#E9EFEF]"
+    >
+      {t("collapsed_count", { count: items.length })}
+    </button>
+  );
+}
+
+export function VerticalTimeline({
+  futureLetters,
+  pastGroups,
+  onWriteLetter,
+  isWriteLetterDisabled,
+  onLetterClick,
+  onDeleteLetter,
+  focusLetterId,
+}: VerticalTimelineProps) {
+  const t = useTranslations("future_letter");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!focusLetterId) return;
+    const target = containerRef.current?.querySelector<HTMLElement>(
+      `[data-node-id="letter-${focusLetterId}"]`
+    );
+    target?.scrollIntoView({ behavior: "instant", block: "center" });
+  }, [focusLetterId]);
+
+  return (
+    <div ref={containerRef} data-testid="future-letter-timeline">
+      {futureLetters.length === 0 ? (
+        <Row dateLabel={t("label_future")} dot={<span className="size-3 rounded-full border-2 border-dashed border-[#E4B84D]" />}>
+          <div className="rounded-2xl border border-dashed border-[#E4B84D] bg-[#FFFDF5] p-5 text-center">
+            <p className="font-bold text-text-dark">{t("cta_title")}</p>
+            <p className="mt-1 text-sm text-text-secondary">{t("cta_description")}</p>
+            <Button
+              disabled={isWriteLetterDisabled}
+              onClick={onWriteLetter}
+              className="mt-4 rounded-full bg-[#FCDD84] font-bold text-text-dark hover:bg-[#FBCF54]"
+            >
+              {t("cta_button")}
+            </Button>
+          </div>
+        </Row>
+      ) : (
+        <>
+          <div className="mb-4 pl-[60px]">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isWriteLetterDisabled}
+              onClick={onWriteLetter}
+              className="rounded-full border-logo-cyan text-logo-cyan hover:bg-[#E7FAF7] hover:text-logo-cyan"
+            >
+              <Mail className="size-4" />
+              {t("write_another")}
+            </Button>
+          </div>
+          {futureLetters.map((letter, index) => (
+            <Row
+              key={letter.id}
+              dateLabel={index === 0 ? t("label_future") : undefined}
+              dot={<span className="size-3 rounded-full border-2 border-dashed border-[#E4B84D] bg-white" />}
+            >
+              <ScheduledLetterCard
+                letter={letter}
+                onClick={() => onLetterClick(letter.letterId, letter.date)}
+                onDelete={() => onDeleteLetter(letter.letterId)}
+              />
+            </Row>
+          ))}
+        </>
+      )}
+
+      <Row
+        dateLabel={t("label_today")}
+        dot={
+          <span
+            data-testid="timeline-node"
+            data-kind="today"
+            className="flex size-3 items-center justify-center rounded-full bg-logo-cyan ring-4 ring-logo-cyan/20"
+          />
+        }
+      >
+        <div className="h-px bg-[#C9DADA]" />
+      </Row>
+
+      {pastGroups.map((group) => (
+        <div key={group.key}>
+          {group.items.map((item, itemIndex) => (
+            <Row
+              key={
+                item.type === "collapsed-check-ins"
+                  ? item.id
+                  : item.type === "letter"
+                    ? item.card.id
+                    : item.card.id
+              }
+              dateLabel={itemIndex === 0 ? group.label : undefined}
+              dot={
+                <span
+                  className={cn(
+                    "size-2.5 rounded-full",
+                    item.type === "letter" ? "bg-[#E4B84D]" : "bg-[#AFC8C8]"
+                  )}
+                />
+              }
+            >
+              {item.type === "letter" && (
+                <DeliveredLetterCard
+                  letter={item.card}
+                  onClick={() => onLetterClick(item.card.letterId, item.card.date)}
+                />
+              )}
+              {item.type === "event" && <EventCardView card={item.card} />}
+              {item.type === "collapsed-check-ins" && <CollapsedCheckins items={item.items} />}
+            </Row>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/product/src/components/me/footprints-page-content.tsx
+++ b/apps/product/src/components/me/footprints-page-content.tsx
@@ -3,7 +3,6 @@
 import { useMyFutureLetters } from "@daodao/api";
 import { useState } from "react";
 import { FutureLetterDialog, FutureLetterTimeline } from "@/components/future-letter";
-import { FootprintsList } from "@/components/me/footprints-list";
 
 export function FootprintsPageContent() {
   const [isLetterDialogOpen, setIsLetterDialogOpen] = useState(false);
@@ -33,9 +32,6 @@ export function FootprintsPageContent() {
           setTimelineVersion((version) => version + 1);
         }}
       />
-      <div className="mx-auto mt-10 max-w-[448px]">
-        <FootprintsList />
-      </div>
     </>
   );
 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -7901,6 +7901,13 @@
     "detail_write_now": "Write your current state",
     "detail_save": "Save",
     "detail_edit": "Edit",
-    "collapse_action": "Collapse"
+    "collapse_action": "Collapse",
+    "delivered_badge": "Delivered",
+    "delivered_at": "Delivered {date}",
+    "sent_at": "Sent {date}",
+    "sent_at_with_practice": "Sent {date} · linked to \"{practice}\"",
+    "write_another": "Write another",
+    "letter_menu": "More actions",
+    "days_remaining": "{days} days left"
   }
 }

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -7901,6 +7901,13 @@
     "detail_write_now": "寫下現在的狀態",
     "detail_save": "儲存",
     "detail_edit": "編輯",
-    "collapse_action": "收起"
+    "collapse_action": "收起",
+    "delivered_badge": "已送達",
+    "delivered_at": "送達於 {date}",
+    "sent_at": "{date} 寄出",
+    "sent_at_with_practice": "{date} 寄出．關聯「{practice}」",
+    "write_another": "再寫一封",
+    "letter_menu": "更多操作",
+    "days_remaining": "還有 {days} 天"
   }
 }


### PR DESCRIPTION
## Summary
- 「我的足跡」全頁時間軸從橫向圖示徽章列改成垂直時間軸＋富內容卡片：未來信件用虛線黃卡＋「未拆封」＋倒數天數＋「⋯」選單刪除，已送達信件用黃底卡片，其餘事件（打卡／里程碑／學習 DNA）依 icon 呈現、無內容的打卡自動收合成一行，完整保留原本 `data-testid`/`data-kind` 契約與下方 detail panel 邏輯，不影響既有 e2e 測試
- 首頁精簡時間軸改成素色圓點＋實線／虛線轉場＋`>>` 箭頭樣式，並置中顯示、修掉會被固定側邊欄蓋住的版面 bug；圓點顏色/尺寸/月份標籤位置皆依 Claude Design prototype 實測 DOM/CSS 數值校正（新增 `.claude/skills/implement-from-prototype/SKILL.md` 記錄這套流程）
- 修掉 `FutureLetterDialog` 因共用 `DialogContent` 內建 `sm:max-w-[350px]` 覆蓋呼叫端 `max-w-lg`，桌機版被鎖死在 350px 寬的 bug
- 移除足跡頁底部會打 400 的舊版 `FootprintsList`
- 暫時關閉首頁「讓我們更認識你！」問答輪播卡（依產品要求）
- 修正四引擎 code review（Codex/OMP/OpenCode/Haiku）抓到的 4 個回歸：非信件節點 focusDate 深連結捲動失效、已送達信件被誤判成未來樣式、月份標籤中文「月」字漏翻譯、刪除信件會誤清另一封已選取信件的詳情面板

## Test plan
- [x] `tsc --noEmit`、`biome lint` 全 repo 通過
- [x] 既有 11 個 vitest 單元測試通過
- [x] 隔離環境（獨立 DB + Redis db）重跑 10 個 Playwright e2e（draft-restore / lifecycle-delete / practice-snapshot / scheduled-secrecy / timeline-summary）全過，`timeline-summary.spec.ts` 排版斷言已改為反映垂直版面（Y 座標）
- [x] 手動截圖比對 prototype，中文站「6月」／英文站「Jun」locale 正確
- [ ] 建議 reviewer 實機看一次「我的足跡」頁與首頁時間軸畫面

🤖 Generated with [Claude Code](https://claude.com/claude-code)