### PR TITLE
fix(onboarding): 提前驗證名字並顯示各區必填提示

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Setup Expo

--- a/apps/product/src/components/onboarding/__tests__/profile-availability.test.ts
+++ b/apps/product/src/components/onboarding/__tests__/profile-availability.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { checkProfileAvailability } from "../profile-availability";
+
+const available = () => Promise.resolve({ data: { data: { available: true } } });
+
+describe("profile availability", () => {
+  it("checks the name independently of customId and reports both conflicts", async () => {
+    const taken = vi.fn().mockResolvedValue({ data: { data: { available: false } } });
+    expect(
+      await checkProfileAvailability(
+        { name: " Taken Name ", customId: " takenid " },
+        { name: taken, customId: taken }
+      )
+    ).toEqual({ name: "unavailable", customId: "unavailable" });
+    expect(taken).toHaveBeenCalledWith("Taken Name");
+    expect(taken).toHaveBeenCalledWith("takenid");
+  });
+  it("accepts both available values", async () => {
+    expect(
+      await checkProfileAvailability(
+        { name: "Name", customId: "customid" },
+        { name: available, customId: available }
+      )
+    ).toEqual({});
+  });
+  it.each([
+    () => Promise.resolve({ error: { message: "unavailable service" } }),
+    () => Promise.resolve({ data: {} }),
+    () => Promise.reject(new Error("network error")),
+  ])("fails closed on API, malformed, and network errors", async (name) => {
+    expect(
+      await checkProfileAvailability(
+        { name: "Name", customId: "customid" },
+        { name, customId: available }
+      )
+    ).toEqual({ name: "failed" });
+  });
+});

--- a/apps/product/src/components/onboarding/__tests__/schema.test.ts
+++ b/apps/product/src/components/onboarding/__tests__/schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createOnboardingFormSchema } from "../schema";
+
+const profile = {
+  email: "onboarding@example.com",
+  birthDate: new Date(1992, 1, 20),
+  name: "Test Person",
+  customId: "testperson",
+  personalSlogan: "Learning every day",
+};
+
+describe("onboarding form validation", () => {
+  it("reports both missing fields in the fixed flow to the form resolver", () => {
+    const result = createOnboardingFormSchema(undefined, { requireFixedFields: true }).safeParse(
+      profile
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors).toMatchObject({
+        professionalFields: ["validation.professionalFieldsRequired"],
+        interests: ["validation.interestsRequired"],
+      });
+    }
+  });
+
+  it.each([
+    ["professionalFields", { interests: ["design"] }],
+    ["interests", { professionalFields: ["design"] }],
+  ])("reports the missing %s field independently", (field, selection) => {
+    const result = createOnboardingFormSchema(undefined, { requireFixedFields: true }).safeParse({
+      ...profile,
+      ...selection,
+      referralSource: "friend",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.flatten().fieldErrors).toHaveProperty(field);
+  });
+
+  it("accepts complete fixed-flow answers", () => {
+    expect(
+      createOnboardingFormSchema(undefined, { requireFixedFields: true }).safeParse({
+        ...profile,
+        professionalFields: ["design"],
+        interests: ["design"],
+        referralSource: "friend",
+      }).success
+    ).toBe(true);
+  });
+
+  it("does not require fixed fields for dynamic flows", () => {
+    expect(
+      createOnboardingFormSchema().safeParse({ ...profile, dynamicAnswers: { "1": ["design"] } })
+        .success
+    ).toBe(true);
+  });
+});

--- a/apps/product/src/components/onboarding/onboarding-form.tsx
+++ b/apps/product/src/components/onboarding/onboarding-form.tsx
@@ -2,6 +2,7 @@
 
 import {
   checkCustomIdAvailability,
+  checkNameAvailability,
   submitOnboardingFlowResponse,
   useUserMutations,
 } from "@daodao/api";
@@ -13,12 +14,13 @@ import { Form } from "@daodao/ui/components/form";
 import { toast } from "@daodao/ui/components/sonner";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { clearTrackingRef, getTrackingRef } from "@/lib/tracking-ref";
 import { DynamicStep } from "./dynamic-step";
 import { InterestsSection } from "./interests-section";
 import { OnboardingStepper } from "./onboarding-stepper";
