### PR TITLE
fix(ci/cd): 修復 Linode SSH 金鑰 libcrypto 錯誤

### DIFF
--- a/.github/workflows/linode-cd.yml
+++ b/.github/workflows/linode-cd.yml
@@ -474,14 +474,14 @@ jobs:
           fi
 
       - name: Set up SSH
-        env:
-          LINODE_SSH_PRIVATE_KEY: ${{ secrets.LINODE_SSH_PRIVATE_KEY }}
-          LINODE_INSTANCE_IP: ${{ secrets.LINODE_INSTANCE_IP }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.LINODE_SSH_PRIVATE_KEY }}
+
+      - name: Add Linode to known_hosts
         run: |
           mkdir -p ~/.ssh
-          printf "%s" "${LINODE_SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H "${LINODE_INSTANCE_IP}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.LINODE_INSTANCE_IP }}" >> ~/.ssh/known_hosts
 
       - name: Create environment files on Linode
         env:
@@ -675,11 +675,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.LINODE_SSH_PRIVATE_KEY }}
+
+      - name: Add Linode to known_hosts
         run: |
           mkdir -p ~/.ssh
-          printf "%s" "${{ secrets.LINODE_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.LINODE_INSTANCE_IP }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.LINODE_INSTANCE_IP }}" >> ~/.ssh/known_hosts
 
       - name: Set Environment Variables
         run: |


### PR DESCRIPTION
## Why is this necessary?

- CI/CD 流程中 Linode SSH 金鑰配置出現 libcrypto 相關錯誤。
- 這個問題阻礙了透過 SSH 連線至 Linode 執行部署任務。
- 需要修正金鑰處理機制以確保部署流程的穩定性。

## How does it address?

- 修正了 Linode SSH 金鑰的 libcrypto 錯誤。
- 修復了 CI/CD 管線中與 SSH 金鑰相關的配置問題。
- 確保 SSH 金鑰能正確運作，恢復部署流程的正常執行。