### PR TITLE
fix(ui): 修復手機版頁面頂部被固定 logo 遮擋的問題

### DIFF
--- a/apps/product/src/app/[locale]/(with-layout)/messages/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/messages/page.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "@daodao/i18n";
 export default function MessagesPage() {
   const t = useTranslations("app_product");
   return (
-    <div className="min-h-screen max-w-[640px] mx-auto px-4 pt-8 pb-[72px]">
+    <div className="min-h-screen max-w-[640px] mx-auto px-4 pt-[68px] md:pt-8 pb-[72px]">
       <h1 className="text-xl font-semibold text-text-dark">{t("nav_messages")}</h1>
       <p className="mt-2 text-sm text-light-gray">即將推出</p>
     </div>

--- a/apps/product/src/app/[locale]/(with-layout)/spaces/[id]/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/spaces/[id]/page.tsx
@@ -104,7 +104,7 @@ export default function EventSpacePage() {
   const practiceCount = detail.practiceCount;
 
   return (
-    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-6">
+    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-[68px] md:pt-6">
       <SpaceSubpageHeader
         title={detail.name}
         subtitle={detail.subtitle}

--- a/apps/product/src/app/[locale]/(with-layout)/spaces/challenge/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/spaces/challenge/page.tsx
@@ -13,7 +13,7 @@ export default function ChallengeSpacePage() {
   const t = useTranslations("space");
 
   return (
-    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-6">
+    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-[68px] md:pt-6">
       <SpaceSubpageHeader title={t("challenge_name")} subtitle={t("challenge_host")} />
       <div className="mb-4 flex items-center gap-3 rounded-2xl border border-[#CDEBE8] bg-[#F0FAF8] px-4 py-3.5">
         <span className="grid size-10 shrink-0 place-items-center rounded-full bg-white text-primary-base">

--- a/apps/product/src/app/[locale]/(with-layout)/spaces/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/spaces/page.tsx
@@ -27,7 +27,7 @@ export default function SpacesPage() {
   };
 
   return (
-    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-8">
+    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-[68px] md:pt-8">
       <p className="mx-1 mb-3 text-[13px] text-text-dark/55">
         {t("space_count", { count: spaces?.total ?? 0 })}
       </p>

--- a/apps/product/src/app/[locale]/(with-layout)/spaces/personal/page.tsx
+++ b/apps/product/src/app/[locale]/(with-layout)/spaces/personal/page.tsx
@@ -33,7 +33,7 @@ export default function PersonalSpacePage() {
   );
 
   return (
-    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-6">
+    <div className="mx-auto min-h-screen max-w-[640px] px-4 pb-[72px] pt-[68px] md:pt-6">
       <SpaceSubpageHeader title={t("personal_name")} subtitle={t("personal_host")} />
       {isLoading ? (
         <div className="flex justify-center py-16">

--- a/apps/product/src/components/layout/page-header.tsx
+++ b/apps/product/src/components/layout/page-header.tsx
@@ -83,7 +83,7 @@ export const PageHeader = ({
   return (
     <div
       className={cn(
-        "relative max-w-[600px] mx-auto grid grid-cols-3 items-center px-5 py-4 md:pt-16",
+        "relative max-w-[600px] mx-auto grid grid-cols-3 items-center px-5 pt-[68px] pb-4 md:pt-16",
         className
       )}
     >


### PR DESCRIPTION
## Why is this necessary?

- 手機版網頁在使用時，頁面頂部內容會被固定的 Logo 元素完全遮擋，導致使用者無法看到或操作頂部的關鍵資訊。
- 固定定位的 Logo 元素在行動裝置的瀏覽器視窗中佔據了過多空間，影響了頁面的可讀性與使用體驗。
- 這是一個阻礙使用者正常瀏覽的 UI 問題，需要立即修正以確保在手機版上能正常顯示頁面內容。

## How does it address?

- 調整了手機版頁面頂部的佈局結構，確保內容區塊不會被固定 Logo 元素覆蓋。
- 修正了 CSS 樣式或定位邏輯，讓頁面內容能正確地顯示在固定 Logo 下方。
- 透過修復這個問題，使用者現在可以無障礙地檢視手機版頁面頂部的所有內容。