### PR TITLE
fix(lighthouse): 場次建立/編輯失敗時顯示 server 錯誤細節

### DIFF
--- a/apps/product/src/components/lighthouse/programs-manager.tsx
+++ b/apps/product/src/components/lighthouse/programs-manager.tsx
@@ -46,7 +46,7 @@ import {
   X,
 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { JoinCode } from "./join-code";
 import { type CohortFieldErrorKey, resolveCohortApiError } from "@/utils/cohort-api-error";
 
@@ -199,8 +199,11 @@ function CohortSetupPanel({
     templates?.filter((tpl) => tpl.title.toLowerCase().includes(templateSearch.toLowerCase())) ??
     [];
 
-  async function handleFormAction(formData: FormData) {
-    await onSubmit(formData, {
+  // 用 onSubmit 而不是 form action：React 19 的 action 完成後會 reset 表單，
+  // 送出失敗（400/409）時使用者填的內容會全部消失，只能從頭再填一次（#188）
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await onSubmit(new FormData(event.currentTarget), {
       interactionModes,
       sessions,
       feeType,
@@ -220,7 +223,7 @@ function CohortSetupPanel({
   return (
     <form
       ref={panelRef}
-      action={handleFormAction}
+      onSubmit={handleSubmit}
       className="scroll-mt-24 rounded-2xl border border-[#CDEBE8] bg-[#F0FBF9] p-5"
     >
       <div className="mb-4 flex items-center justify-between">

--- a/apps/product/src/components/lighthouse/programs-manager.tsx
+++ b/apps/product/src/components/lighthouse/programs-manager.tsx
@@ -48,6 +48,7 @@ import {
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { JoinCode } from "./join-code";
+import { type CohortFieldErrorKey, resolveCohortApiError } from "@/utils/cohort-api-error";
 
 type SessionEntry = { id: string; sessionDate: string; startTime: string; endTime: string };
 
@@ -66,6 +67,22 @@ const SETUP_TABS: SetupTab[] = ["basic", "templates", "home", "privacy", "signup
 const COHORT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 /** HTML pattern 屬性版本（Chrome 以 v flag 編譯，字元類別結尾的 `-` 會被判定為無效正則而整個忽略） */
 const COHORT_SLUG_HTML_PATTERN = "[a-z0-9]+(-[a-z0-9]+)*";
+
+type CohortErrorTranslator = (
+  key: CohortFieldErrorKey | "cohort_create_failed" | "save_failed"
+) => string;
+
+/** 把場次 API 錯誤轉成 toast 文字：已知欄位走 i18n、其他顯示 server 訊息、最後才退回通用訊息 */
+function cohortErrorMessage(
+  t: CohortErrorTranslator,
+  error: unknown,
+  fallbackKey: "cohort_create_failed" | "save_failed"
+): string {
+  const resolved = resolveCohortApiError(error);
+  if (resolved.type === "i18n") return t(resolved.key);
+  if (resolved.type === "message") return resolved.message;
+  return t(fallbackKey);
+}
 
 interface CohortSetupPanelProps {
   mode: "create" | "edit";
@@ -846,7 +863,7 @@ function CohortCard({ programId, organizationId, cohort, templates, refresh }: C
       } as Parameters<typeof updateLighthouseCohort>[2]);
       setBusy(false);
       if (response.error) {
-        toast.error(t("save_failed"));
+        toast.error(cohortErrorMessage(t, response.error, "save_failed"));
         return;
       }
       await refresh();
@@ -1122,7 +1139,7 @@ function ProgramPanel({ program, refreshPrograms }: ProgramPanelProps) {
       } as Parameters<typeof createLighthouseCohort>[1]);
       if (response.error || !response.data) {
         setBusy(false);
-        toast.error(t("cohort_create_failed"));
+        toast.error(cohortErrorMessage(t, response.error, "cohort_create_failed"));
         return;
       }
       const newCohortId = (response.data as { data: { id: number } }).data.id;

--- a/apps/product/src/components/lighthouse/programs-manager.tsx
+++ b/apps/product/src/components/lighthouse/programs-manager.tsx
@@ -47,8 +47,8 @@ import {
 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
-import { JoinCode } from "./join-code";
 import { type CohortFieldErrorKey, resolveCohortApiError } from "@/utils/cohort-api-error";
+import { JoinCode } from "./join-code";
 
 type SessionEntry = { id: string; sessionDate: string; startTime: string; endTime: string };
 

--- a/apps/product/src/components/lighthouse/programs-manager.tsx
+++ b/apps/product/src/components/lighthouse/programs-manager.tsx
@@ -62,6 +62,10 @@ const COHORT_STATUS_STYLES: Record<LighthouseCohortType["status"], string> = {
 
 type SetupTab = "basic" | "templates" | "home" | "privacy" | "signup";
 const SETUP_TABS: SetupTab[] = ["basic", "templates", "home", "privacy", "signup"];
+/** 與 server createCohortSchema 一致：小寫英數，單一連字號分隔，不可首尾或連續連字號 */
+const COHORT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+/** HTML pattern 屬性版本（Chrome 以 v flag 編譯，字元類別結尾的 `-` 會被判定為無效正則而整個忽略） */
+const COHORT_SLUG_HTML_PATTERN = "[a-z0-9]+(-[a-z0-9]+)*";
 
 interface CohortSetupPanelProps {
   mode: "create" | "edit";
@@ -254,6 +258,7 @@ function CohortSetupPanel({
               id={`${prefix}-name`}
               name="displayName"
               required
+              maxLength={100}
               defaultValue={cohort?.displayName ?? ""}
             />
           </label>
@@ -264,7 +269,9 @@ function CohortSetupPanel({
                 id={`${prefix}-slug`}
                 name="slug"
                 required
-                pattern="[a-z0-9-]+"
+                maxLength={50}
+                pattern={COHORT_SLUG_HTML_PATTERN}
+                title={t("cohort_slug_error")}
                 placeholder="2026-summer"
               />
             </label>
@@ -406,6 +413,7 @@ function CohortSetupPanel({
               <Input
                 id={`${prefix}-location`}
                 name="location"
+                maxLength={200}
                 placeholder={t("cohort_location_placeholder")}
                 defaultValue={cohort?.location ?? ""}
               />
@@ -495,7 +503,7 @@ function CohortSetupPanel({
                     <Input
                       name="feeAmount"
                       type="number"
-                      min={0}
+                      min={1}
                       required
                       defaultValue={cohort?.feeAmount ?? ""}
                     />
@@ -1073,9 +1081,14 @@ function ProgramPanel({ program, refreshPrograms }: ProgramPanelProps) {
         toast.error(t("cohort_external_signup_url_error"));
         return;
       }
+      const slug = String(formData.get("slug") ?? "").trim();
+      if (!COHORT_SLUG_PATTERN.test(slug)) {
+        toast.error(t("cohort_slug_error"));
+        return;
+      }
       setBusy(true);
       const response = await createLighthouseCohort(program.id, {
-        slug: String(formData.get("slug") ?? "").trim(),
+        slug,
         displayName: String(formData.get("displayName") ?? "").trim(),
         tagline: String(formData.get("tagline") ?? "").trim() || undefined,
         startDate,

--- a/apps/product/src/utils/__tests__/cohort-api-error.test.ts
+++ b/apps/product/src/utils/__tests__/cohort-api-error.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { resolveCohortApiError } from "../cohort-api-error";
+
+describe("resolveCohortApiError", () => {
+  it("maps a 400 detail on a known field to its i18n key", () => {
+    const error = {
+      success: false,
+      error: {
+        type: "bad_request",
+        message: "驗證失敗",
+        details: [
+          {
+            path: "slug",
+            message: "Invalid string: must match pattern /^[a-z0-9]+(?:-[a-z0-9]+)*$/",
+          },
+        ],
+      },
+    };
+    expect(resolveCohortApiError(error)).toEqual({ type: "i18n", key: "cohort_slug_error" });
+  });
+
+  it("shows path and server message for an unmapped 400 detail", () => {
+    const error = {
+      error: {
+        type: "bad_request",
+        message: "驗證失敗",
+        details: [{ path: "displayName", message: "Too big" }],
+      },
+    };
+    expect(resolveCohortApiError(error)).toEqual({
+      type: "message",
+      message: "displayName: Too big",
+    });
+  });
+
+  it("prefers the first mappable detail over the generic 驗證失敗 message", () => {
+    const error = {
+      error: {
+        message: "驗證失敗",
+        details: [
+          { path: "tagline", message: "Too big" },
+          { path: "feeAmount", message: "Too small" },
+        ],
+      },
+    };
+    expect(resolveCohortApiError(error)).toEqual({ type: "message", message: "tagline: Too big" });
+  });
+
+  it("uses the server message for 409 / 403 style errors without details", () => {
+    const error = {
+      success: false,
+      data: null,
+      error: { code: "APP_ERROR", message: "同一系列下不可使用重複 slug" },
+    };
+    expect(resolveCohortApiError(error)).toEqual({
+      type: "message",
+      message: "同一系列下不可使用重複 slug",
+    });
+  });
+
+  it("falls back to a top-level message when there is no nested error object", () => {
+    expect(resolveCohortApiError({ message: "Network down" })).toEqual({
+      type: "message",
+      message: "Network down",
+    });
+  });
+
+  it("falls back when the error is not an object or has no usable message", () => {
+    expect(resolveCohortApiError(null)).toEqual({ type: "fallback" });
+    expect(resolveCohortApiError("boom")).toEqual({ type: "fallback" });
+    expect(resolveCohortApiError({ error: { message: "   " } })).toEqual({ type: "fallback" });
+  });
+});

--- a/apps/product/src/utils/cohort-api-error.ts
+++ b/apps/product/src/utils/cohort-api-error.ts
@@ -1,0 +1,56 @@
+/**
+ * 把 lighthouse 場次 API 的錯誤回應轉成可顯示的訊息來源。
+ *
+ * server 回應形狀：
+ * - 400 驗證失敗：`{ error: { type: "bad_request", message: "驗證失敗", details: [{ path, message }] } }`
+ * - 409 / 403 等：`{ error: { code: "APP_ERROR", message: "同一系列下不可使用重複 slug" } }`
+ *
+ * 前端已知欄位對應到既有 i18n key；其餘帶 path 的細節直接顯示 server 訊息；都沒有才退回通用訊息。
+ */
+
+export const COHORT_FIELD_ERROR_KEYS = {
+  slug: "cohort_slug_error",
+  interactionModes: "cohort_interaction_modes_error",
+  feeAmount: "cohort_fee_amount_error",
+  externalSignupUrl: "cohort_external_signup_url_error",
+  endDate: "cohort_date_error",
+} as const;
+
+export type CohortFieldErrorKey =
+  (typeof COHORT_FIELD_ERROR_KEYS)[keyof typeof COHORT_FIELD_ERROR_KEYS];
+
+export type CohortApiErrorResolution =
+  | { type: "i18n"; key: CohortFieldErrorKey }
+  | { type: "message"; message: string }
+  | { type: "fallback" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function resolveCohortApiError(error: unknown): CohortApiErrorResolution {
+  if (!isRecord(error)) return { type: "fallback" };
+  const inner = isRecord(error.error) ? error.error : error;
+
+  const details = Array.isArray(inner.details) ? inner.details : [];
+  for (const detail of details) {
+    if (!isRecord(detail)) continue;
+    const path = readString(detail, "path");
+    const message = readString(detail, "message");
+    if (path && path in COHORT_FIELD_ERROR_KEYS) {
+      return {
+        type: "i18n",
+        key: COHORT_FIELD_ERROR_KEYS[path as keyof typeof COHORT_FIELD_ERROR_KEYS],
+      };
+    }
+    if (message) return { type: "message", message: path ? `${path}: ${message}` : message };
+  }
+
+  const message = readString(inner, "message") ?? readString(error, "message");
+  return message ? { type: "message", message } : { type: "fallback" };
+}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -7638,6 +7638,7 @@
     "cohort_interaction_modes_error": "Select at least one interaction mode.",
     "cohort_fee_amount_error": "Enter a fee amount for paid cohorts.",
     "cohort_external_signup_url_error": "Enter an external signup URL for external signup.",
+    "cohort_slug_error": "The URL slug may only contain lowercase letters, numbers, and single hyphens, and cannot start or end with a hyphen (e.g. 2026-summer).",
     "cohort_display_name": "Cohort name",
     "cohort_slug": "URL slug",
     "start_date": "Start date",

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -7638,6 +7638,7 @@
     "cohort_interaction_modes_error": "請至少選擇一種互動方式",
     "cohort_fee_amount_error": "付費活動請填寫費用金額",
     "cohort_external_signup_url_error": "外部連結報名請填寫外部報名連結",
+    "cohort_slug_error": "網址代稱只能使用小寫英文、數字與單一連字號，不可以連字號開頭或結尾（例：2026-summer）",
     "cohort_display_name": "場次名稱",
     "cohort_slug": "網址代稱",
     "start_date": "開始日期",


### PR DESCRIPTION
## Why is this necessary?

- 場次表單送出失敗時，使用者輸入的資料會遺失，導致使用者必須重新填寫。
- 場次建立或編輯失敗時，顯示通用的錯誤訊息，無法讓使用者瞭解具體的錯誤原因，降低除錯效率。
- 場次 slug 的前端驗證規則與 server 端不一致，導致驗證結果不可靠。
- Chrome 瀏覽器忽略無效的 pattern 屬性，導致前端驗證失效，無法攔截錯誤的 slug 格式。

## How does it address?

- 場次表單送出失敗時，保留使用者已輸入的資料，避免資料遺失。
- 顯示 server 傳回的具體錯誤細節，讓使用者能明確知道失敗原因。
- 將場次 slug 的前端驗證規則對齊 server 端規則，確保驗證結果一致。
- 修正前端驗證對齊 server 規則，並修正 Chrome 忽略無效 pattern 的問題，確保前端能正確攔截錯誤的 slug 格式。