### PR TITLE
fix(lighthouse): 修正總覽頁與側邊欄對齊問題

### DIFF
--- a/apps/product/src/components/lighthouse/lighthouse-overview.tsx
+++ b/apps/product/src/components/lighthouse/lighthouse-overview.tsx
@@ -1,121 +1,31 @@
 "use client";
 
 import {
-  archiveLighthouseCohort,
-  duplicateLighthouseCohort,
   type LighthouseOrganizationCohortType,
-  updateLighthouseCohort,
   useLighthouseOrganizationCohorts,
   useLighthouseOrganizations,
 } from "@daodao/api";
 import { useTranslations } from "@daodao/i18n";
-import { useRouter } from "@daodao/i18n/navigation";
 import { Button } from "@daodao/ui/components/button";
 import { CustomLink } from "@daodao/ui/components/custom-link";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@daodao/ui/components/dropdown-menu";
-import { toast } from "@daodao/ui/components/sonner";
-import { useDialog } from "@daodao/ui/hooks/use-dialog";
-import { cn } from "@daodao/ui/lib/utils";
-import { Archive, ArrowUpRight, Copy, MoreVertical, Pencil, RadioTower, Send } from "lucide-react";
-import { useState } from "react";
+import { ArrowUpRight, Pencil, RadioTower } from "lucide-react";
 
-/** FR-OV-02：狀態標籤三色——已發佈綠底、草稿灰底、已封存紅底 */
 const STATUS_STYLES: Record<LighthouseOrganizationCohortType["status"], string> = {
-  published: "bg-[#EDF8F6] text-[#0D7773]",
-  draft: "bg-[#F1F4F4] text-[#5A7B79]",
-  archived: "bg-[#FDECEC] text-[#C03A3A]",
+  published: "text-[#0D7773]",
+  draft: "text-[#5A7B79]",
+  archived: "text-[#C03A3A]",
 };
 
