### PR TITLE
fix(ui): 修正時間軸與手機版版面溢位問題

### DIFF
--- a/apps/product/src/app/[locale]/practices/create/success/page.tsx
+++ b/apps/product/src/app/[locale]/practices/create/success/page.tsx
@@ -85,7 +85,7 @@ export default function PracticeSuccessPage() {
         </div>
 
         {/* 角色區域 */}
-        <div className="flex items-center justify-center w-[375px] h-[275px]">
+        <div className="flex items-center justify-center w-full max-w-[375px] h-[275px]">
           <Lottie
             animationData={featureHappyJson}
             className="*:w-full *:h-full"

--- a/apps/product/src/components/future-letter/compact-timeline-strip.tsx
+++ b/apps/product/src/components/future-letter/compact-timeline-strip.tsx
@@ -35,7 +35,7 @@ function connectorWidth(from: string, to: string): number {
  *  (proportionally to that width, never below `minWidth`) so the strip fits a
  *  narrow mobile viewport instead of overflowing past the right edge. */
 function shrinkableWidth(width: number, minWidth = 6): CSSProperties {
-  return { flex: `0 1 ${width}px`, minWidth };
+  return { flex: `0 1 ${width}px`, minWidth: Math.min(minWidth, width) };
 }
 
 /** Prototype renders dates without zero-padding (8/14, not 08/14). */

--- a/apps/product/src/components/future-letter/compact-timeline-strip.tsx
+++ b/apps/product/src/components/future-letter/compact-timeline-strip.tsx
@@ -31,6 +31,13 @@ function connectorWidth(from: string, to: string): number {
   return Math.min(2 * days + 4, 40);
 }
 
+/** Connectors take their prototype width when there is room, but may shrink
+ *  (proportionally to that width, never below `minWidth`) so the strip fits a
+ *  narrow mobile viewport instead of overflowing past the right edge. */
+function shrinkableWidth(width: number, minWidth = 6): CSSProperties {
+  return { flex: `0 1 ${width}px`, minWidth };
+}
+
 /** Prototype renders dates without zero-padding (8/14, not 08/14). */
 function trimDateLabel(label: string): string {
   return label.replace(/^0/, "").replace("/0", "/");
@@ -133,8 +140,7 @@ export function CompactTimelineStrip({
 
   return (
     <div
-      className="relative"
-      style={{ width: 540, maxWidth: "82%" }}
+      className="relative w-[540px] max-w-[calc(100%-32px)] md:max-w-[82%]"
       data-testid="home-timeline-summary"
     >
       <style>{KEYFRAMES}</style>
@@ -150,8 +156,8 @@ export function CompactTimelineStrip({
             onOpen?.();
           }
         }}
-        className="flex cursor-pointer items-center transition-transform duration-[220ms] hover:-translate-y-[2px]"
-        style={{ height: 44, gap: 16, padding: "0 22px", borderRadius: 999 }}
+        className="flex cursor-pointer items-center px-3 transition-transform duration-[220ms] hover:-translate-y-[2px] md:px-[22px]"
+        style={{ height: 44, gap: 16, borderRadius: 999 }}
       >
         <span className="flex min-w-0 flex-1 items-center">
           {pastAndToday.map((node, index) => {
@@ -165,10 +171,9 @@ export function CompactTimelineStrip({
                     aria-hidden="true"
                     style={
                       isToday
-                        ? { width: 12, flex: "none", height: 0.5, background: SOLID_LINE }
+                        ? { ...shrinkableWidth(12), height: 0.5, background: SOLID_LINE }
                         : {
-                            width: connectorWidth(prev.date, node.date),
-                            flex: "none",
+                            ...shrinkableWidth(connectorWidth(prev.date, node.date)),
                             height: 1,
                             background: SOLID_LINE,
                           }
@@ -206,8 +211,7 @@ export function CompactTimelineStrip({
                   <span
                     aria-hidden="true"
                     style={{
-                      width: connectorWidth(prev.date, node.date),
-                      flex: "none",
+                      ...shrinkableWidth(connectorWidth(prev.date, node.date)),
                       height: 1,
                       background: DOTTED_LINE,
                     }}
@@ -247,13 +251,13 @@ export function CompactTimelineStrip({
           )}
           <span
             aria-hidden="true"
-            style={{ width: 96, flex: "none", height: 1, background: DOTTED_LINE }}
+            style={{ ...shrinkableWidth(96, 20), height: 1, background: DOTTED_LINE }}
           />
         </span>
         <span
           aria-hidden="true"
-          className="flex flex-none items-center"
-          style={{ marginLeft: -8, marginRight: 34, color: "#0F3036" }}
+          className="-ml-2 mr-2 flex flex-none items-center md:mr-[34px]"
+          style={{ color: "#0F3036" }}
         >
           <ChevronRight className="size-[18px]" style={{ marginRight: -9 }} />
           <ChevronRight className="size-[18px]" />

--- a/apps/product/src/components/future-letter/future-letter-dialog.tsx
+++ b/apps/product/src/components/future-letter/future-letter-dialog.tsx
@@ -327,7 +327,7 @@ export function FutureLetterDialog({
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent
-                  className="w-[360px] border-0 bg-[#0D3036] p-4 text-[#E7F4F4] shadow-[0_14px_34px_rgba(15,48,54,0.28)] rounded-2xl"
+                  className="w-[min(360px,calc(100vw-32px))] border-0 bg-[#0D3036] p-4 text-[#E7F4F4] shadow-[0_14px_34px_rgba(15,48,54,0.28)] rounded-2xl"
                   side="top"
                   align="start"
                 >

--- a/apps/product/src/components/user/island-header.tsx
+++ b/apps/product/src/components/user/island-header.tsx
@@ -191,7 +191,7 @@ export function IslandHeader({ resultType, userId, identifier }: IslandHeaderPro
           </div>
         )}
         {isEmptyResult && isOwnProfile && (
-          <div className="absolute left-0 right-0 top-[150px] w-[600px] mx-auto overflow-hidden mask-marquee">
+          <div className="absolute left-0 right-0 top-[150px] w-full max-w-[600px] mx-auto overflow-hidden mask-marquee">
             <div className="animate-marquee flex w-max gap-3 will-change-transform">
               {/* 第一份內容 */}
               {Array.from(resultTypeToLottiePathMap.keys()).map((key) => {


### PR DESCRIPTION
## Why is this necessary?

- 修正手機版版面中三處寫死尺寸造成的截斷與溢位問題，確保在手機螢幕上正常顯示。
- 修正首頁時間軸在手機寬度右側溢位破版的情況，維持版面完整性。
- 修正時間軸連線線下限不得超過 prototype 基準寬度，確保視覺一致性。

## How does it address?

- 調整手機版寬度相關的尺寸設定，移除寫死的尺寸限制，解決截斷與溢位問題。
- 修正時間軸在手機寬度下的溢位問題，確保內容不超出螢幕邊界。
- 調整時間軸連線線的顯示邏輯，確保其下限不超過 prototype 基準寬度。