### PR TITLE
chore(config): 同步 daodao 共享設定

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -274,8 +274,11 @@ jobs:
         run: |
           BODY="$(cat "$RUNNER_TEMP/review-body.md")"
           HEAD_MARKER="<!-- daodao-ai-code-review-head:$HEAD_SHA -->"
+          # 新版 gh CLI 不允許 --slurp 與 --jq 併用，改用管線交給 jq；
+          # 順便用 --arg 傳 marker，避免 shell 內插進 jq 程式。
           COMMENTS="$(gh api --paginate --slurp "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq "add | [.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$HEAD_MARKER\")))]")"
+            | jq --arg marker "$HEAD_MARKER" \
+              'add | [.[] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)))]')"
           EXISTING=$(printf '%s' "$COMMENTS" | jq 'length')
 
           if [ "$EXISTING" -gt "0" ]; then


### PR DESCRIPTION
## Why is this necessary?

- 確保專案配置與上游 daodao 來源保持一致，避免因配置差異導致的環境問題。
- 更新共享設定以反映最新的專案需求或修復現有的配置錯誤。
- 維護配置檔案的同步性，確保所有開發環境使用相同的設定標準。

## How does it address?

- 執行同步指令將 daodao 的共享配置複製至專案中。
- 更新相關的配置檔案以匹配來源設定。
- 確保配置更新後的檔案能被正確納入版本控制。