-function errorMessage(error: unknown, fallback: string): string {
-  return error && typeof error === "object" && "message" in error
-    ? String((error as { message: unknown }).message)
-    : fallback;
-}
-
-interface CohortCardProps {
-  cohort: LighthouseOrganizationCohortType;
-  refresh: () => Promise<unknown>;
-}
-
-function CohortCard({ cohort, refresh }: CohortCardProps) {
+function CohortCard({ cohort }: { cohort: LighthouseOrganizationCohortType }) {
   const t = useTranslations("lighthouse");
-  const router = useRouter();
-  const { openWarningDialog } = useDialog();
-  const [busy, setBusy] = useState(false);
   const manageHref = `/lighthouse/programs/${cohort.programId}/cohorts/${cohort.id}/dashboard`;
   const editHref = `/lighthouse/programs?edit=${cohort.id}#cohort-${cohort.id}`;
-
-  async function run(action: () => Promise<{ error?: unknown }>, success: string, failure: string) {
-    setBusy(true);
-    const response = await action();
-    if (response.error) {
-      toast.error(errorMessage(response.error, failure));
-      setBusy(false);
-      return;
-    }
-    toast.success(success);
-    await refresh();
-    setBusy(false);
-  }
-
-  async function handlePublish() {
-    const result = await openWarningDialog({
-      title: t("cohort_publish"),
-      message: t("cohort_publish_confirm"),
-      buttons: [
-        { label: t("cancel"), value: "cancel", variant: "outline" },
-        { label: t("cohort_publish"), value: "publish", variant: "default" },
-      ],
-    });
-    if (result.value !== "publish") return;
-    await run(
-      () => updateLighthouseCohort(cohort.programId, cohort.id, { status: "published" }),
-      t("cohort_published"),
-      t("cohort_publish_failed")
-    );
-  }
-
-  async function handleArchive() {
-    const result = await openWarningDialog({
-      title: t("archive"),
-      message: t("cohort_archive_confirm"),
-      buttons: [
-        { label: t("cancel"), value: "cancel", variant: "outline" },
-        { label: t("archive"), value: "archive", variant: "orange" },
-      ],
-    });
-    if (result.value !== "archive") return;
-    await run(
-      () => archiveLighthouseCohort(cohort.programId, cohort.id),
-      t("cohort_archived"),
-      t("cohort_archive_failed")
-    );
-  }
-
-  async function handleDuplicate() {
-    setBusy(true);
-    const response = await duplicateLighthouseCohort(cohort.programId, cohort.id);
-    if (response.error) {
-      toast.error(errorMessage(response.error, t("cohort_duplicate_failed")));
-      setBusy(false);
-      return;
-    }
-    toast.success(t("cohort_duplicated", { name: response.data.data.displayName }));
-    await refresh();
-    setBusy(false);
-  }
 
   return (
     <article
       className="group relative rounded-3xl border border-[#CDEBE8] bg-white p-6 transition-transform hover:-translate-y-0.5 focus-within:-translate-y-0.5"
       aria-labelledby={`cohort-card-${cohort.id}-title`}
     >
-      {/* 卡片本體（非按鈕區域）點擊 → 進入場次管理 */}
       <CustomLink
         href={manageHref}
         className="absolute inset-0 rounded-3xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-logo-cyan"
@@ -126,12 +36,7 @@ function CohortCard({ cohort, refresh }: CohortCardProps) {
 
       <div className="pointer-events-none relative flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <span
-            className={cn(
-              "inline-flex rounded-full px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em]",
-              STATUS_STYLES[cohort.status]
-            )}
-          >
+          <span className={`text-xs font-medium ${STATUS_STYLES[cohort.status]}`}>
             {t(`cohort_status_${cohort.status}`)}
           </span>
           <div className="mt-2 flex items-center gap-2">
@@ -155,78 +60,27 @@ function CohortCard({ cohort, refresh }: CohortCardProps) {
             )}
           </div>
           <p className="mt-1 text-xs text-[#78928F]">
-            {cohort.startDate.slice(0, 10)} — {cohort.endDate.slice(0, 10)} ·{" "}
-            {t("overview_program_label")}：{cohort.programName}
+            {cohort.startDate.slice(0, 10)} — {cohort.endDate.slice(0, 10)}
           </p>
         </div>
-        <div className="pointer-events-auto relative z-10 flex shrink-0 items-center gap-1">
-          <CustomLink
-            href={manageHref}
-            className="grid size-8 place-items-center rounded-full text-[#0D7773] hover:bg-[#EDF8F6]"
-            aria-label={t("manage_cohort")}
-            title={t("manage_cohort")}
-          >
-            <ArrowUpRight className="size-4" aria-hidden="true" />
-          </CustomLink>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-8"
-                aria-label={t("cohort_actions")}
-                title={t("cohort_actions")}
-                disabled={busy}
-              >
-                <MoreVertical className="size-4" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-36 rounded-xl border-[#CDEBE8]">
-              <DropdownMenuItem onClick={handleDuplicate} disabled={busy} className="gap-2">
-                <Copy className="size-4" aria-hidden="true" />
-                {t("cohort_duplicate")}
-              </DropdownMenuItem>
-              {cohort.status !== "archived" && (
-                <DropdownMenuItem
-                  onClick={handleArchive}
-                  disabled={busy}
-                  className="gap-2 text-[#C03A3A]"
-                >
-                  <Archive className="size-4" aria-hidden="true" />
-                  {t("archive")}
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        <CustomLink
+          href={manageHref}
+          className="pointer-events-auto relative z-10 grid size-8 place-items-center rounded-full text-[#0D7773] hover:bg-[#EDF8F6]"
+          aria-label={t("manage_cohort")}
+          title={t("manage_cohort")}
+        >
+          <ArrowUpRight className="size-4" aria-hidden="true" />
+        </CustomLink>
       </div>
 
-      <div className="pointer-events-none relative mt-5 flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-[#456B68]">
-          {t("overview_joined_count", { count: cohort.joinedCount })}
-        </p>
-        <div className="pointer-events-auto relative z-10 flex items-center gap-2">
-          {cohort.status === "draft" && (
-            <Button size="sm" onClick={handlePublish} disabled={busy}>
-              <Send className="size-4" aria-hidden="true" />
-              {t("cohort_publish")}
-            </Button>
-          )}
-          {cohort.status === "published" && (
-            <Button asChild variant="outline" size="sm" className="border-[#CDEBE8] text-[#0D5B59]">
-              <CustomLink href={editHref}>{t("edit")}</CustomLink>
-            </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-[#0D7773]"
-            onClick={() => router.push(manageHref)}
-          >
-            {t("manage_cohort")}
-            <ArrowUpRight className="size-4" aria-hidden="true" />
-          </Button>
+      <div className="pointer-events-none relative mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-xl bg-[#EDF8F6] p-4">
+          <span className="text-2xl font-semibold text-[#0D7773]">{cohort.celebrateCount}</span>
+          <span className="mt-1 block text-xs text-[#456B68]">{t("overview_stat_celebrate")}</span>
+        </div>
+        <div className="rounded-xl bg-[#FFF4E5] p-4">
+          <span className="text-2xl font-semibold text-[#A95D00]">{cohort.encourageCount}</span>
+          <span className="mt-1 block text-xs text-[#456B68]">{t("overview_stat_encourage")}</span>
         </div>
       </div>
     </article>
@@ -237,23 +91,15 @@ export function LighthouseOverview() {
   const t = useTranslations("lighthouse");
   const { organizations } = useLighthouseOrganizations();
   const organizationId = organizations?.[0]?.id;
-  const { cohorts, isLoading, mutate } = useLighthouseOrganizationCohorts(organizationId);
+  const { cohorts, isLoading } = useLighthouseOrganizationCohorts(organizationId);
 
   return (
     <div className="mx-auto w-full max-w-6xl px-5 py-10 md:px-10 md:py-14">
-      <header className="max-w-3xl">
+      <header>
         <h1 className="text-2xl font-semibold leading-[1.08] tracking-[-0.045em] md:text-4xl">
           {t("overview_title")}
         </h1>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-[#456B68]">
-          {t("overview_description")}
-        </p>
-      </header>
-      <section className="mt-10" aria-labelledby="overview-cohorts-title">
-        <div className="flex items-center justify-between">
-          <h2 id="overview-cohorts-title" className="text-xl font-semibold">
-            {t("overview_active_cohorts")}
-          </h2>
+        <div className="mt-3 text-right">
           <CustomLink
             href="/lighthouse/programs"
             className="text-sm font-semibold text-[#0D7773] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-logo-cyan"
@@ -261,19 +107,19 @@ export function LighthouseOverview() {
             {t("nav_programs")}
           </CustomLink>
         </div>
-        {isLoading && <p className="mt-6 text-sm text-[#5A7B79]">{t("loading")}</p>}
-        {!isLoading && !cohorts?.length && (
-          <div className="mt-6 rounded-3xl border border-dashed border-[#B9DCD8] px-6 py-14 text-center">
-            <RadioTower className="mx-auto size-8 text-[#0D7773]" aria-hidden="true" />
-            <p className="mt-4 font-semibold">{t("overview_empty")}</p>
-          </div>
-        )}
-        <div className="mt-5 grid gap-4 lg:grid-cols-2">
-          {cohorts?.map((cohort) => (
-            <CohortCard key={cohort.id} cohort={cohort} refresh={mutate} />
-          ))}
+      </header>
+      {isLoading && <p className="mt-6 text-sm text-[#5A7B79]">{t("loading")}</p>}
+      {!isLoading && !cohorts?.length && (
+        <div className="mt-6 rounded-3xl border border-dashed border-[#B9DCD8] px-6 py-14 text-center">
+          <RadioTower className="mx-auto size-8 text-[#0D7773]" aria-hidden="true" />
+          <p className="mt-4 font-semibold">{t("overview_empty")}</p>
         </div>
-      </section>
+      )}
+      <div className="mt-8 grid gap-4 lg:grid-cols-2">
+        {cohorts?.map((cohort) => (
+          <CohortCard key={cohort.id} cohort={cohort} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/product/src/components/lighthouse/lighthouse-shell.tsx
+++ b/apps/product/src/components/lighthouse/lighthouse-shell.tsx
@@ -1,23 +1,10 @@
 "use client";
 
-import { useLighthouseOrganizations } from "@daodao/api";
-import favicon256Png from "@daodao/assets/images/brand/favicon256.png";
 import { useTranslations } from "@daodao/i18n";
 import { usePathname } from "@daodao/i18n/navigation";
-import { getStorage, StorageEnum } from "@daodao/shared";
-import { Button } from "@daodao/ui/components/button";
 import { CustomLink } from "@daodao/ui/components/custom-link";
 import { cn } from "@daodao/ui/lib/utils";
-import {
-  BookOpenText,
-  Building2,
-  LayoutDashboard,
-  PanelLeftClose,
-  PanelLeftOpen,
-  RadioTower,
-} from "lucide-react";
-import Image from "next/image";
-import { useEffect, useState } from "react";
+import { BookOpenText, Building2, ChevronLeft, LayoutDashboard, RadioTower } from "lucide-react";
 
 interface LighthouseShellProps {
   children: React.ReactNode;
@@ -35,91 +22,26 @@ const navigationItems = [
   },
 ] as const;
 
-/** 側邊欄收合狀態存在瀏覽器（@daodao/shared getStorage）；寬度依 FRD-OV-01：展開 256px、收合 76px */
-const collapsedStorage = () => getStorage<boolean>(StorageEnum.LighthouseSidebarCollapsed);
-
-function useSidebarCollapsed(): [boolean, () => void] {
-  const [collapsed, setCollapsed] = useState(false);
-  useEffect(() => {
-    setCollapsed(collapsedStorage().get() === true);
-  }, []);
-  const toggle = () => {
-    setCollapsed((current) => {
-      const next = !current;
-      collapsedStorage().set(next);
-      return next;
-    });
-  };
-  return [collapsed, toggle];
-}
-
 export function LighthouseShell({ children }: LighthouseShellProps) {
   const pathname = usePathname();
   const t = useTranslations("lighthouse");
-  const [collapsed, toggleCollapsed] = useSidebarCollapsed();
-  const { organizations } = useLighthouseOrganizations();
-  const organization = organizations?.[0];
-  const organizationName = organization?.name ?? t("title");
-  const organizationInitial = organizationName.trim().charAt(0) || "燈";
 
   return (
     <div className="min-h-screen bg-[#F5FFFD] text-[#0D3036]">
-      <aside
-        data-collapsed={collapsed ? "1" : "0"}
-        className={cn(
-          "fixed inset-y-0 left-0 z-40 hidden border-r border-[#CDEBE8] bg-white/95 py-5 transition-[width] duration-200 md:flex md:flex-col",
-          collapsed ? "w-[76px] px-3" : "w-64 px-5"
-        )}
-      >
-        <div className={cn("flex items-center gap-2", collapsed ? "flex-col" : "justify-between")}>
+      <aside className="fixed inset-y-0 left-0 z-40 hidden w-64 border-r border-[#CDEBE8] bg-white/95 px-5 py-5 md:flex md:flex-col">
+        <div className="flex items-center gap-3 px-1">
           <CustomLink
             href="/"
             aria-label={t("back_home")}
             title={t("back_home")}
-            className="grid size-10 shrink-0 place-items-center rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-logo-cyan"
+            className="grid size-8 place-items-center rounded-lg text-[#5A7B79] hover:bg-[#EDF8F6]"
           >
-            <Image src={favicon256Png.src} alt="daodao logo" width={32} height={32} />
+            <ChevronLeft className="size-5" aria-hidden="true" />
           </CustomLink>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={toggleCollapsed}
-            aria-label={collapsed ? t("sidebar_expand") : t("sidebar_collapse")}
-            aria-expanded={!collapsed}
-            title={collapsed ? t("sidebar_expand") : t("sidebar_collapse")}
-            className="size-9 text-[#5A7B79] hover:bg-[#EDF8F6] hover:text-[#0D3036]"
-          >
-            {collapsed ? (
-              <PanelLeftOpen className="size-[18px]" aria-hidden="true" />
-            ) : (
-              <PanelLeftClose className="size-[18px]" aria-hidden="true" />
-            )}
-          </Button>
         </div>
-
-        <div
-          className={cn("mt-6 flex items-center gap-3", collapsed ? "justify-center" : "px-1")}
-          data-lh-org
-        >
-          <span
-            className="relative grid size-11 shrink-0 place-items-center rounded-full bg-[#0D3036] text-base font-semibold text-white"
-            aria-hidden="true"
-          >
-            {organizationInitial}
-            <span className="absolute -right-1 top-1 size-2.5 rounded-full bg-[#FFA10B] ring-2 ring-white" />
-          </span>
-          {!collapsed && (
-            <span className="min-w-0">
-              <span className="block truncate text-lg font-semibold tracking-[-0.03em]">
-                {organizationName}
-              </span>
-              <span className="block font-mono text-[10px] uppercase tracking-[0.18em] text-[#5A7B79]">
-                {t("coach_workspace")}
-              </span>
-            </span>
-          )}
-          {collapsed && <span className="sr-only">{organizationName}</span>}
+        <div className="mt-4 flex items-center gap-2 px-1">
+          <RadioTower className="size-6 text-[#0D7773]" aria-hidden="true" />
+          <span className="text-lg font-semibold tracking-[-0.03em]">{t("title")}</span>
         </div>
 
         <nav className="mt-8" aria-label={t("navigation_label")}>
@@ -132,34 +54,22 @@ export function LighthouseShell({ children }: LighthouseShellProps) {
                   <CustomLink
                     href={item.href}
                     aria-current={isActive ? "page" : undefined}
-                    aria-label={collapsed ? t(item.labelKey) : undefined}
-                    title={collapsed ? t(item.labelKey) : undefined}
                     className={cn(
-                      "relative flex items-center gap-3 rounded-xl py-3 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-logo-cyan",
-                      "before:absolute before:h-5 before:w-1 before:rounded-r-full before:bg-transparent before:transition-all",
-                      collapsed ? "justify-center px-0 before:-left-3" : "px-4 before:-left-5",
+                      "relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-logo-cyan",
+                      "before:absolute before:-left-5 before:h-5 before:w-1 before:rounded-r-full before:bg-transparent before:transition-all",
                       isActive
                         ? "bg-[#E7FAF7] text-[#0D5B59] before:h-9 before:bg-[#16B9B3]"
                         : "text-[#5A7B79] hover:bg-[#F5FFFD] hover:text-[#0D3036]"
                     )}
                   >
                     <Icon className="size-[18px] shrink-0" aria-hidden="true" />
-                    {!collapsed && <span className="truncate">{t(item.labelKey)}</span>}
+                    <span className="truncate">{t(item.labelKey)}</span>
                   </CustomLink>
                 </li>
               );
             })}
           </ul>
         </nav>
-
-        {!collapsed && (
-          <div className="mt-auto border-t border-[#DDEFED] pt-5">
-            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#78928F]">
-              {t("principle_label")}
-            </p>
-            <p className="mt-2 text-sm leading-6 text-[#345E5B]">{t("principle_copy")}</p>
-          </div>
-        )}
       </aside>
 
       <header className="sticky top-0 z-40 border-b border-[#CDEBE8] bg-white/95 px-4 py-3 backdrop-blur md:hidden">
@@ -169,9 +79,10 @@ export function LighthouseShell({ children }: LighthouseShellProps) {
             aria-label={t("back_home")}
             className="grid size-9 place-items-center"
           >
-            <Image src={favicon256Png.src} alt="daodao logo" width={28} height={28} />
+            <ChevronLeft className="size-5" aria-hidden="true" />
           </CustomLink>
-          <span className="truncate font-semibold tracking-[-0.02em]">{organizationName}</span>
+          <RadioTower className="size-5 text-[#0D7773]" aria-hidden="true" />
+          <span className="truncate font-semibold tracking-[-0.02em]">{t("title")}</span>
         </div>
         <nav className="mt-3 overflow-x-auto" aria-label={t("navigation_label")}>
           <ul className="flex min-w-max gap-2 pb-1">
@@ -196,12 +107,7 @@ export function LighthouseShell({ children }: LighthouseShellProps) {
         </nav>
       </header>
 
-      <main
-        className={cn(
-          "min-h-screen transition-[padding] duration-200",
-          collapsed ? "md:pl-[76px]" : "md:pl-64"
-        )}
-      >
+      <main className="min-h-screen md:pl-64">
         {children}
       </main>
     </div>

--- a/packages/api/src/services/cohort.ts
+++ b/packages/api/src/services/cohort.ts
@@ -130,20 +130,18 @@ export const lighthouseCohortListResponseSchema: z.ZodType<CohortListResponse> =
 );
 
 export const lighthouseCohortResponseSchema = apiSuccessSchema(lighthouseCohortSchema);
-/** 總覽用：組織底下所有系列的全部場次，附系列名稱與已加入人數（FR-OV-02） */
-type OrganizationCohortListResponse =
-  paths["/api/v1/lighthouse/organizations/{organizationId}/cohorts"]["get"]["responses"][200]["content"]["application/json"];
-export const lighthouseOrganizationCohortSchema: z.ZodType<
-  OrganizationCohortListResponse["data"][number]
-> = z.object({
+/** 總覽用：組織底下所有系列的全部場次，附系列名稱、已加入人數與焦點摘要（FR-OV-02） */
+export const lighthouseOrganizationCohortSchema = z.object({
   ...lighthouseCohortShape,
   programName: z.string(),
   joinedCount: z.number().int().nonnegative(),
+  encourageCount: z.number().int().nonnegative(),
+  celebrateCount: z.number().int().nonnegative(),
 });
 export const lighthouseOrganizationCohortListResponseSchema = apiSuccessSchema(
   z.array(lighthouseOrganizationCohortSchema)
 );
-export type LighthouseOrganizationCohortType = OrganizationCohortListResponse["data"][number];
+export type LighthouseOrganizationCohortType = z.infer<typeof lighthouseOrganizationCohortSchema>;
 
 export const lighthouseCohortMembersResponseSchema = apiSuccessSchema(
   z.array(

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -7804,6 +7804,8 @@
     "cohort_actions": "更多操作",
     "overview_joined_count": "{count} 位已加入",
     "overview_program_label": "系列",
+    "overview_stat_celebrate": "值得慶祝",
+    "overview_stat_encourage": "位需要鼓勵",
     "overview_empty": "還沒有任何場次，先到「系列與場次」建立一個。",
     "confirm": "確定",
     "joining_resume": "重新開放加入",


### PR DESCRIPTION
## Why is this necessary?

- 總覽頁面目前的佈局與側邊欄未達到預期的對齊標準，影響視覺一致性。
- POC 階段提出的設計稿中，兩者應具有特定的對齊關係，目前尚未實現。
- 為了確保使用者介面的一致性，必須修正此對齊問題。

## How does it address?

- 透過調整總覽頁的佈局或側邊欄的樣式，使其符合 POC 設計的對齊規範。
- 修正相關的 CSS 或佈局邏輯，確保兩者在不同螢幕尺寸下都能正確對齊。
- 完成對齊的 POC 實作，作為後續正式開發的基礎。