### PR TITLE
chore(config): 同步 daodao 共享配置

### DIFF
--- a/.claude/hooks/pre-write-guard.sh
+++ b/.claude/hooks/pre-write-guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook (Layer 2): 敏感檔案保護 + Profile-based 品質攔截
-# 設計參考 Mai CLI Dev Harness 的四層 Hook Pipeline
+# 四層 Hook Pipeline 品質攔截
 set -euo pipefail
 
 HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,7 +4,7 @@ set -uo pipefail
 
 PROJECT_ROOT="${CLAUDE_WORKING_DIRECTORY:-$(pwd)}"
 
-echo "🏗️  島島阿學 Dev Harness v0.1.0"
+echo "🏗️  daodao-guard v0.1.0"
 echo ""
 
 # === 1. 偵測工作位置 ===


### PR DESCRIPTION
## Why is this necessary?

- 確保專案配置與外部共享設定保持一致，避免因配置差異導致的環境不一致問題。
- 維護配置檔案的同步性，確保所有開發者使用相同的設定標準。
- 避免因配置更新滯後而導致的潛在功能異常或編譯錯誤。

## How does it address?

- 從 `daodao` 倉庫同步最新的共享配置檔案。
- 更新專案中的配置設定以反映最新的變更。
- 確保配置檔案的版本與上游保持同步。