### PR TITLE
[auto] #907 APP - 打卡頁顯示

### DIFF
--- a/apps/mobile/components/check-in/display/check-in-card.tsx
+++ b/apps/mobile/components/check-in/display/check-in-card.tsx
@@ -317,7 +317,7 @@ export const CheckInCard = ({
             )}
           </View>
         ) : (
-          <YStack paddingTop="$4" paddingHorizontal="$5" maxHeight={460}>
+          <YStack paddingTop="$4" paddingHorizontal="$5">
             {contentBody}
           </YStack>
         )}


### PR DESCRIPTION
## Summary

- Remove the `maxHeight={460}` cap on `CheckInCard`'s non-scrollable content wrapper
- This wrapper is used by the offscreen render in `use-check-in-image-render.tsx` that `captureRef`s the auto-generated check-in share image — long check-in notes exceeded the cap and got cut off in the captured image
- The interactive detail screen already uses the separate `scrollable` path (its own max-height + fade), and the feed showcase card already applies its own external `maxHeight={240} overflow="hidden"` crop, so neither is affected by removing this inner cap

## Implementation Notes

`apps/mobile` has no component-level test infrastructure (no jest/RTL configured, no `test` script in `package.json`), so the usual test-first XS flow (failing test → fix → passing test) isn't available for this UI/layout change. Verified instead via `biome check` and `tsc --noEmit` (both clean) and by tracing all three call sites of the non-scrollable `CheckInCard` path to confirm none relied on the removed cap.

## Test Plan

- [x] `npx biome check` on changed file passes
- [x] `npx tsc --noEmit` passes (apps/mobile)
- [ ] Manual check on device: check in with a long note, confirm the generated share image is not cut off

## Links

- Closes #907

---
🤖 Auto-generated by daodao pipeline | Scope: XS

---
_Generated by [Claude Code](https://claude.ai/code/session_013o4nAqT17EV7w5Utf1oCaT)_