### PR TITLE
fix(ui): 暫時隱藏上島按鈕

### DIFF
--- a/apps/product/src/components/user/island-header.tsx
+++ b/apps/product/src/components/user/island-header.tsx
@@ -178,7 +178,8 @@ export function IslandHeader({ resultType, userId, identifier }: IslandHeaderPro
           className="md:hidden object-cover"
         />
         <PageHeader {...pageHeaderProps} />
-        {identifier && (
+        {/* TODO: 暫時隱藏上島按鈕，待功能完備後移除 false 條件 */}
+        {false && identifier && (
           <div className="absolute right-4 top-[64px] md:top-[72px]">
             <Button
               variant="orange"


### PR DESCRIPTION
## Why is this necessary?

- 為了暫時隱藏介面中的「Visit island」按鈕，以進行相關功能的測試或調整。
- 避免使用者誤觸該按鈕，導致進入尚未準備好的島嶼功能。
- 透過修改 UI 元件的顯示狀態，提供一個臨時的解決方案，直到正式上線。

## How does it address?

- 在使用者介面層級直接隱藏「Visit island」按鈕，使其不再顯示給使用者。
- 透過程式碼變更確保該按鈕的顯示邏輯被暫時停用。
- 變更僅影響按鈕的顯示，不影響後端邏輯或其他功能。