+import { checkProfileAvailability } from "./profile-availability";
 import { ProfileSection } from "./profile-section";
 import { ReferralSection } from "./referral-section";
 import {
@@ -40,6 +42,9 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
   const { isTemporary, refreshAuth, refreshToken } = useAuth();
   const { updateCurrentUserWithFormData, createCurrentUserWithFormData } = useUserMutations();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
+  const validationPending = useRef(false);
+  const submissionPending = useRef(false);
   const [dynamicStepError, setDynamicStepError] = useState<string | null>(null);
 
   // 動態流程：若有啟用的流程，以其步驟取代固定的興趣 + 來源步驟
@@ -50,7 +55,7 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
   const dynamicStepCount = flowSteps?.length ?? 2;
   const totalSteps = 1 + dynamicStepCount + 1;
 
-  const { currentStep, nextStep, prevStep, isFirstStep, isLastInputStep, isSuccessStep } =
+  const { currentStep, nextStep, prevStep, goToStep, isFirstStep, isLastInputStep, isSuccessStep } =
     useOnboardingStep(totalSteps);
 
   // 當前動態步驟（step 2 → index 0, step 3 → index 1, ...）
@@ -58,7 +63,7 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
   const currentDynamicStep = flowSteps?.[dynamicStepIndex] ?? null;
 
   const form = useForm<OnboardingFormValues>({
-    resolver: zodResolver(createOnboardingFormSchema(t)),
+    resolver: zodResolver(createOnboardingFormSchema(t, { requireFixedFields: !flowSteps })),
     defaultValues: {
       email: initialEmail || "",
       birthDate: undefined,
@@ -74,20 +79,30 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
     mode: "onChange",
   });
 
-  const validateCustomIdAvailability = async (customId: string): Promise<boolean> => {
-    const response = await checkCustomIdAvailability(customId.trim());
-    if (response.error) {
-      toast.error(t("errors.submitFailed"));
+  const validateProfile = async (values: OnboardingFormValues): Promise<boolean> => {
+    form.clearErrors(["name", "customId"]);
+    const errors = await checkProfileAvailability(values, {
+      name: checkNameAvailability,
+      customId: checkCustomIdAvailability,
+    });
+    // Do not advance using a result for values edited while the request was pending.
+    if (values.name !== form.getValues("name") || values.customId !== form.getValues("customId")) {
       return false;
     }
-    if (!response.data?.data?.available) {
-      form.setError("customId", {
-        type: "server",
-        message: t("steps.profile.usernameUnavailable"),
-      });
-      return false;
+    for (const field of ["name", "customId"] as const) {
+      const error = errors[field];
+      if (error) {
+        const unavailableMessage =
+          field === "name"
+            ? t("steps.profile.nameUnavailable")
+            : t("steps.profile.usernameUnavailable");
+        form.setError(field, {
+          type: "server",
+          message: error === "failed" ? t("errors.availabilityFailed") : unavailableMessage,
+        });
+      }
     }
-    return true;
+    return Object.keys(errors).length === 0;
   };
 
   const validateCurrentStep = async (): Promise<boolean> => {
@@ -102,7 +117,7 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
           customId: values.customId,
           personalSlogan: values.personalSlogan,
         });
-        return validateCustomIdAvailability(values.customId);
+        return validateProfile(values);
       }
 
       // 動態流程步驟驗證
@@ -144,14 +159,30 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
   };
 
   const handleNext = async () => {
-    const isValid = await validateCurrentStep();
-    if (isValid) nextStep();
+    if (validationPending.current) return;
+    validationPending.current = true;
+    setIsValidating(true);
+    try {
+      const isValid = await validateCurrentStep();
+      if (isValid) nextStep();
+    } finally {
+      validationPending.current = false;
+      setIsValidating(false);
+    }
   };
 
   const handleSubmit = async (values: OnboardingFormValues) => {
+    if (validationPending.current || submissionPending.current) return;
+    // Enter must follow the same step validation as the Next button.
+    if (!isLastInputStep) {
+      await handleNext();
+      return;
+    }
+    submissionPending.current = true;
     setIsSubmitting(true);
 
     try {
+      if (!(await validateCurrentStep())) return;
       const dynamicAnswerMap = values.dynamicAnswers ?? {};
 
       // 預設使用固定流程欄位；動態流程透過 fieldKey 覆蓋
@@ -226,6 +257,9 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
             if (detail.path && detail.message) {
               const fieldName = mapApiPathToFormField(detail.path);
               if (fieldName) {
+                if (["name", "customId", "birthDate", "personalSlogan"].includes(fieldName)) {
+                  goToStep(1);
+                }
                 form.setError(fieldName as keyof OnboardingFormValues, {
                   type: "server",
                   message: detail.message,
@@ -239,6 +273,7 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
         toast.error(t("errors.submitFailed"));
       }
     } finally {
+      submissionPending.current = false;
       setIsSubmitting(false);
     }
   };
@@ -279,7 +314,17 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+      <form
+        onSubmit={(event) => {
+          if (!isLastInputStep) {
+            event.preventDefault();
+            void handleNext();
+          } else {
+            void form.handleSubmit(handleSubmit)(event);
+          }
+        }}
+        className="space-y-6"
+      >
         <OnboardingStepper currentStep={currentStep} totalSteps={totalSteps} />
 
         {currentStep === 1 && <ProfileSection form={form} />}
@@ -299,12 +344,24 @@ export const OnboardingForm = ({ initialEmail }: OnboardingFormProps) => {
           <footer className="fixed bottom-0 left-0 right-0 flex justify-center gap-4 p-6 border-t border-light-gray bg-very-light-gray">
             <div className="w-full max-w-[448px] flex gap-4">
               {!isFirstStep && (
-                <Button type="button" variant="ghost" className="flex-1" onClick={prevStep}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="flex-1"
+                  onClick={prevStep}
+                  disabled={isValidating || isSubmitting}
+                >
                   {t("navigation.previous")}
                 </Button>
               )}
               {!isLastInputStep ? (
-                <Button type="button" variant="orange" className="flex-1" onClick={handleNext}>
+                <Button
+                  type="button"
+                  variant="orange"
+                  className="flex-1"
+                  onClick={handleNext}
+                  disabled={isValidating}
+                >
                   {t("navigation.next")}
                 </Button>
               ) : (

--- a/apps/product/src/components/onboarding/profile-availability.ts
+++ b/apps/product/src/components/onboarding/profile-availability.ts
@@ -1,0 +1,29 @@
+type AvailabilityResponseType = {
+  data?: { data?: { available?: boolean } };
+  error?: unknown;
+};
+type ProfileFieldType = "name" | "customId";
+type AvailabilityErrorType = "unavailable" | "failed";
+
+/** Check both identifiers using the same trimmed values sent during registration. */
+export async function checkProfileAvailability(
+  values: Record<ProfileFieldType, string>,
+  checks: Record<ProfileFieldType, (value: string) => Promise<AvailabilityResponseType>>
+): Promise<Partial<Record<ProfileFieldType, AvailabilityErrorType>>> {
+  const fields = ["name", "customId"] as const;
+  const results = await Promise.allSettled(
+    fields.map((field) => checks[field](values[field].trim()))
+  );
+  const errors: Partial<Record<ProfileFieldType, AvailabilityErrorType>> = {};
+  for (const [index, field] of fields.entries()) {
+    const result = results[index];
+    if (!result || result.status === "rejected" || result.value.error) {
+      errors[field] = "failed";
+    } else if (result.value.data?.data?.available === false) {
+      errors[field] = "unavailable";
+    } else if (result.value.data?.data?.available !== true) {
+      errors[field] = "failed";
+    }
+  }
+  return errors;
+}

--- a/apps/product/src/components/onboarding/schema.ts
+++ b/apps/product/src/components/onboarding/schema.ts
@@ -15,15 +15,20 @@ type TFunction = ReturnType<typeof useTranslations<"onboarding">>;
 /**
  * 主表單 Schema（送出時驗證）
  *
- * interests / professionalFields / referralSource 允許為空，
+ * 動態流程的 interests / professionalFields / referralSource 允許為空，
  * 因為動態流程模式下這些欄位由 dynamicAnswers 透過 fieldKey 映射填入。
- * 每個步驟的強制填寫在 createOnboardingStepSchemas 裡驗證。
+ * 固定流程重用步驟 Schema，讓 resolver 同步回報必填錯誤。
  */
-export const createOnboardingFormSchema = (t?: TFunction) => {
+export const createOnboardingFormSchema = (
+  t?: TFunction,
+  { requireFixedFields = false }: { requireFixedFields?: boolean } = {}
+) => {
   const msg = (key: string, params?: Record<string, string | number>) => {
     if (t) return t(key as Parameters<TFunction>[0], params as never);
     return key;
   };
+
+  const fixedSchemas = createOnboardingStepSchemas(t);
 
   return z.object({
     // Step 1: Profile
@@ -52,19 +57,24 @@ export const createOnboardingFormSchema = (t?: TFunction) => {
       .max(150, msg("validation.personalSloganMax", { max: 150 })),
 
     // Step 2+: 固定流程欄位（動態流程時可為空，由 fieldKey 映射覆蓋）
-    professionalFields: z.array(z.string()).max(5).default([]),
-    interests: z.array(z.string()).max(5).default([]),
-    referralSource: z.string().default(""),
+    professionalFields: (requireFixedFields
+      ? fixedSchemas.interestsStepSchema.shape.professionalFields
+      : z.array(z.string()).max(5)
+    ).default([]),
+    interests: (requireFixedFields
+      ? fixedSchemas.interestsStepSchema.shape.interests
+      : z.array(z.string()).max(5)
+    ).default([]),
+    referralSource: (requireFixedFields
+      ? fixedSchemas.referralStepSchema.shape.referralSource
+      : z.string()
+    ).default(""),
     otherReferralText: z.string().optional().or(z.literal("")),
 
     // 動態流程步驟回答：key 為 stepId.toString()，value 為選取或輸入的答案陣列
     dynamicAnswers: z.record(z.string(), z.array(z.string())).default({}),
   });
 };
-
-export const onboardingFormSchema = createOnboardingFormSchema();
-
-export type OnboardingFormValues = z.infer<typeof onboardingFormSchema>;
 
 /**
  * 步驟驗證 Schema（用於固定流程逐步驗證，仍維持必填）
@@ -120,3 +130,6 @@ export const createOnboardingStepSchemas = (t?: TFunction) => {
 
 export const { profileStepSchema, interestsStepSchema, referralStepSchema } =
   createOnboardingStepSchemas();
+
+export const onboardingFormSchema = createOnboardingFormSchema();
+export type OnboardingFormValues = z.infer<typeof onboardingFormSchema>;

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -4,8 +4,8 @@
  */
 
 import { client, getApiBaseUrl, unauthorizedHandler } from "../client";
-import { extractApiErrorMessage } from "./check-in-form-data";
 import type { components, paths } from "../types";
+import { extractApiErrorMessage } from "./check-in-form-data";
 
 // ============================================================================
 // Types
@@ -328,8 +328,9 @@ const sendUserFormDataRequest = async <T>(
       "details" in errorData.error &&
       Array.isArray((errorData.error as { details?: unknown }).details)
     ) {
-      error.details = (errorData.error as { details: Array<{ path?: string; message?: string }> })
-        .details;
+      error.details = (
+        errorData.error as { details: Array<{ path?: string; message?: string }> }
+      ).details;
     }
     throw error;
   }
@@ -400,6 +401,13 @@ export const deleteUser = async (id: string) => {
     params: {
       path: { id },
     },
+  });
+};
+
+/** Check name availability before submitting onboarding. */
+export const checkNameAvailability = async (name: string) => {
+  return client.GET("/api/v1/users/name/check", {
+    params: { query: { name } },
   });
 };
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -37110,6 +37110,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users/name/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 檢查使用者名稱可用性
+         * @description 精確比對 nickname，包含非公開帳號。無需登入；提供有效的正式用戶 token 時，本人的名稱視為可用。
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description 要檢查的使用者名稱，精確比對且不移除空白 */
+                    name: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功檢查名稱可用性 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["NameAvailabilityResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequestError"];
+                500: components["responses"]["InternalServerError"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/users/custom-id/check/{customId}": {
         parameters: {
             query?: never;
@@ -51747,6 +51791,106 @@ export interface components {
              * @example 2026-09-01T08:00:00.000Z
              */
             scheduledAt?: string;
+        };
+        /**
+         * @description Standard success response format
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "id": 123,
+         *         "_id": "550e8400-e29b-41d4-a716-446655440000",
+         *         "name": "JavaScript 基礎教程",
+         *         "description": "從零開始學習 JavaScript 程式設計",
+         *         "status": "published"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z"
+         *     }
+         * @example {
+         *       "success": true,
+         *       "data": {
+         *         "userId": 456,
+         *         "username": "john_doe",
+         *         "email": "john@example.com",
+         *         "role": "student"
+         *       },
+         *       "timestamp": "2024-01-15T10:30:00.000Z",
+         *       "meta": {
+         *         "cacheHit": true,
+         *         "processingTime": 23.1
+         *       }
+         *     }
+         */
+        NameAvailabilityResponse: {
+            /**
+             * @description Indicates successful API response
+             * @enum {boolean}
+             */
+            success: true;
+            /** @description The main response data */
+            data: {
+                /**
+                 * @description 查詢的使用者名稱
+                 * @example 島島學習者
+                 */
+                name: string;
+                /**
+                 * @description 名稱是否可用，正式登入者自己的名稱亦可用
+                 * @example true
+                 */
+                available: boolean;
+            };
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp of the response
+             */
+            timestamp: string;
+            /**
+             * @description Optional metadata about the response
+             * @example {
+             *       "searchQuery": "JavaScript教程",
+             *       "searchTime": 45,
+             *       "cacheHit": false,
+             *       "processingTime": 123.5,
+             *       "requestId": "req-123e4567-e89b-12d3-a456-426614174000"
+             *     }
+             * @example {
+             *       "categoryCounts": {
+             *         "前端開發": 25,
+             *         "後端開發": 18,
+             *         "資料科學": 12
+             *       },
+             *       "filters": {
+             *         "difficulty": "intermediate",
+             *         "language": "zh-TW"
+             *       }
+             *     }
+             */
+            meta?: {
+                /** @description Search query used for filtering results */
+                searchQuery?: string;
+                /** @description Time taken to execute the search query in milliseconds */
+                searchTime?: number;
+                /** @description Applied filters for the request */
+                filters?: {
+                    [key: string]: unknown;
+                };
+                /** @description Count of items per category */
+                categoryCounts?: {
+                    [key: string]: number;
+                };
+                /** @description Aggregated statistical data */
+                aggregateData?: {
+                    [key: string]: unknown;
+                };
+                /** @description Unique identifier for request tracking */
+                requestId?: string;
+                /** @description Whether the response was served from cache */
+                cacheHit?: boolean;
+                /** @description Total processing time in milliseconds */
+                processingTime?: number;
+            } & {
+                [key: string]: unknown;
+            };
         };
         /**
          * @description 自訂 ID 可用性檢查回應

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4729,13 +4729,14 @@
         "usernameHint": "Only letters and numbers allowed, 3-15 characters",
         "usernameValid": "Username is available",
         "usernameInvalid": "Username must be 3-15 characters, letters and numbers only",
+        "nameUnavailable": "This name is already taken",
         "usernameUnavailable": "This username is already taken",
         "bio": "Personal Tagline",
         "bioPlaceholder": "Introduce yourself in one sentence"
       },
       "interests": {
         "title": "Professional & Interest Fields",
-        "professionalFieldsLabel": "Your professional or learning fields (optional, max 5)",
+        "professionalFieldsLabel": "Your professional or learning fields (select 1–5)",
         "interestsLabel": "Fields you're interested in exploring",
         "interestsRequired": "Required",
         "maxReached": "Great! We have enough info to personalize your learning experience"
@@ -4760,6 +4761,7 @@
       "submitting": "Submitting..."
     },
     "errors": {
+      "availabilityFailed": "Unable to check availability. Please try again.",
       "submitFailed": "Submission failed, please try again later"
     },
     "taskGuide": {

--- a/packages/i18n/src/locales/zh-TW.json
+++ b/packages/i18n/src/locales/zh-TW.json
@@ -4729,13 +4729,14 @@
         "usernameHint": "僅可使用英文字母和數字，長度 3-15 個字元",
         "usernameValid": "帳號名稱可以使用",
         "usernameInvalid": "帳號名稱必須為 3-15 個字元，僅限使用英文字母和數字",
+        "nameUnavailable": "此名字已被使用",
         "usernameUnavailable": "此帳號名稱已被使用",
         "bio": "個人標語",
         "bioPlaceholder": "用一句話介紹自己"
       },
       "interests": {
         "title": "專業與興趣領域",
-        "professionalFieldsLabel": "你的專業或正在學習的領域（選填，最多 5 個）",
+        "professionalFieldsLabel": "你的專業或正在學習的領域（請選擇 1–5 個）",
         "interestsLabel": "你有興趣探索的領域",
         "interestsRequired": "必選",
         "maxReached": "太棒了！我們已經有足夠資訊為你個人化學習體驗"
@@ -4760,6 +4761,7 @@
       "submitting": "提交中..."
     },
     "errors": {
+      "availabilityFailed": "暫時無法確認是否可用，請稍後再試",
       "submitFailed": "提交失敗，請稍後再試"
     },
     "taskGuide": {


### PR DESCRIPTION
## Summary

Onboarding 第一步會同時檢查名字與 customId，重複或查重失敗時停留在原步驟並顯示欄位錯誤；避免連點下一步和過期查重回應跳過驗證。

固定流程的表單 resolver 重用步驟必填規則，使專業／興趣各自缺填時都顯示提示，保留動態流程相容性。同步中英文必填文案、API client/types 與回歸測試。

## Related

- Closes daodaoedu/daodao#190
- 後端 PR：[daodao-server#469](https://github.com/daodaoedu/daodao-server/pull/469)。
- 合併與部署順序：後端 PR → 此前端 PR（需先提供 `/api/v1/users/name/check`）。

## Test plan

- [x] 新增 10 項 profile availability／schema regression tests（缺填問題先 red 再 green）。
- [x] `pnpm test`、lint、typecheck、format 與 diff check 通過。
- [x] 13 項真實頁面瀏覽器檢查通過：名字/customId 重複、500、pending 連點/改名、Enter/requestSubmit、各區缺填、動態流程與繁中提示。
- [x] 390px 無橫向溢出；無 page errors，console 僅預期 mock 錯誤。
- [x] [Task 190 驗證報告](https://docs.google.com/document/d/1sF8Msk2T131O0zEF9pV7ExKKxHiO9Jz8isg_nLROSME/edit)

## Validation scope

瀏覽器使用真實 OnboardingForm 與模擬 API，不建立真實帳號。正式部署與真實註冊尚未驗證。依獨立 spec audit 補齊 renderer、API 契約與瀏覽器證據後，AC-1–7 本地驗收通過。

## Review status

獨立 spec audit 補證後通過。四引擎分支 review 僅 Haiku 完成且未回報問題；Codex、OMP 各於 300 秒逾時，OpenCode 兩次服務端錯誤。未將未完成的審查列為通過。

## CI follow-up

已於 `55b8a814` 將 EAS job 的 Node 固定為 `22.18.0`，修正上游設定 `22` 與既有測試要求不一致的問題。兩項 workflow tests、lint 與 typecheck 均通過。[Linode CI](https://github.com/daodaoedu/daodao-f2e/actions/runs/34694601609) 與 [Mobile CI](https://github.com/daodaoedu/daodao-f2e/actions/runs/34694601613) 均已通過，包含 workflow-tests、產品檢查、Mobile TypeScript/Lint 及 EAS config 驗證。
