### PR TITLE
chore(config): 同步 daodao 共享設定

### DIFF
--- a/.github/scripts/retrieve-context.sh
+++ b/.github/scripts/retrieve-context.sh
@@ -247,6 +247,48 @@ EOF
   echo
 }
 
+# ── 3b. migration/schema diff 跨表引用但不在本次 diff 的表定義 ─────────
+# 動機：cross-table 誤判（reviewer 只看得到 diff 裡的表，看不到 FK 指向的表）
+# 屬結構性、可靠地從 REFERENCES 子句解析，涵蓋率不含自由文字註解提到的表名。
+section_referenced_tables() {
+  echo "## 3b. migration/schema diff 跨表引用的表定義（不在本次 diff 內）"
+  echo
+
+  if ! printf '%s\n' "$CHANGED_FILES" | grep -qE '(^|/)(schema|migrate/sql)/.*\.sql$'; then
+    echo "（本次 diff 未觸及 schema/migration SQL，略過）"
+    echo
+    return 0
+  fi
+
+  local created referenced
+  created="$(printf '%s\n' "$ADDED_LINES" \
+    | grep -oiE 'CREATE TABLE( IF NOT EXISTS)? "[A-Za-z_][A-Za-z0-9_]*"' \
+    | grep -oE '"[A-Za-z_][A-Za-z0-9_]*"$' | tr -d '"' | sort -u || true)"
+  referenced="$(printf '%s\n' "$ADDED_LINES" \
+    | grep -oiE 'REFERENCES "[A-Za-z_][A-Za-z0-9_]*"' \
+    | grep -oE '"[A-Za-z_][A-Za-z0-9_]*"$' | tr -d '"' | sort -u || true)"
+
+  local tbl any=0 def_file
+  while IFS= read -r tbl; do
+    [ -z "$tbl" ] && continue
+    printf '%s\n' "$created" | grep -qxF "$tbl" && continue
+    def_file="$(search "CREATE TABLE( IF NOT EXISTS)? \\\"${tbl}\\\"" \
+      | awk -F: '$1 ~ /(^|\/)schema\// { print $1 }' | sort -u | awk 'NR==1')"
+    [ -z "$def_file" ] && continue
+    printf -- '- `%s`（定義於 `%s`）：\n' "$tbl" "$def_file"
+    awk -v needle="\"$tbl\"" '
+      /CREATE TABLE/ && index($0, needle) > 0 { on=1 }
+      on { print "      " $0 }
+      on && /^\);/ { exit }
+    ' "$def_file" | awk 'NR<=25{print} NR==26{print "      …（截斷）"}'
+    any=1
+  done <<EOF
+$referenced
+EOF
+  [ "$any" = 0 ] && echo "（無跨表引用需要補充，或引用的表本次已在 diff 內建立）"
+  echo
+}
+
 # ── 4. 精簡 repo map ───────────────────────────────────────────────────
 section_repo_map() {
   echo "## 4. 精簡 repo map"
@@ -272,6 +314,7 @@ build_pack() {
   section_symbol_callers
   section_importers
   section_call_patterns
+  section_referenced_tables
   section_inflight
   section_repo_map
 }

--- a/.github/scripts/test-retrieve-context.sh
+++ b/.github/scripts/test-retrieve-context.sh
@@ -119,4 +119,40 @@ MAX_HITS=10000 PER_FILE_LINES=5000 PACK_BYTES=700 "$RETRIEVE" main fix/postmessa
 [ "$(wc -c < "$SMALL_PACK" | tr -d ' ')" -le 700 ] || fail "context pack 超過 PACK_BYTES"
 iconv -f UTF-8 -t UTF-8 "$SMALL_PACK" >/dev/null || fail "context pack 截出非法 UTF-8"
 
+# 斷言 8：migration diff 的跨表 FK 引用——被引用但不在 diff 內的表要附上定義，
+# 本次 diff 自己建立的表不用另外附（重演 daodao-storage #215 review 誤判：
+# reviewer 看不到 FK 指向的既有表，誤判欄位/約束跨表引用有誤）
+git checkout -q main
+mkdir -p schema migrate/sql
+cat > schema/010_create_table_users.sql <<'EOF'
+CREATE TABLE "users" (
+    "id" SERIAL PRIMARY KEY,
+    "email" VARCHAR(255) NOT NULL,
+    "privacy_status" VARCHAR(20) NOT NULL DEFAULT 'public'
+);
+EOF
+git add -A && git commit -qm "base: users table"
+
+git checkout -qb fix/add-posts-table
+cat > migrate/sql/002_add_posts.sql <<'EOF'
+CREATE TABLE "posts" (
+    "id" SERIAL PRIMARY KEY,
+    "user_id" INT NOT NULL,
+    "body" TEXT NOT NULL,
+
+    CONSTRAINT "fk_posts_user"
+        FOREIGN KEY ("user_id") REFERENCES "users"("id")
+        ON DELETE CASCADE ON UPDATE NO ACTION
+);
+EOF
+git add -A && git commit -qm "feat: add posts table referencing users"
+
+PACK_SQL="$("$RETRIEVE" main fix/add-posts-table)"
+
+fail_sql() { echo "❌ $1"; echo "---- pack ----"; printf '%s\n' "$PACK_SQL"; exit 1; }
+
+printf '%s' "$PACK_SQL" | grep -q '`users`（定義於' || fail_sql "pack 缺少被 FK 引用但不在 diff 內的 users 表定義"
+printf '%s' "$PACK_SQL" | grep -q 'privacy_status' || fail_sql "pack 沒有把 users 表的實際欄位（privacy_status）附進去"
+printf '%s' "$PACK_SQL" | grep -q '`posts`（定義於' && fail_sql "本次 diff 自己建立的 posts 表不該被當成「不在 diff 內」又附一次"
+
 echo "✅ retrieve-context fixture 回歸測試通過"


### PR DESCRIPTION
## Why is this necessary?

- 確保專案配置與外部共享設定保持一致，避免環境差異導致的問題。
- 維護配置的集中管理，減少分散在不同檔案中的重複設定。
- 透過同步機制確保所有開發者使用相同的基礎設定。

## How does it address?

- 從 daodao 儲存庫同步最新的共享配置檔案。
- 更新專案中的設定檔案以反映最新的變更。
- 確保配置同步後的版本與來源一致。