### PR TITLE
[auto] #897 打卡頁分享錯誤修正

### DIFF
--- a/apps/product/src/components/check-in/display/__tests__/check-in-card-classnames.test.ts
+++ b/apps/product/src/components/check-in/display/__tests__/check-in-card-classnames.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { MOOD_LABEL_CLASSNAME, TAG_CLASSNAME } from "../check-in-card-classnames";
+
+describe("check-in card text wrap classNames", () => {
+  it("keeps the mood label on a single line", () => {
+    expect(MOOD_LABEL_CLASSNAME).toContain("whitespace-nowrap");
+  });
+
+  it("keeps a single tag's text on one line instead of breaking mid-word", () => {
+    expect(TAG_CLASSNAME).toContain("whitespace-nowrap");
+    expect(TAG_CLASSNAME).not.toContain("break-words");
+  });
+});

--- a/apps/product/src/components/check-in/display/check-in-card-classnames.ts
+++ b/apps/product/src/components/check-in/display/check-in-card-classnames.ts
@@ -1,0 +1,5 @@
+/**
+ * 打卡卡片文字換行相關 className。
+ */
+export const MOOD_LABEL_CLASSNAME = "text-sm text-text-dark";
+export const TAG_CLASSNAME = "min-w-0 break-words";

--- a/apps/product/src/components/check-in/display/check-in-card-classnames.ts
+++ b/apps/product/src/components/check-in/display/check-in-card-classnames.ts
@@ -1,5 +1,6 @@
 /**
  * 打卡卡片文字換行相關 className。
+ * 心情描述與單一 tag 需維持單行（不因長文字而換行），僅 tag 與 tag 之間可換行。
  */
-export const MOOD_LABEL_CLASSNAME = "text-sm text-text-dark";
-export const TAG_CLASSNAME = "min-w-0 break-words";
+export const MOOD_LABEL_CLASSNAME = "text-sm text-text-dark whitespace-nowrap";
+export const TAG_CLASSNAME = "whitespace-nowrap";

--- a/apps/product/src/components/check-in/display/check-in-card.tsx
+++ b/apps/product/src/components/check-in/display/check-in-card.tsx
@@ -8,6 +8,7 @@ import { format, isValid } from "date-fns";
 import * as React from "react";
 import { MOOD_OPTIONS, type MoodType } from "@/constants/mood";
 import { isBlankContent } from "@/utils/check-in-content";
+import { MOOD_LABEL_CLASSNAME, TAG_CLASSNAME } from "./check-in-card-classnames";
 
 interface ICheckInCardProps {
   taskTitle: string;
@@ -128,7 +129,7 @@ export const CheckInCard = ({
                 {MoodEmoji && (
                   <div className="flex items-center gap-2">
                     <MoodEmoji className="size-6" />
-                    <span className="text-sm text-text-dark">
+                    <span className={MOOD_LABEL_CLASSNAME}>
                       {t("mood_label", { label: moodLabel || moodOption?.label || "" })}
                     </span>
                   </div>
@@ -162,7 +163,9 @@ export const CheckInCard = ({
                 {tags && tags.length > 0 && (
                   <div className="flex flex-wrap gap-2 text-logo-cyan text-sm">
                     {tags.map((tag) => (
-                      <p key={tag} className="min-w-0 break-words"># {tag}</p>
+                      <p key={tag} className={TAG_CLASSNAME}>
+                        # {tag}
+                      </p>
                     ))}
                   </div>
                 )}


### PR DESCRIPTION
## Summary

- 打卡卡片（`CheckInCard`）心情描述文字改為單行不換行（`whitespace-nowrap`）
- 單一 tag 文字改為單行不斷字（移除 `break-words`，改用 `whitespace-nowrap`），tag 與 tag 之間仍可換行（`flex-wrap` 維持不變）

## Implementation Notes

Acceptance criteria 第三項「使用者上傳圖片需顯示」未包含在此 PR：靜態分析 `captureElementAsImage`（`modern-screenshot` 的 `domToPng`）與呼叫端 `ShareCheckInSheetContent` 後，找不到能高信心指出的前端根因（`domToPng` 已內建圖片 fetch/inline，元件端無明顯漏等待邏輯），懷疑可能與圖片來源網域的 CORS 設定或暫存 blob URL 有關，需要實際重現/瀏覽器除錯才能確認，不在 XS scope 內用猜測方式修改。已跳過此項，留給人類進一步排查。

## Test Plan

- [x] `pnpm --filter product exec vitest run src/components/check-in/display/__tests__/check-in-card-classnames.test.ts`（test-first：先確認舊 className 值會 fail，改完後 pass）
- [x] `pnpm exec biome check` 通過（僅剩 pre-existing 的 `parseTextLinks` key 警告，非本次改動引入）

## Links

- Closes #897
- Parent: daodaoedu/daodao#（issue body 未含 Parent 標記，無法反查中央卡）

---
🤖 Auto-generated by daodao pipeline | Scope: XS

---
_Generated by [Claude Code](https://claude.ai/code/session_015By8w1MqXNb5exdvLfdeh5)_