### PR TITLE
hotfix(user): 暫時隱藏「Visit island」上島按鈕

### DIFF
--- a/apps/product/src/components/user/island-header.tsx
+++ b/apps/product/src/components/user/island-header.tsx
@@ -178,7 +178,8 @@ export function IslandHeader({ resultType, userId, identifier }: IslandHeaderPro
           className="md:hidden object-cover"
         />
         <PageHeader {...pageHeaderProps} />
-        {identifier && (
+        {/* TODO: 暫時隱藏上島按鈕，待功能完備後移除 false 條件 */}
+        {false && identifier && (
           <div className="absolute right-4 top-[64px] md:top-[72px]">
             <Button
               variant="orange"


### PR DESCRIPTION
## Summary
- 「上島」功能尚未完備但按鈕已顯示在 prod 的我的小島頁面
- 以 `false &&` 條件暫時隱藏「Visit island」按鈕
- 待功能完備後移除 `false &&` 條件即可恢復

## Test plan
- [ ] 確認我的小島頁面不再顯示「Visit island」按鈕
- [ ] 確認頁面其他元素（banner、Lottie 動畫、學習類型卡片）不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d8vSKxD8X3QntmtpRSATU